### PR TITLE
M7-4: Self-host env defaults and pilot documentation

### DIFF
--- a/.cursor/agents/docs-writer.md
+++ b/.cursor/agents/docs-writer.md
@@ -12,7 +12,7 @@ You are the **docs-writer** for ai-doc-to-chat-pipeline.
 
 - `docs/**`
 - `DEPLOYMENT.md`, `DEPLOYMENT-ANTHROPIC.md`, `RUNBOOK.md` (when created)
-- README deploy/pilot sections (when assigned)
+- **README.md** — especially: demo vs self-host table, milestone status, production direction summary, quick-start pointers, consulting blurb (keep detail in linked docs)
 
 ## Must NOT touch
 
@@ -25,6 +25,7 @@ You are the **docs-writer** for ai-doc-to-chat-pipeline.
 - Clear prerequisites, verify steps, troubleshooting.
 - Link AGENTS.md, ROADMAP, architecture diagrams.
 - Client-facing tone: professional, no fluff.
+- **README:** update milestone checklist and “what works today” when issues merge; do not duplicate DEPLOYMENT.md procedures in README.
 
 ## Workflow
 

--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,29 @@ ANTHROPIC_API_KEY=
 # Optional Hugging Face Hub token (higher rate limits / faster model downloads)
 HF_TOKEN=
 
-# Ollama server URL (Compose sets http://ollama:11434; local default is http://127.0.0.1:11434)
+# =============================================================================
+# Self-hosted pilot (Docker Compose, VPS, local Streamlit + Ollama)
+# =============================================================================
+# Copy to `.env` for overrides. Compose already sets OLLAMA_HOST, OLLAMA_MODEL,
+# and USE_DUMMY_GENERATOR=false on the app service; add `env_file: .env` under
+# `app` in docker-compose.yml when you want file-based overrides.
+#
+# Generation defaults (model, temperature, context, etc.) live in
+# configs/config.yaml under rag.generation unless overridden below.
+
+# Ollama server URL
+#   Compose (in-network): http://ollama:11434
+#   Streamlit on host + Ollama in Docker (port 11435): http://127.0.0.1:11435
+#   Native Ollama on host: http://127.0.0.1:11434
 OLLAMA_HOST=
 
-# Optional local Ollama overrides (leave empty to use configs/config.yaml defaults; default model is llama3.1:8b)
+# Real Ollama answers (required for Compose / VPS / local self-host).
+# Set false for pilot deployments. Empty locally defaults to false (Ollama);
+# on Streamlit Cloud defaults to true (dummy). Compose sets false automatically.
+USE_DUMMY_GENERATOR=
+
+# Optional Ollama generation overrides (empty = configs/config.yaml rag.generation)
+# YAML default model is llama3.1:8b; CPU demos often use phi3:mini (see docker-compose.yml).
 OLLAMA_MODEL=
 OLLAMA_MAX_NEW_TOKENS=
 OLLAMA_TEMPERATURE=
@@ -20,6 +39,3 @@ OLLAMA_DO_SAMPLE=
 OLLAMA_FALLBACK_TO_DUMMY=
 OLLAMA_NUM_CTX=
 OLLAMA_TIMEOUT_SECONDS=
-
-# UI toggle default (true/false). If empty: false locally (Ollama), true on Streamlit Cloud (dummy).
-USE_DUMMY_GENERATOR=

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ uploaded/
 .coverage
 htmlcov/
 
+# Private operator notes (sales / deployment — not for repo)
+docs-private/
+
 # OS / temp files
 .DS_Store
 Thumbs.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Full roadmap: [docs/ROADMAP.md](docs/ROADMAP.md) · M7 GitHub milestone: [#1](ht
 | `config-guardian` | M7–M12 | `configs/**`, `.env.example` | Application logic |
 | `rag-core-engineer` | M8, M9, M12 | `src/rag.py`, `src/rag/**`, `src/api/**` | Streamlit UI, Docker |
 | `streamlit-engineer` | All UI | `src/app.py` | Docker, FastAPI internals |
-| `docs-writer` | M7, M10–M12 | `docs/**`, `DEPLOYMENT*.md`, README deploy sections | Python except docstrings |
+| `docs-writer` | M7, M10–M12 | `docs/**`, `DEPLOYMENT*.md`, **README** (status, deploy pointers, production vision — not app code) | Python except docstrings |
 | `verifier` | All | Runs pytest/ruff; `tests/**` fixes only | Feature implementation |
 | `blocker-reporter` | All | Blocker summaries | Code changes |
 
@@ -101,7 +101,27 @@ Specialists and `blocker-reporter` use this format:
 
 ---
 
-## Repository strategy
+## Documentation maintenance
+
+Keep user-facing docs aligned when milestones ship or deployment behavior changes.
+
+| File | Owner | Update when |
+|------|-------|-------------|
+| **README.md** | `docs-writer` | Milestone status changes, new deploy paths, production vision shifts |
+| **DEPLOYMENT.md** | `docs-writer` + `deploy-engineer` review | Compose, env, VPS, HTTPS, troubleshooting |
+| **docs/ROADMAP.md** | `docs-writer` | M7–M12 scope or definition-of-done changes |
+| **docs/architecture-pilot.md** | `docs-writer` | Architecture target changes (M9+ especially) |
+| **AGENTS.md** | Human + orchestrator | New agents, decision log, issue→agent map |
+
+**After merging a GitHub milestone slice** (e.g. M7 complete, M8 started):
+
+1. Orchestrator or human opens a **docs issue** or adds sub-task: “Sync README + ROADMAP status.”
+2. Dispatch **`docs-writer` only** — do not parallelize with code issues on the same PR unless docs-only.
+3. README stays **short** — link to `DEPLOYMENT.md` and `docs/ROADMAP.md` for depth ([`docs-commercial` rule](.cursor/rules/docs-commercial.mdc)).
+
+There is **no separate README agent** — use **`docs-writer`** for README status, deploy sections, and production narrative.
+
+---
 
 - **Public repo:** app code, generic Compose, `DEPLOYMENT.md`, agents/rules (this file).
 - **Private deploy repo (later):** client hostnames, SSO configs, production secrets — not duplicated app logic.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -56,6 +56,20 @@ Open [http://localhost:8501](http://localhost:8501). For Ollama-backed answers, 
 
 The app service receives `OLLAMA_HOST=http://ollama:11434` and `USE_DUMMY_GENERATOR=false`.
 
+### Environment variables
+
+Pilot-relevant settings are documented in [`.env.example`](.env.example). For self-hosted deployments:
+
+| Variable | Compose default | Purpose |
+|----------|-----------------|--------|
+| `OLLAMA_HOST` | `http://ollama:11434` | Ollama API URL (service name in Compose, not `localhost`) |
+| `USE_DUMMY_GENERATOR` | `false` | Must be `false` for real Ollama answers on Compose/VPS |
+| `OLLAMA_MODEL` | `phi3:mini` | Override; YAML default is `llama3.1:8b` in `configs/config.yaml` |
+
+To override via a file: `cp .env.example .env`, edit values, and add `env_file: .env` under the `app` service in `docker-compose.yml`. Generation tuning (`temperature`, `num_ctx`, etc.) follows `configs/config.yaml` → `rag.generation` unless set as `OLLAMA_*` in `.env`.
+
+See also [docs/architecture-pilot.md](docs/architecture-pilot.md#environment-variables-pilot).
+
 ### One-shot equivalent
 
 If you prefer a single command after models are already pulled:

--- a/README.md
+++ b/README.md
@@ -2,267 +2,146 @@
 
 > **Privacy · Reproducibility · Honesty** — grounded answers on *your* infrastructure, not a black-box SaaS tab.
 
-[Live Demo](https://ai-doc-to-chat-demo.streamlit.app) · [Deployment Guide](DEPLOYMENT.md) · [Production Roadmap](docs/ROADMAP.md)
+[Live Demo](https://ai-doc-to-chat-demo.streamlit.app) · [Deployment Guide](DEPLOYMENT.md)
 
 **Private RAG chat for your PDFs** — upload contracts, invoices, or scans, ask questions in plain language, and get **grounded answers with page-level sources**. Built for teams that need **control over data and infrastructure**, not another public chatbot tab.
 
-**Want real answers on confidential documents?** The public demo shows the UI only. [Contact me](#for-teams-and-consulting) for a **private pilot** (real Ollama) or to deploy inside your company.
+**Want real answers on confidential documents?** The [public demo](https://ai-doc-to-chat-demo.streamlit.app) shows the interface only. [Contact me](#for-teams-and-consulting) for a **private pilot** with real local AI, or deployment inside your company.
 
 ---
 
 ## Two ways to use this project
 
-| Mode | Where | Who hosts | Generation | Best for |
-|------|--------|-----------|------------|----------|
-| **Public demo** | [Streamlit Cloud](https://ai-doc-to-chat-demo.streamlit.app) | Streamlit (free tier) | Dummy — retrieval + UI work; no LLM on that server | Try the UX, share a portfolio link |
-| **Private pilot** | Your laptop **or** one VPS / company VM | **You**, your client, or me (consulting) | **Real Ollama** via [Docker Compose](DEPLOYMENT.md) | Confidential PDFs, sales demos, pilots |
-
-Both use the **same app code**. The difference is **where it runs** and whether **real local AI** (`Ollama`) is attached.
-
-### Why laptop *and* VPS?
-
-They are the **same stack**, on different machines:
-
-| Setup | What it is | Typical use |
-|-------|------------|-------------|
-| **Laptop** | Docker Compose on your Mac/PC — app + Ollama on `localhost:8501` | Build, test, record demos, learn the stack |
-| **Single VPS** | Same Compose on one cloud VM (e.g. Hetzner) — team opens `https://your-pilot.example.com` | Client pilot, small-team access, “hire me” reference deployment |
-
-Nothing in the repo forces one or the other. **One `docker-compose.yml`** defines app + Ollama; you run it wherever Docker runs.
+| Mode | Where | Generation | Best for |
+|------|--------|------------|----------|
+| **Public demo** | [Streamlit Cloud](https://ai-doc-to-chat-demo.streamlit.app) | UI + retrieval preview (no LLM on that host) | Try the experience, share a link |
+| **Private pilot** | Your infrastructure or mine | **Real Ollama** — answers grounded in your documents | Confidential PDFs, evaluations, rollouts |
 
 ---
 
-## How it works (architecture in plain English)
+## How it works
 
-Each question you ask goes through these layers on **one machine** (laptop or VM):
+Each question flows through a **single private stack** — your documents never leave your environment:
 
 ```text
-┌─────────────────────────────────────────────────────────────┐
-│  Single VM (laptop or cloud server)                         │
-│                                                              │
-│  Browser ──► Streamlit app (:8501)                           │
-│                 │                                            │
-│                 ├─► PDF upload → extract text (PyMuPDF/OCR)  │
-│                 ├─► Chunk + embed → FAISS search (local)     │
-│                 ├─► Retrieve relevant pages (no cloud LLM)     │
-│                 └─► Ollama (:11434) → grounded answer        │
-│                      ▲                                       │
-│                      └── OLLAMA_HOST (Docker network)        │
-└─────────────────────────────────────────────────────────────┘
+Browser ──► Streamlit (upload + chat)
+              ├─► Extract text from PDF (digital + scanned/OCR)
+              ├─► Find relevant passages (local embeddings + search)
+              └─► Ollama (local LLM) → answer with page-level sources
 ```
 
-| Layer | Technology | Role |
-|-------|------------|------|
-| **UI** | Streamlit | Upload PDF, chat, show sources (page, score, snippet) |
-| **Retrieval** | LangChain + FAISS + sentence-transformers | Find the right chunks in *your* document — stays local |
-| **Generation** | Ollama | Local LLM writes the answer from retrieved context only |
-| **Packaging** | Docker + Compose | One command to run app + Ollama together; same recipe on any VM |
+| Layer | Role |
+|-------|------|
+| **Interface** | Upload PDFs, chat, inspect sources (page, score, excerpt) |
+| **Retrieval** | Semantic and hybrid search over your document — runs locally |
+| **Generation** | Local LLM produces answers from retrieved context only |
+| **Deployment** | Docker Compose packages app + Ollama for a one-VM pilot |
 
-**Today:** indexes live in memory per session (fine for pilots). **Roadmap (M9+):** Postgres/pgvector + file storage so documents survive restarts — see [Production direction](#production-direction-m8m12).
-
----
-
-## Configuration: “the switches”
-
-These settings control **real vs dummy** answers and **which Ollama** to call. They can come from three places (first match wins for env vars):
-
-| Source | File | When it applies |
-|--------|------|-----------------|
-| **Compose** | [`docker-compose.yml`](docker-compose.yml) `environment:` | Default for Docker pilot — **no `.env` required** |
-| **Optional overrides** | [`.env`](.env.example) (copy from `.env.example`) | Custom model, context size, or non-Compose runs |
-| **YAML defaults** | [`configs/config.yaml`](configs/config.yaml) `rag.generation` | Fallback when an env var is empty (e.g. model `llama3.1:8b`) |
-
-**Pilot switches (most important):**
-
-| Switch | Compose value | Meaning |
-|--------|---------------|---------|
-| `USE_DUMMY_GENERATOR` | `false` | Use **real Ollama** answers (required for private pilot) |
-| `OLLAMA_HOST` | `http://ollama:11434` | App talks to the **Ollama container** on Docker’s internal network (`ollama` = service name, not `localhost`) |
-| `OLLAMA_MODEL` | `phi3:mini` | Which model to load (CPU-friendly demo; YAML default is `llama3.1:8b`) |
-
-**How the app reads them:** `src/app.py` loads `.env` via `python-dotenv`, then reads `USE_DUMMY_GENERATOR`. `src/rag.py` reads `OLLAMA_*` and merges with `configs/config.yaml`. In Compose, variables are injected by Docker — you do **not** need a `.env` file unless you want overrides.
-
-**DEPLOYMENT table:** the markdown table in [DEPLOYMENT.md § Environment variables](DEPLOYMENT.md#environment-variables) documents the same Compose defaults as `docker-compose.yml` — for humans, not for Docker.
-
-**Dockerfile `ENV` vs Compose `environment`:** the [Dockerfile](Dockerfile) sets **Streamlit/Hugging Face noise reduction** (port, log levels). [Compose](docker-compose.yml) sets **RAG pilot switches** (`OLLAMA_*`, `USE_DUMMY_GENERATOR`). Different jobs; both end up as environment variables inside the container.
+Pilots use in-session indexing (ideal for evaluations). Longer-term deployments add persistent storage, API access, and enterprise auth — see [Future work](#future-work).
 
 ---
 
-## Do clients need to clone this repo?
+## Demo vs private pilot
 
-**It depends who hosts:**
-
-| Scenario | What the client does | Who runs Ollama |
-|----------|----------------------|-----------------|
-| **Public Streamlit demo** | Open the URL — no clone | Nobody (dummy answers only) |
-| **You host a private pilot** | You send a **password-protected URL** (VPS + HTTPS, M7-6) | You, on your VM — client never clones |
-| **Client self-hosts** | Their IT clones repo, runs Compose on **their** VM | Client — data never leaves their infra |
-| **Consulting engagement** | You deploy on their cloud or a dedicated VM they own | Client-owned or contractually isolated |
-
-The repo is a **reference deployment** (copy-paste recipe), not the only delivery model. Many buyers never touch git — they get a URL or you install it for them.
-
-**Without `.env.example` / Compose docs:** you could still run *your* hosted pilot by setting env vars in Compose — but clients and IT would not know the recipe. That documentation is the **portfolio + sales asset**.
+1. **Public demo** — open the link, upload a sample PDF, explore the UX. Generation is intentionally limited on the hosted demo.
+2. **Private pilot** — real local AI on your or my infrastructure, suitable for confidential or redacted documents under NDA.
+3. **Production rollout** — persistence, SSO, runbooks, and your choice of cloud or on-prem — scoped per engagement.
 
 ---
 
-## For buyers: demo vs full pilot
-
-**Recommended funnel:**
-
-1. **Public demo** — zero friction; proves UX and retrieval. Answers are intentionally **not** from a real LLM (Streamlit Cloud cannot run Ollama for you).
-2. **Private pilot** — contact for access: real Ollama, their or your VM, NDA-friendly. This is where **Privacy · Reproducibility · Honesty** matter.
-3. **Production** — persistence, SSO, runbooks ([M8–M12](#production-direction-m8m12)).
-
-Showing real private RAG **immediately** to everyone is possible but costly (GPU/CPU, abuse, support). **Gating the full pilot** (email / call / shared URL) is a strong strategy: the public demo **teases**; the pilot **closes**.
-
----
-
-## How a company deployment typically looks
-
-**Small team pilot (5–20 users, one VM):**
+## Typical company pilot
 
 ```text
-Employees → HTTPS (Caddy + basic auth or SSO later)
-              → Streamlit on company VM or VPC
-              → Ollama on same VM
-              → PDFs processed in-session (M7); stored in DB later (M9)
+Team ──► HTTPS ──► Streamlit + Ollama (one VM or VPC)
+                      └── PDFs processed in your environment
 ```
 
-| Phase | What you get |
-|-------|----------------|
-| **Week 1 — Pilot** | Single VM, Compose, `phi3:mini` or `llama3.1:8b`, password on URL |
-| **Month 1–3 — Hardening** | Backups, monitoring, model tuning, optional FastAPI (M8) |
-| **Production** | Client-owned cloud, pgvector, SSO, audit trail (M9–M11) |
+| Phase | Outcome |
+|-------|---------|
+| **Pilot** | Single VM, real answers, access control on the URL |
+| **Hardening** | Backups, monitoring, model tuning |
+| **Production** | Client-owned cloud, persistent indexes, SSO, audit trail |
 
-**Repeatable on any single VM** means: same `git clone` + `docker compose up` works on your laptop, a Hetzner box, or a client’s Azure VM — no “works on my machine” magic. Advantage for a **small team**: one IT person can reproduce the stack from this repo; you help with sizing, HTTPS, and compliance narrative.
-
-Details: [DEPLOYMENT.md](DEPLOYMENT.md) · [docs/architecture-pilot.md](docs/architecture-pilot.md)
+Operational detail: [DEPLOYMENT.md](DEPLOYMENT.md) · [docs/architecture-pilot.md](docs/architecture-pilot.md)
 
 ---
 
 ## What works today
 
-### Application (M1–M6, `v0.6.0` baseline)
+**Document AI (stable baseline, `v0.6.0`)**
 
-- PDF upload with **PyMuPDF** + optional **Tesseract OCR** for scans  
-- **Chunking**, **local embeddings** (`all-MiniLM-L6-v2`), **FAISS** retrieval  
-- **Semantic** and **hybrid (BM25 + dense)** retrieval with optional reranker  
-- **Streamlit** chat UI with source previews (page, score, chunk text)  
-- **Ollama** or dummy generation ([`configs/config.yaml`](configs/config.yaml), `.env`)  
-- Developer mode: retrieval metrics, exact context fed to the LLM  
+- PDF upload with **PyMuPDF** and optional **Tesseract OCR** for scans
+- Local **embeddings** and **FAISS** retrieval — semantic and hybrid (BM25 + dense)
+- **Streamlit** chat with source previews (page, score, chunk text)
+- **Ollama** for private generation, or dummy mode for the public demo
+- Optional developer view: retrieval metrics and context transparency
 
-### Reference deployment (M7 — in progress)
+**Reference deployment (M7 — shipping now)**
 
-Shipped on `main` so far:
+- [`Dockerfile`](Dockerfile) — reproducible app image (Python 3.12, OCR runtime)
+- [`docker-compose.yml`](docker-compose.yml) — app + Ollama, health-gated startup, persistent model volume
+- [`DEPLOYMENT.md`](DEPLOYMENT.md) — build, compose, model pull, environment setup, troubleshooting
+- [`.env.example`](.env.example) — documented settings for self-hosted pilots
 
-- [`Dockerfile`](Dockerfile) — reproducible Streamlit image (Python 3.12, OCR runtime)  
-- [`docker-compose.yml`](docker-compose.yml) — **app + Ollama**, health-gated startup, persistent model volume  
-- [`DEPLOYMENT.md`](DEPLOYMENT.md) — build, compose, model pull, env vars, troubleshooting  
-- [`.env.example`](.env.example) — self-host settings (`OLLAMA_HOST`, `USE_DUMMY_GENERATOR`, …)  
-- [`AGENTS.md`](AGENTS.md) + [`.cursor/agents/`](.cursor/agents/) — milestone delivery playbook for contributors  
-
-Still open for **M7 finish line** (see [roadmap](docs/ROADMAP.md)): full VPS/HTTPS guide, Caddy, demo video, pilot URL.
+**Next on the M7 finish line:** HTTPS + access control, full VPS guide, demo assets.
 
 ---
 
-## Production direction (M8–M12)
+## Future work
 
-The demo is a **Streamlit session app** (in-memory FAISS per upload). Production pilots and enterprise delivery add layers on the same RAG core:
+The current pilot is a **session-based** app (indexes per upload). Typical production extensions on the same RAG core:
 
-| Milestone | Delivers |
-|-----------|----------|
-| **M8** | Extract `rag/` package + **FastAPI** (`/health`, `/chat`, OpenAPI) — integration surface beyond Streamlit |
-| **M9** | **Postgres/pgvector** + object storage — documents and indexes **survive restart** |
-| **M10** | **SSO / auth proxy**, `SECURITY.md` |
-| **M11** | **RUNBOOK.md**, backups, monitoring |
-| **M12** | **Anthropic** (or Azure OpenAI) as swappable LLM backend; pilot/pricing docs; demo recording |
-
-Target architecture:
-
-```text
-Browser → HTTPS → Streamlit and/or FastAPI
-                      ├── Postgres + pgvector
-                      ├── MinIO (PDFs)
-                      └── LLM (Ollama | Anthropic | …)
-```
-
-Details: [docs/ROADMAP.md](docs/ROADMAP.md) · [docs/architecture-pilot.md](docs/architecture-pilot.md)
+- **API layer** — integrate beyond the Streamlit UI
+- **Persistent storage** — documents and vectors survive restarts
+- **Enterprise access** — SSO, security documentation, operational runbooks
+- **Flexible LLM backend** — local Ollama, or private cloud APIs where procurement requires it
 
 ---
 
-## Quick start (self-hosted, real answers)
+## Quick start (self-hosted)
 
-**Fastest path:** Docker Compose with Ollama (see [DEPLOYMENT.md](DEPLOYMENT.md) for full steps).
+See [DEPLOYMENT.md](DEPLOYMENT.md) for the full walkthrough.
 
 ```bash
 git clone https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline.git
 cd ai-doc-to-chat-pipeline
 
 docker compose up -d ollama
-docker compose exec ollama ollama pull phi3:mini   # once, into persistent volume
+docker compose exec ollama ollama pull phi3:mini
 docker compose up --build
 ```
 
-Open [http://localhost:8501](http://localhost:8501). Compose sets `OLLAMA_HOST=http://ollama:11434` and `USE_DUMMY_GENERATOR=false`.
-
-**Local dev without Compose:** install [Ollama](https://ollama.com), `pip install -r requirements.txt`, `ollama pull llama3.1:8b`, then `streamlit run src/app.py` (dummy mode off in sidebar).
-
-**Streamlit Cloud demo:** [ai-doc-to-chat-demo.streamlit.app](https://ai-doc-to-chat-demo.streamlit.app) — dummy generation only; use self-host for real LLM answers.
-
----
-
-## Project milestones
-
-| Phase | Status |
-|-------|--------|
-| M1–M4 | ✅ Prototype, PDF/OCR, FAISS RAG, generation |
-| M5–M6 (`v0.6.0`) | ✅ Live demo, cloud-ready shell |
-| **M7** | 🚧 Reference deployment (Dockerfile, Compose, health gate — [milestone #1](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/1)) |
-| M8–M12 | 📋 Planned — API, persistence, auth, ops, commercial docs |
-
-Last tagged release: **`v0.6.0`**. Post-`v0.6.0` work ships via `main` and GitHub milestones until the next tag.
+Open [http://localhost:8501](http://localhost:8501) — real local generation with Docker Compose.
 
 ---
 
 ## For teams and consulting
 
-I help organizations deploy **private document AI** — single-VM pilots through production-shaped stacks (Compose, VPS, optional FastAPI, SSO, vector DB), without sending confidential PDFs to public SaaS chat.
+I deploy **private document AI** for organizations that cannot send contracts or policies to public chat tools — from single-VM pilots through production-shaped stacks on **your** cloud or dedicated infrastructure.
 
-**Reference deployment** = this public repo proves: *I don’t only have a demo link — I can ship a private, deployable version.*
+| | |
+|--|--|
+| **Privacy** | Documents and prompts stay in your environment; local or VPC-hosted LLM |
+| **Reproducibility** | Docker Compose reference deployment your IT can audit and reproduce |
+| **Honesty** | Public demo shows the UI; private pilot delivers real generation — clearly separated |
 
-| Buyer concern | How this project addresses it |
-|---------------|----------------------------------|
-| **Privacy** | Documents and prompts stay on *your* VM; Ollama runs locally |
-| **Reproducibility** | Docker Compose + documented env — IT can run the same stack |
-| **Honesty** | Public demo = UI only; private pilot = real generation, clearly labeled |
+**Typical path:** pilot on your infrastructure → hardening and persistence → production with auth and runbooks. Local Ollama for air-gap; private cloud APIs when quality or procurement requires it.
 
-**Get in touch for:**
-
-- A **live private demo** (real Ollama on sample or redacted docs)  
-- **Pilot setup** on your laptop, VPS, or company cloud  
-- **Production path** — persistence, auth, runbooks ([roadmap](docs/ROADMAP.md))
-
-Typical engagement path:
-
-1. **Pilot** — self-hosted Compose + Ollama on your or my infrastructure  
-2. **Production** — persistence, auth, runbooks, client-owned cloud or dedicated VM  
-3. **Engine choice** — local Ollama for air-gap; Anthropic/Azure OpenAI via private API when quality or procurement requires it  
-
-Same RAG pipeline; deployment and LLM backend vary by compliance and budget.
+**[Contact me](#for-teams-and-consulting)** for a live private demo, pilot setup, or scoping a production rollout.
 
 ---
 
-## Development
+## How this project is built
 
-- Config: [`configs/config.yaml`](configs/config.yaml), [`configs/prompts.yaml`](configs/prompts.yaml)  
-- Tests: `pytest tests/ -v`  
-- Contributor workflow: [AGENTS.md](AGENTS.md) (orchestrator, slash commands, one-issue-one-PR)  
+Developed with **agentic workflows in Cursor** — specialized agents (orchestrator, deploy-engineer, docs-writer, config-guardian, verifier) own distinct parts of the stack and ship one GitHub issue per PR. That keeps delivery fast, reviewable, and aligned with a production roadmap rather than ad-hoc prompts.
+
+Contributor playbook: [AGENTS.md](AGENTS.md)
 
 ---
 
 ## Core stack
 
-Streamlit · LangChain · FAISS · sentence-transformers · PyMuPDF · Tesseract · Ollama · Docker · YAML-driven config
+Streamlit · LangChain · FAISS · sentence-transformers · PyMuPDF · Tesseract · Ollama · Docker
 
 MIT licensed — free to use, modify, or build on commercially.
 

--- a/README.md
+++ b/README.md
@@ -1,109 +1,269 @@
 # AI Doc to Chat
 
-[Live Demo](https://ai-doc-to-chat-demo.streamlit.app)
+> **Privacy · Reproducibility · Honesty** — grounded answers on *your* infrastructure, not a black-box SaaS tab.
 
-**Private, local chat with your PDFs** — upload contracts, invoices, reports or scans, ask real questions in plain language, and get accurate answers with exact page references. No hallucinations, no data leaves your machine.
+[Live Demo](https://ai-doc-to-chat-demo.streamlit.app) · [Deployment Guide](DEPLOYMENT.md) · [Production Roadmap](docs/ROADMAP.md)
 
-### Why this matters in 2026
+**Private RAG chat for your PDFs** — upload contracts, invoices, or scans, ask questions in plain language, and get **grounded answers with page-level sources**. Built for teams that need **control over data and infrastructure**, not another public chatbot tab.
 
-Public AI tools like ChatGPT or Claude are great for casual use, but when dealing with sensitive contracts, legal docs, or internal policies, you need **privacy**, **control**, and **traceability**.
+**Want real answers on confidential documents?** The public demo shows the UI only. [Contact me](#for-teams-and-consulting) for a **private pilot** (real Ollama) or to deploy inside your company.
 
-This local RAG (Retrieval-Augmented Generation) pipeline:
+---
 
-- Retrieves only relevant parts of your documents
-- Generates grounded answers backed by real sources
-- Runs completely offline (after setup)
-- Can reduce document review time by up to 40% in real workflows
+## Two ways to use this project
 
-Perfect for lawyers, compliance teams, support staff, or anyone who works with confidential or regulated documents.
+| Mode | Where | Who hosts | Generation | Best for |
+|------|--------|-----------|------------|----------|
+| **Public demo** | [Streamlit Cloud](https://ai-doc-to-chat-demo.streamlit.app) | Streamlit (free tier) | Dummy — retrieval + UI work; no LLM on that server | Try the UX, share a portfolio link |
+| **Private pilot** | Your laptop **or** one VPS / company VM | **You**, your client, or me (consulting) | **Real Ollama** via [Docker Compose](DEPLOYMENT.md) | Confidential PDFs, sales demos, pilots |
 
-Try the **[live demo](https://ai-doc-to-chat-demo.streamlit.app)** right now — drag a PDF, ask a question, and see cited answers.  
-**Cut document review time by up to 40%** and turn your data into actionable insights with zero data exposure.
+Both use the **same app code**. The difference is **where it runs** and whether **real local AI** (`Ollama`) is attached.
 
-### Project Milestones (March 2026)
+### Why laptop *and* VPS?
 
-- ✅ Milestone 1 — Local prototype (upload + chat shell)
-- ✅ Milestone 2 — Reliable PDF extraction (including OCR fallback)
-- ✅ Milestone 3 — Chunking + embeddings + FAISS retrieval
-- ✅ Milestone 4 — Basic RAG generation and answer display
-- ✅ Milestone 5 — Live demo deployment completed ([ai-doc-to-chat-demo.streamlit.app](https://ai-doc-to-chat-demo.streamlit.app))
-- ✅ Milestone 6 (`v0.6.0`) — First stable cloud-ready release
+They are the **same stack**, on different machines:
 
-Last tagged release: `v0.6.0`.
+| Setup | What it is | Typical use |
+|-------|------------|-------------|
+| **Laptop** | Docker Compose on your Mac/PC — app + Ollama on `localhost:8501` | Build, test, record demos, learn the stack |
+| **Single VPS** | Same Compose on one cloud VM (e.g. Hetzner) — team opens `https://your-pilot.example.com` | Client pilot, small-team access, “hire me” reference deployment |
 
-### Run Locally From Scratch (Docker + Ollama)
+Nothing in the repo forces one or the other. **One `docker-compose.yml`** defines app + Ollama; you run it wherever Docker runs.
 
-1. Install Docker Desktop (Apple Silicon or Intel), launch it, and verify:
+---
 
-```bash
-docker --version
-docker run hello-world
+## How it works (architecture in plain English)
+
+Each question you ask goes through these layers on **one machine** (laptop or VM):
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│  Single VM (laptop or cloud server)                         │
+│                                                              │
+│  Browser ──► Streamlit app (:8501)                           │
+│                 │                                            │
+│                 ├─► PDF upload → extract text (PyMuPDF/OCR)  │
+│                 ├─► Chunk + embed → FAISS search (local)     │
+│                 ├─► Retrieve relevant pages (no cloud LLM)     │
+│                 └─► Ollama (:11434) → grounded answer        │
+│                      ▲                                       │
+│                      └── OLLAMA_HOST (Docker network)        │
+└─────────────────────────────────────────────────────────────┘
 ```
 
-1. Clone project and install Python dependencies:
+| Layer | Technology | Role |
+|-------|------------|------|
+| **UI** | Streamlit | Upload PDF, chat, show sources (page, score, snippet) |
+| **Retrieval** | LangChain + FAISS + sentence-transformers | Find the right chunks in *your* document — stays local |
+| **Generation** | Ollama | Local LLM writes the answer from retrieved context only |
+| **Packaging** | Docker + Compose | One command to run app + Ollama together; same recipe on any VM |
+
+**Today:** indexes live in memory per session (fine for pilots). **Roadmap (M9+):** Postgres/pgvector + file storage so documents survive restarts — see [Production direction](#production-direction-m8m12).
+
+---
+
+## Configuration: “the switches”
+
+These settings control **real vs dummy** answers and **which Ollama** to call. They can come from three places (first match wins for env vars):
+
+| Source | File | When it applies |
+|--------|------|-----------------|
+| **Compose** | [`docker-compose.yml`](docker-compose.yml) `environment:` | Default for Docker pilot — **no `.env` required** |
+| **Optional overrides** | [`.env`](.env.example) (copy from `.env.example`) | Custom model, context size, or non-Compose runs |
+| **YAML defaults** | [`configs/config.yaml`](configs/config.yaml) `rag.generation` | Fallback when an env var is empty (e.g. model `llama3.1:8b`) |
+
+**Pilot switches (most important):**
+
+| Switch | Compose value | Meaning |
+|--------|---------------|---------|
+| `USE_DUMMY_GENERATOR` | `false` | Use **real Ollama** answers (required for private pilot) |
+| `OLLAMA_HOST` | `http://ollama:11434` | App talks to the **Ollama container** on Docker’s internal network (`ollama` = service name, not `localhost`) |
+| `OLLAMA_MODEL` | `phi3:mini` | Which model to load (CPU-friendly demo; YAML default is `llama3.1:8b`) |
+
+**How the app reads them:** `src/app.py` loads `.env` via `python-dotenv`, then reads `USE_DUMMY_GENERATOR`. `src/rag.py` reads `OLLAMA_*` and merges with `configs/config.yaml`. In Compose, variables are injected by Docker — you do **not** need a `.env` file unless you want overrides.
+
+**DEPLOYMENT table:** the markdown table in [DEPLOYMENT.md § Environment variables](DEPLOYMENT.md#environment-variables) documents the same Compose defaults as `docker-compose.yml` — for humans, not for Docker.
+
+**Dockerfile `ENV` vs Compose `environment`:** the [Dockerfile](Dockerfile) sets **Streamlit/Hugging Face noise reduction** (port, log levels). [Compose](docker-compose.yml) sets **RAG pilot switches** (`OLLAMA_*`, `USE_DUMMY_GENERATOR`). Different jobs; both end up as environment variables inside the container.
+
+---
+
+## Do clients need to clone this repo?
+
+**It depends who hosts:**
+
+| Scenario | What the client does | Who runs Ollama |
+|----------|----------------------|-----------------|
+| **Public Streamlit demo** | Open the URL — no clone | Nobody (dummy answers only) |
+| **You host a private pilot** | You send a **password-protected URL** (VPS + HTTPS, M7-6) | You, on your VM — client never clones |
+| **Client self-hosts** | Their IT clones repo, runs Compose on **their** VM | Client — data never leaves their infra |
+| **Consulting engagement** | You deploy on their cloud or a dedicated VM they own | Client-owned or contractually isolated |
+
+The repo is a **reference deployment** (copy-paste recipe), not the only delivery model. Many buyers never touch git — they get a URL or you install it for them.
+
+**Without `.env.example` / Compose docs:** you could still run *your* hosted pilot by setting env vars in Compose — but clients and IT would not know the recipe. That documentation is the **portfolio + sales asset**.
+
+---
+
+## For buyers: demo vs full pilot
+
+**Recommended funnel:**
+
+1. **Public demo** — zero friction; proves UX and retrieval. Answers are intentionally **not** from a real LLM (Streamlit Cloud cannot run Ollama for you).
+2. **Private pilot** — contact for access: real Ollama, their or your VM, NDA-friendly. This is where **Privacy · Reproducibility · Honesty** matter.
+3. **Production** — persistence, SSO, runbooks ([M8–M12](#production-direction-m8m12)).
+
+Showing real private RAG **immediately** to everyone is possible but costly (GPU/CPU, abuse, support). **Gating the full pilot** (email / call / shared URL) is a strong strategy: the public demo **teases**; the pilot **closes**.
+
+---
+
+## How a company deployment typically looks
+
+**Small team pilot (5–20 users, one VM):**
+
+```text
+Employees → HTTPS (Caddy + basic auth or SSO later)
+              → Streamlit on company VM or VPC
+              → Ollama on same VM
+              → PDFs processed in-session (M7); stored in DB later (M9)
+```
+
+| Phase | What you get |
+|-------|----------------|
+| **Week 1 — Pilot** | Single VM, Compose, `phi3:mini` or `llama3.1:8b`, password on URL |
+| **Month 1–3 — Hardening** | Backups, monitoring, model tuning, optional FastAPI (M8) |
+| **Production** | Client-owned cloud, pgvector, SSO, audit trail (M9–M11) |
+
+**Repeatable on any single VM** means: same `git clone` + `docker compose up` works on your laptop, a Hetzner box, or a client’s Azure VM — no “works on my machine” magic. Advantage for a **small team**: one IT person can reproduce the stack from this repo; you help with sizing, HTTPS, and compliance narrative.
+
+Details: [DEPLOYMENT.md](DEPLOYMENT.md) · [docs/architecture-pilot.md](docs/architecture-pilot.md)
+
+---
+
+## What works today
+
+### Application (M1–M6, `v0.6.0` baseline)
+
+- PDF upload with **PyMuPDF** + optional **Tesseract OCR** for scans  
+- **Chunking**, **local embeddings** (`all-MiniLM-L6-v2`), **FAISS** retrieval  
+- **Semantic** and **hybrid (BM25 + dense)** retrieval with optional reranker  
+- **Streamlit** chat UI with source previews (page, score, chunk text)  
+- **Ollama** or dummy generation ([`configs/config.yaml`](configs/config.yaml), `.env`)  
+- Developer mode: retrieval metrics, exact context fed to the LLM  
+
+### Reference deployment (M7 — in progress)
+
+Shipped on `main` so far:
+
+- [`Dockerfile`](Dockerfile) — reproducible Streamlit image (Python 3.12, OCR runtime)  
+- [`docker-compose.yml`](docker-compose.yml) — **app + Ollama**, health-gated startup, persistent model volume  
+- [`DEPLOYMENT.md`](DEPLOYMENT.md) — build, compose, model pull, env vars, troubleshooting  
+- [`.env.example`](.env.example) — self-host settings (`OLLAMA_HOST`, `USE_DUMMY_GENERATOR`, …)  
+- [`AGENTS.md`](AGENTS.md) + [`.cursor/agents/`](.cursor/agents/) — milestone delivery playbook for contributors  
+
+Still open for **M7 finish line** (see [roadmap](docs/ROADMAP.md)): full VPS/HTTPS guide, Caddy, demo video, pilot URL.
+
+---
+
+## Production direction (M8–M12)
+
+The demo is a **Streamlit session app** (in-memory FAISS per upload). Production pilots and enterprise delivery add layers on the same RAG core:
+
+| Milestone | Delivers |
+|-----------|----------|
+| **M8** | Extract `rag/` package + **FastAPI** (`/health`, `/chat`, OpenAPI) — integration surface beyond Streamlit |
+| **M9** | **Postgres/pgvector** + object storage — documents and indexes **survive restart** |
+| **M10** | **SSO / auth proxy**, `SECURITY.md` |
+| **M11** | **RUNBOOK.md**, backups, monitoring |
+| **M12** | **Anthropic** (or Azure OpenAI) as swappable LLM backend; pilot/pricing docs; demo recording |
+
+Target architecture:
+
+```text
+Browser → HTTPS → Streamlit and/or FastAPI
+                      ├── Postgres + pgvector
+                      ├── MinIO (PDFs)
+                      └── LLM (Ollama | Anthropic | …)
+```
+
+Details: [docs/ROADMAP.md](docs/ROADMAP.md) · [docs/architecture-pilot.md](docs/architecture-pilot.md)
+
+---
+
+## Quick start (self-hosted, real answers)
+
+**Fastest path:** Docker Compose with Ollama (see [DEPLOYMENT.md](DEPLOYMENT.md) for full steps).
 
 ```bash
 git clone https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline.git
 cd ai-doc-to-chat-pipeline
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
-pip install -r requirements.txt
+
+docker compose up -d ollama
+docker compose exec ollama ollama pull phi3:mini   # once, into persistent volume
+docker compose up --build
 ```
 
-1. Start Ollama server in Docker on port `11435`:
+Open [http://localhost:8501](http://localhost:8501). Compose sets `OLLAMA_HOST=http://ollama:11434` and `USE_DUMMY_GENERATOR=false`.
 
-```bash
-docker run -d --name ollama-cpu --restart unless-stopped -p 11435:11434 -v ollama:/root/.ollama ollama/ollama
-# If container already exists:
-# docker start ollama-cpu
-```
+**Local dev without Compose:** install [Ollama](https://ollama.com), `pip install -r requirements.txt`, `ollama pull llama3.1:8b`, then `streamlit run src/app.py` (dummy mode off in sidebar).
 
-1. Pull a model into that same Ollama server:
+**Streamlit Cloud demo:** [ai-doc-to-chat-demo.streamlit.app](https://ai-doc-to-chat-demo.streamlit.app) — dummy generation only; use self-host for real LLM answers.
 
-```bash
-OLLAMA_HOST=http://127.0.0.1:11435 ollama pull phi3:mini
-# Optional larger model:
-# OLLAMA_HOST=http://127.0.0.1:11435 ollama pull llama3.1:8b
-```
+---
 
-1. Verify Ollama is reachable:
+## Project milestones
 
-```bash
-curl http://127.0.0.1:11435/api/tags
-```
+| Phase | Status |
+|-------|--------|
+| M1–M4 | ✅ Prototype, PDF/OCR, FAISS RAG, generation |
+| M5–M6 (`v0.6.0`) | ✅ Live demo, cloud-ready shell |
+| **M7** | 🚧 Reference deployment (Dockerfile, Compose, health gate — [milestone #1](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/1)) |
+| M8–M12 | 📋 Planned — API, persistence, auth, ops, commercial docs |
 
-1. Run Streamlit against Docker Ollama:
+Last tagged release: **`v0.6.0`**. Post-`v0.6.0` work ships via `main` and GitHub milestones until the next tag.
 
-```bash
-OLLAMA_HOST=http://127.0.0.1:11435 OLLAMA_MODEL=phi3:mini streamlit run src/app.py
-```
+---
 
-Open `http://localhost:8501`, upload a PDF, and ask questions.
+## For teams and consulting
 
-### Recommended Docker Resources
+I help organizations deploy **private document AI** — single-VM pilots through production-shaped stacks (Compose, VPS, optional FastAPI, SSO, vector DB), without sending confidential PDFs to public SaaS chat.
 
-- CPU: `8-10` cores
-- Memory: `16 GB` minimum (`24 GB` recommended for `llama3.1:8b`)
-- Swap: `2-4 GB`
+**Reference deployment** = this public repo proves: *I don’t only have a demo link — I can ship a private, deployable version.*
 
-If generation is slow or fails with memory errors, use `phi3:mini` and/or lower context (`OLLAMA_NUM_CTX=2048`).
+| Buyer concern | How this project addresses it |
+|---------------|----------------------------------|
+| **Privacy** | Documents and prompts stay on *your* VM; Ollama runs locally |
+| **Reproducibility** | Docker Compose + documented env — IT can run the same stack |
+| **Honesty** | Public demo = UI only; private pilot = real generation, clearly labeled |
 
-### Apple M5 / Metal Compatibility Note
+**Get in touch for:**
 
-On some M5/macOS combinations, native Ollama can crash in the Metal backend (`MTLLibraryErrorDomain`).  
-Running Ollama inside Docker is the recommended workaround until upstream Metal fixes are fully stable across builds.
+- A **live private demo** (real Ollama on sample or redacted docs)  
+- **Pilot setup** on your laptop, VPS, or company cloud  
+- **Production path** — persistence, auth, runbooks ([roadmap](docs/ROADMAP.md))
 
-### Core Technologies (simple view)
+Typical engagement path:
 
-- **Streamlit** — clean, interactive UI  
-- **LangChain + FAISS** — fast, private RAG retrieval  
-- **PyMuPDF + Tesseract** — handles any PDF (digital or scanned)  
-- **Ollama** — local LLM generation (phi3, llama3.1, etc.)  
-- Fully configurable via YAML files
+1. **Pilot** — self-hosted Compose + Ollama on your or my infrastructure  
+2. **Production** — persistence, auth, runbooks, client-owned cloud or dedicated VM  
+3. **Engine choice** — local Ollama for air-gap; Anthropic/Azure OpenAI via private API when quality or procurement requires it  
+
+Same RAG pipeline; deployment and LLM backend vary by compliance and budget.
+
+---
+
+## Development
+
+- Config: [`configs/config.yaml`](configs/config.yaml), [`configs/prompts.yaml`](configs/prompts.yaml)  
+- Tests: `pytest tests/ -v`  
+- Contributor workflow: [AGENTS.md](AGENTS.md) (orchestrator, slash commands, one-issue-one-PR)  
+
+---
+
+## Core stack
+
+Streamlit · LangChain · FAISS · sentence-transformers · PyMuPDF · Tesseract · Ollama · Docker · YAML-driven config
 
 MIT licensed — free to use, modify, or build on commercially.
 
-**Looking for a customized version?**  
-Multi-user access, enterprise vector DB integration, audit logs, SSO, or cloud deployment? I'm available for freelance/consulting projects.
-
-Made with ❤️ by **Roxana Tapia** — March 2026
+Made with ❤️ by **Roxana Tapia** — 2026

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,7 +149,7 @@ Browser → HTTPS (Caddy) → Streamlit and/or FastAPI
                               └── LLM backend (Ollama | Anthropic)
 ```
 
-Current repo (pre-M7): single Streamlit process, in-memory FAISS, external Ollama.
+**Today (M7 in progress):** Streamlit app in Docker Compose with co-located Ollama, health-gated startup, in-memory FAISS per session. **M9+** adds Postgres/pgvector persistence.
 
 ---
 
@@ -165,5 +165,7 @@ This repo uses Cursor **rules**, **subagents**, and **slash commands** to delive
 | Workflow rules | `.cursor/rules/milestone-workflow.mdc` |
 
 **Operator loop:** pick GitHub issue → `/ship-m7-issue #NN` → resolve blockers → approve commits → merge PR.
+
+**After a milestone phase ships:** dispatch `docs-writer` to sync [README.md](../README.md) status with this roadmap.
 
 M7 issues [#33–#39](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/1) map to specialists (`deploy-engineer`, `config-guardian`, `docs-writer`) — see AGENTS.md.


### PR DESCRIPTION
## Summary

Closes #36 — self-host env defaults and client-facing pilot documentation.

- **`.env.example` + `DEPLOYMENT.md`** — `OLLAMA_HOST`, `USE_DUMMY_GENERATOR=false` for Compose/VPS, YAML cross-ref, Environment variables table.
- **`README.md`** — client-facing refactor: architecture at a glance, demo vs private pilot, company pilot path, future work, consulting (**Privacy · Reproducibility · Honesty**), Cursor agentic delivery note. Operator-only content removed from public README.
- **`AGENTS.md` / `docs-writer` / `ROADMAP.md`** — documentation maintenance playbook and M7 status sync.
- **`.gitignore`** — `docs-private/` for local operator notes (sales, roadmap detail, infra) — not committed.

## Commits (5)

1. `docs(m7): document self-host env defaults in .env.example`
2. `docs: expand README for private pilot architecture and buyer funnel`
3. `docs: add documentation maintenance playbook for agents`
4. `docs: refocus README for client-facing audience`
5. `chore: gitignore docs-private for local operator notes`

## Test plan

- [x] Review `.env.example` and DEPLOYMENT env table against `docker-compose.yml` defaults
- [x] README reads well for a buyer (no internal operator jargon)
- [x] Links resolve: `DEPLOYMENT.md#environment-variables`, `.env.example`, `docs/architecture-pilot.md`
- [x] `docker compose up` smoke test — real Ollama answers without creating `.env`
- [x] Public demo vs private pilot messaging is accurate (Streamlit Cloud vs Compose)