### PR TITLE
M7-2: Add docker-compose.yml (app + Ollama)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,7 +15,8 @@ htmlcov/
 .env.*
 !.env.example
 
-.streamlit/
+.streamlit/*
+!.streamlit/config.toml
 data/
 samples/
 uploaded/

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,12 @@ OPENAI_API_KEY=
 GROQ_API_KEY=
 ANTHROPIC_API_KEY=
 
+# Optional Hugging Face Hub token (higher rate limits / faster model downloads)
+HF_TOKEN=
+
+# Ollama server URL (Compose sets http://ollama:11434; local default is http://127.0.0.1:11434)
+OLLAMA_HOST=
+
 # Optional local Ollama overrides (leave empty to use configs/config.yaml defaults; default model is llama3.1:8b)
 OLLAMA_MODEL=
 OLLAMA_MAX_NEW_TOKENS=

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,4 @@
+[server]
+# Docker has no hot-reload; disable watcher to avoid probing transformers submodules
+# that optionally import torchvision (not installed — not needed for embeddings).
+fileWatcherType = "none"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,7 +19,27 @@ docker build -t ai-doc-to-chat .
 docker run --rm -p 8501:8501 ai-doc-to-chat
 ```
 
-Open [http://localhost:8501](http://localhost:8501). For Ollama-backed answers, run Ollama on the host and pass `OLLAMA_HOST` (Compose wiring arrives in M7-2).
+Open [http://localhost:8501](http://localhost:8501). For Ollama-backed answers, use Docker Compose (below) or run Ollama on the host and pass `OLLAMA_HOST`.
+
+## Docker Compose (app + Ollama)
+
+Start both services on the default Compose network:
+
+```bash
+docker compose up --build
+```
+
+The app service receives `OLLAMA_HOST=http://ollama:11434` and `USE_DUMMY_GENERATOR=false`. Ollama model weights persist in the `ollama_models` volume.
+
+Pull a model once (CPU demo default from [AGENTS.md](AGENTS.md)):
+
+```bash
+docker compose exec ollama ollama pull phi3:mini
+```
+
+Optional: set `OLLAMA_MODEL=phi3:mini` in a local `.env` file and add `env_file: .env` under the `app` service, or export it before `docker compose up`.
+
+Open [http://localhost:8501](http://localhost:8501) and ask a question after uploading a PDF. First run may be slow while embedding weights download inside the app container.
 
 ## Notes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,17 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY configs/ configs/
 COPY src/ src/
+COPY .streamlit/config.toml .streamlit/
 
 EXPOSE 8501
 
 ENV STREAMLIT_SERVER_ADDRESS=0.0.0.0 \
     STREAMLIT_SERVER_PORT=8501 \
-    STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
+    STREAMLIT_BROWSER_GATHER_USAGE_STATS=false \
+    STREAMLIT_SERVER_FILE_WATCHER_TYPE=none \
+    HF_HUB_DISABLE_PROGRESS_BARS=1 \
+    HF_HUB_VERBOSITY=error \
+    TRANSFORMERS_VERBOSITY=error \
+    TQDM_DISABLE=1
 
 CMD ["streamlit", "run", "src/app.py", "--server.address=0.0.0.0", "--server.port=8501"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  ollama:
+    image: ollama/ollama:0.6.5
+    volumes:
+      - ollama_models:/root/.ollama
+    restart: unless-stopped
+
+  app:
+    build: .
+    ports:
+      - "8501:8501"
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+      USE_DUMMY_GENERATOR: "false"
+      STREAMLIT_SERVER_FILE_WATCHER_TYPE: none
+    depends_on:
+      - ollama
+    restart: unless-stopped
+
+volumes:
+  ollama_models:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ pytesseract>=0.3.13                        # Tesseract OCR wrapper (requires Tes
 # RAG & LangChain core (stable 1.x series)
 langchain>=1.2.10,<2.0.0
 langchain-community>=0.4.1,<1.0.0
+langchain-huggingface>=1.2.0,<2.0.0
 langchain-text-splitters>=1.1.1,<2.0.0     # Chunking utilities
 pydantic>=2.12.5,<3.0.0                    # LangChain compatibility
 

--- a/src/app.py
+++ b/src/app.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 
 # LangChain imports for Milestone 3
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_community.vectorstores import FAISS
 from langchain_core.documents import Document
 from rag import generate_answer, load_generation_config


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` with `app` (Streamlit) and `ollama` services on a shared network
- Set `OLLAMA_HOST=http://ollama:11434`, `USE_DUMMY_GENERATOR=false`, and persist Ollama models in the `ollama_models` volume
- Harden the app container for production-style runs: disable Streamlit file watcher (avoids transformers/torchvision probe noise), quiet HF Hub log verbosity
- Document Compose startup and model pull in `DEPLOYMENT.md`; add `OLLAMA_HOST` and optional `HF_TOKEN` to `.env.example`
- Migrate embeddings import to `langchain-huggingface` (removes LangChain deprecation warning)

## Test plan
- [x] `docker compose config`
- [x] `docker build` / `docker compose up --build` (both services start; app logs clean)
- [x] `docker compose exec ollama ollama pull phi3:mini`
- [x] Upload PDF at http://localhost:8501 and confirm real Ollama answer (not dummy)

Closes #34

Made with [Cursor](https://cursor.com)