### PR TITLE
M7-5: Write DEPLOYMENT.md (Ollama single-VM path)

### DIFF
--- a/.cursor/agents/docs-writer.md
+++ b/.cursor/agents/docs-writer.md
@@ -12,7 +12,10 @@ You are the **docs-writer** for ai-doc-to-chat-pipeline.
 
 - `docs/**`
 - `DEPLOYMENT.md`, `DEPLOYMENT-ANTHROPIC.md`, `RUNBOOK.md` (when created)
-- **README.md** — especially: demo vs self-host table, milestone status, production direction summary, quick-start pointers, consulting blurb (keep detail in linked docs)
+- **README.md** — client-facing only: demo vs pilot, outcomes, consulting CTA, short pointers to DEPLOYMENT (no compose commands, issue numbers, or env priority chains)
+- `docs/**` (public)
+- `DEPLOYMENT.md`, `DEPLOYMENT-ANTHROPIC.md`, `RUNBOOK.md` (when created)
+- **`docs-private/`** — local operator notes (gitignored); sync when public deploy/sales docs change
 
 ## Must NOT touch
 
@@ -22,10 +25,11 @@ You are the **docs-writer** for ai-doc-to-chat-pipeline.
 ## Standards
 
 - Placeholders for URLs/hostnames until human provides values.
-- Clear prerequisites, verify steps, troubleshooting.
-- Link AGENTS.md, ROADMAP, architecture diagrams.
-- Client-facing tone: professional, no fluff.
-- **README:** update milestone checklist and “what works today” when issues merge; do not duplicate DEPLOYMENT.md procedures in README.
+- Clear prerequisites, verify steps, troubleshooting in DEPLOYMENT.
+- Link ROADMAP and architecture from contributor-facing docs, not README.
+- Client-facing tone in README; IT-facing tone in DEPLOYMENT.
+- **README:** update “what works today” when issues merge; never duplicate DEPLOYMENT procedures.
+- **docs-private:** recording scripts, sales playbook, env “switches”, provider recommendations — not in public repo.
 
 ## Workflow
 

--- a/.cursor/rules/docs-commercial.mdc
+++ b/.cursor/rules/docs-commercial.mdc
@@ -1,14 +1,25 @@
 ---
 description: Deployment and commercial documentation — clear, client-facing prose
-globs: docs/**,DEPLOYMENT*.md,RUNBOOK.md
+globs: docs/**,DEPLOYMENT*.md,RUNBOOK.md,README.md
 alwaysApply: false
 ---
 
 # Docs & commercial writing
 
-- Write for a technical buyer: ops steps, sizing, cost bands, privacy boundaries.
+## Audiences
+
+| Doc | Audience | Tone |
+|-----|----------|------|
+| **README.md** | Clients, buyers, casual visitors | Outcomes, privacy, pilot path — no issue numbers or deploy commands |
+| **DEPLOYMENT.md** | Client IT, technical buyers | Prerequisites → install → verify → troubleshoot |
+| **docs/architecture-pilot.md** | Client IT | Diagram + data flow; no milestone jargon |
+| **docs/ROADMAP.md**, **AGENTS.md** | Contributors | Issues, agents, workflow |
+| **`docs-private/`** | Operator (local, gitignored) | Sales, switches, provider picks, full roadmap, demo script |
+
+## Rules
+
+- Write for a technical buyer in DEPLOYMENT; write for a business buyer in README.
 - Use placeholders (`YOUR_VPS_IP`, `demo.example.com`) until human provides real values.
-- Link to [AGENTS.md](AGENTS.md) and [docs/ROADMAP.md](docs/ROADMAP.md) where relevant.
-- DEPLOYMENT docs: prerequisites → install → verify → troubleshoot.
+- Link README → DEPLOYMENT for setup; do not duplicate compose commands in README.
 - No secrets, client names, or internal passwords in committed docs.
-- Keep README deploy section short; detail lives in `DEPLOYMENT.md`.
+- After updating public deploy docs, mirror operator-only detail in `docs-private/` when a counterpart file exists.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,16 +110,28 @@ Keep user-facing docs aligned when milestones ship or deployment behavior change
 | **README.md** | `docs-writer` | Milestone status changes, new deploy paths — **client-facing only** |
 | **DEPLOYMENT.md** | `docs-writer` + `deploy-engineer` review | Compose, env, VPS, HTTPS, troubleshooting (technical buyers + IT) |
 | **docs/ROADMAP.md** | `docs-writer` | M7–M12 scope or definition-of-done changes (contributors) |
-| **docs/architecture-pilot.md** | `docs-writer` | Architecture target changes (M9+ especially) |
-| **`docs-private/`** | Human + `docs-writer` | **Local only (gitignored)** — sales playbook, env switches, full roadmap detail, infra notes |
+| **docs/architecture-pilot.md** | `docs-writer` | Architecture target changes (client/IT summary) |
+| **docs/demo-script.md** | `docs-writer` | Public stub only — link placeholder until video ships |
+| **`docs-private/`** | Human + `docs-writer` | **Local only (gitignored)** — sales playbook, env switches, full roadmap detail, demo recording script, infra notes |
 | **AGENTS.md** | Human + orchestrator | New agents, decision log, issue→agent map |
+
+**Audience split**
+
+| Audience | Read | Do not put here |
+|----------|------|-----------------|
+| **Clients / buyers** | README | Issue numbers, agent names, env priority chains, sales scripts |
+| **Client IT** | DEPLOYMENT.md, architecture-pilot | Internal pricing, VPS provider picks, funnel scripts |
+| **You / operators** | `docs-private/` | Real hostnames, secrets, client names |
+| **Contributors** | AGENTS.md, ROADMAP | Sales playbook |
+
+**Bootstrap `docs-private/`** on a new machine: copy or recreate the folder locally (see index in your existing `docs-private/README.md`). It is never committed.
 
 **After merging a GitHub milestone slice** (e.g. M7 complete, M8 started):
 
 1. Orchestrator or human opens a **docs issue** or adds sub-task: “Sync README + ROADMAP status.”
 2. Dispatch **`docs-writer` only** — do not parallelize with code issues on the same PR unless docs-only.
-3. **README** stays **short and client-facing** — no operator jargon, env implementation detail, or milestone issue numbers. Link to `DEPLOYMENT.md` for deploy depth ([`docs-commercial` rule](.cursor/rules/docs-commercial.mdc)).
-4. **Operator / sales detail** (funnel scripts, VPS provider picks, “the switches”, clone-vs-URL hosting) lives in **`docs-private/`** on your machine — never committed.
+3. **README** stays **short and client-facing** — no operator jargon, env implementation detail, milestone issue numbers, or duplicate deploy commands. Link to `DEPLOYMENT.md` for setup ([`docs-commercial` rule](.cursor/rules/docs-commercial.mdc)).
+4. **Operator / sales detail** (funnel scripts, VPS provider picks, “the switches”, clone-vs-URL hosting, demo recording checklist) lives in **`docs-private/`** on your machine — never committed. After shipping public docs, sync the matching `docs-private/` file if one exists.
 
 There is **no separate README agent** — use **`docs-writer`** for README status, deploy sections, and production narrative.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,17 +107,19 @@ Keep user-facing docs aligned when milestones ship or deployment behavior change
 
 | File | Owner | Update when |
 |------|-------|-------------|
-| **README.md** | `docs-writer` | Milestone status changes, new deploy paths, production vision shifts |
-| **DEPLOYMENT.md** | `docs-writer` + `deploy-engineer` review | Compose, env, VPS, HTTPS, troubleshooting |
-| **docs/ROADMAP.md** | `docs-writer` | M7–M12 scope or definition-of-done changes |
+| **README.md** | `docs-writer` | Milestone status changes, new deploy paths — **client-facing only** |
+| **DEPLOYMENT.md** | `docs-writer` + `deploy-engineer` review | Compose, env, VPS, HTTPS, troubleshooting (technical buyers + IT) |
+| **docs/ROADMAP.md** | `docs-writer` | M7–M12 scope or definition-of-done changes (contributors) |
 | **docs/architecture-pilot.md** | `docs-writer` | Architecture target changes (M9+ especially) |
+| **`docs-private/`** | Human + `docs-writer` | **Local only (gitignored)** — sales playbook, env switches, full roadmap detail, infra notes |
 | **AGENTS.md** | Human + orchestrator | New agents, decision log, issue→agent map |
 
 **After merging a GitHub milestone slice** (e.g. M7 complete, M8 started):
 
 1. Orchestrator or human opens a **docs issue** or adds sub-task: “Sync README + ROADMAP status.”
 2. Dispatch **`docs-writer` only** — do not parallelize with code issues on the same PR unless docs-only.
-3. README stays **short** — link to `DEPLOYMENT.md` and `docs/ROADMAP.md` for depth ([`docs-commercial` rule](.cursor/rules/docs-commercial.mdc)).
+3. **README** stays **short and client-facing** — no operator jargon, env implementation detail, or milestone issue numbers. Link to `DEPLOYMENT.md` for deploy depth ([`docs-commercial` rule](.cursor/rules/docs-commercial.mdc)).
+4. **Operator / sales detail** (funnel scripts, VPS provider picks, “the switches”, clone-vs-URL hosting) lives in **`docs-private/`** on your machine — never committed.
 
 There is **no separate README agent** — use **`docs-writer`** for README status, deploy sections, and production narrative.
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,101 +1,272 @@
 # Deployment Guide
 
-> Stub for M7-1. Full Ollama, Compose, and VPS instructions land in M7-5.
+Complete walkthrough for a **single-VM Ollama pilot**: Docker Compose on a VPS (production-shaped) or on your laptop (local dev). No source-code reading required.
+
+Architecture overview: [docs/architecture-pilot.md](docs/architecture-pilot.md)
+
+---
 
 ## Prerequisites
 
-- Docker 24+ with BuildKit enabled
-- ~4 GB free disk for the image (PyTorch + embedding models download on first run)
+| Requirement | Notes |
+|-------------|--------|
+| **Docker 24+** | With BuildKit enabled (`DOCKER_BUILDKIT=1`) |
+| **Docker Compose v2** | `docker compose` (plugin), not legacy `docker-compose` |
+| **git** | To clone the repository |
+| **~4 GB free disk** | App image (PyTorch + embedding models) plus Ollama model weights in a named volume |
+| **SSH access** | For VPS deployment |
+| **Outbound internet** | First run downloads Hugging Face embedding weights and Ollama model blobs |
 
-## Build image
+Optional: copy [`.env.example`](.env.example) to `.env` if you need to override generation settings (see [Environment variables](#environment-variables)).
+
+---
+
+## VPS sizing
+
+Choose hardware to match the Ollama model you plan to run. The Compose stack defaults to **`phi3:mini`** on the app service — suitable for CPU-only demos.
+
+| Profile | Example sizing | Model | Typical use | Cost band (placeholder) |
+|---------|----------------|-------|-------------|-------------------------|
+| **CPU demo** | 4 vCPU, 8 GB RAM (e.g. Hetzner **CX32** or similar) | `phi3:mini` | Pilot evaluations, small teams, low concurrency | ~€15/mo |
+| **GPU** | 8 GB+ VRAM (dedicated GPU VPS or cloud GPU instance) | `llama3.1:8b` | Higher answer quality, faster inference | ~$50–$200+/mo (provider-dependent) |
+
+**CPU vs GPU notes**
+
+- **`phi3:mini`** — default for CPU-only hosts; lower memory footprint; first answers may take 30–60+ seconds on cold start.
+- **`llama3.1:8b`** — better quality; practical on GPU or very large RAM hosts; on CPU-only VMs you may hit slow responses or OOM — prefer `phi3:mini` or reduce `OLLAMA_NUM_CTX` (see [Troubleshooting](#troubleshooting)).
+
+Model weights persist in the Docker volume `ollama_models` across restarts; pull each model once per volume.
+
+---
+
+## Deploy on a VPS
+
+Replace `YOUR_VPS_IP` with your server’s public address. HTTPS and access control are planned for M7-6 (Caddy); until then, restrict port **8501** to trusted IPs.
+
+### 1. Prepare the server
+
+```bash
+# Example: Ubuntu/Debian — install Docker (official docs may vary by distro)
+sudo apt-get update
+sudo apt-get install -y git ca-certificates curl
+# Install Docker Engine 24+ and Compose plugin per https://docs.docker.com/engine/install/
+
+sudo usermod -aG docker "$USER"
+# Log out and back in so group membership applies
+```
+
+**Firewall (interim, before HTTPS):** allow SSH and Streamlit from trusted sources only. Ollama stays on the internal Compose network — do **not** expose port 11434 publicly.
+
+```bash
+# Example (ufw) — adjust CIDR to your office/VPN
+sudo ufw allow OpenSSH
+sudo ufw allow from YOUR_TRUSTED_CIDR to any port 8501
+sudo ufw enable
+```
+
+### 2. Clone the repository
+
+```bash
+git clone https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline.git
+cd ai-doc-to-chat-pipeline
+```
+
+### 3. Start Ollama and wait until healthy
+
+The app service does not start until Ollama passes its health check (`ollama list` inside the container).
+
+```bash
+docker compose up -d ollama
+docker compose ps ollama   # STATUS should show "healthy" (may take up to ~60s on first boot)
+```
+
+If status stays `starting`, inspect logs: `docker compose logs -f ollama`.
+
+### 4. Pull a model (one time per volume)
+
+```bash
+# CPU demo default (matches docker-compose.yml OLLAMA_MODEL)
+docker compose exec ollama ollama pull phi3:mini
+
+# GPU / higher-quality hosts
+# docker compose exec ollama ollama pull llama3.1:8b
+```
+
+If you pull `llama3.1:8b`, set `OLLAMA_MODEL=llama3.1:8b` via `.env` and `env_file` on the app service, or export before `docker compose up`.
+
+### 5. Build and start the full stack
+
+```bash
+docker compose up --build -d
+docker compose ps
+```
+
+Both services should be **Up**; `ollama` should remain **healthy**. Streamlit listens on **8501** on the host.
+
+### 6. Open the app
+
+From a machine that can reach the VPS:
+
+```text
+http://YOUR_VPS_IP:8501
+```
+
+Upload a PDF and ask a question. The first query may be slow while embedding weights download inside the app container.
+
+---
+
+## Verify deployment
+
+Run these on the VPS from the project directory.
+
+### Compose health
+
+```bash
+docker compose ps
+```
+
+Expect `ollama` **healthy** and `app` **Up**. The app waits on `depends_on: condition: service_healthy` so Streamlit does not race a still-booting Ollama daemon.
+
+### Ollama CLI (models in volume)
+
+```bash
+docker compose exec ollama ollama list
+```
+
+You should see `phi3:mini` (or the model you pulled).
+
+### Ollama HTTP API (`/api/tags`)
+
+Ollama is **not** published to the host in the default `docker-compose.yml` (internal network only). Use a one-off `curl` container on the Compose network:
+
+```bash
+# Network name is usually <project-directory>_default
+PROJECT=$(basename "$PWD")
+docker run --rm --network "${PROJECT}_default" curlimages/curl:8.5.0 \
+  -s http://ollama:11434/api/tags
+```
+
+You should get JSON listing installed models. If the network name differs:
+
+```bash
+docker network ls | grep default
+# Then: docker run --rm --network YOUR_NETWORK_NAME curlimages/curl:8.5.0 -s http://ollama:11434/api/tags
+```
+
+**Optional — host `curl`:** temporarily add `ports: ["11434:11434"]` under the `ollama` service locally (do not commit if you prefer internal-only), then:
+
+```bash
+curl -s http://127.0.0.1:11434/api/tags
+```
+
+Remove the port mapping when finished.
+
+### Streamlit UI
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8501/_stcore/health
+```
+
+Expect `200`. Then open `http://YOUR_VPS_IP:8501` in a browser and confirm chat works after a PDF upload.
+
+---
+
+## Local development
+
+Same Compose flow on your laptop — useful before promoting to a VPS.
+
+### Build image only (smoke test, no Ollama)
 
 ```bash
 docker build -t ai-doc-to-chat .
-```
-
-## Run container (local smoke test)
-
-```bash
 docker run --rm -p 8501:8501 ai-doc-to-chat
 ```
 
-Open [http://localhost:8501](http://localhost:8501). For Ollama-backed answers, use Docker Compose (below) or run Ollama on the host and pass `OLLAMA_HOST`.
+Open [http://localhost:8501](http://localhost:8501). For real Ollama answers, use Docker Compose below (or run Ollama on the host and set `OLLAMA_HOST`).
 
-## Docker Compose (app + Ollama)
+### Docker Compose (app + Ollama)
 
-### Fresh start (end-to-end)
+#### Fresh start (end-to-end)
 
-1. Start Ollama and wait until it is healthy (the app service does not start until then):
+1. Start Ollama and wait until healthy:
 
    ```bash
    docker compose up -d ollama
    docker compose ps ollama   # STATUS should show "healthy"
    ```
 
-2. Pull a model **once** into the persistent `ollama_models` volume (choose one):
+2. Pull a model **once** into the persistent `ollama_models` volume:
 
    ```bash
-   # CPU demo default (see AGENTS.md)
    docker compose exec ollama ollama pull phi3:mini
-
-   # GPU / more capable hosts
-   docker compose exec ollama ollama pull llama3.1:8b
+   # docker compose exec ollama ollama pull llama3.1:8b   # GPU hosts
    ```
 
-3. Start the app (or bring up the full stack):
+3. Start the app (foreground or detached):
 
    ```bash
    docker compose up --build
+   # or: docker compose up --build -d
    ```
 
-   Compose starts `ollama` first; `app` waits on `depends_on: condition: service_healthy` so Streamlit does not race a still-booting Ollama daemon.
+4. Optional: `cp .env.example .env`, edit values, add `env_file: .env` under the `app` service in `docker-compose.yml`.
 
-4. Optional: match the pulled model in a local `.env` (e.g. `OLLAMA_MODEL=phi3:mini`), add `env_file: .env` under the `app` service, or export before `docker compose up`.
+5. Open [http://localhost:8501](http://localhost:8501), upload a PDF, and ask a question.
 
-5. Open [http://localhost:8501](http://localhost:8501), upload a PDF, and ask a question. The first run may be slow while Hugging Face embedding weights download inside the app container.
+The app receives `OLLAMA_HOST=http://ollama:11434`, `USE_DUMMY_GENERATOR=false`, and `OLLAMA_MODEL=phi3:mini` from Compose.
 
-The app service receives `OLLAMA_HOST=http://ollama:11434` and `USE_DUMMY_GENERATOR=false`.
+#### One-shot equivalent
 
-### Environment variables
-
-Pilot-relevant settings are documented in [`.env.example`](.env.example). For self-hosted deployments:
-
-| Variable | Compose default | Purpose |
-|----------|-----------------|--------|
-| `OLLAMA_HOST` | `http://ollama:11434` | Ollama API URL (service name in Compose, not `localhost`) |
-| `USE_DUMMY_GENERATOR` | `false` | Must be `false` for real Ollama answers on Compose/VPS |
-| `OLLAMA_MODEL` | `phi3:mini` | Override; YAML default is `llama3.1:8b` in `configs/config.yaml` |
-
-To override via a file: `cp .env.example .env`, edit values, and add `env_file: .env` under the `app` service in `docker-compose.yml`. Generation tuning (`temperature`, `num_ctx`, etc.) follows `configs/config.yaml` → `rag.generation` unless set as `OLLAMA_*` in `.env`.
-
-See also [docs/architecture-pilot.md](docs/architecture-pilot.md#environment-variables-pilot).
-
-### One-shot equivalent
-
-If you prefer a single command after models are already pulled:
+After models are already pulled:
 
 ```bash
 docker compose up --build
 ```
 
-Model weights still persist in the `ollama_models` volume across restarts.
+Model weights persist in the `ollama_models` volume across restarts.
+
+### Environment variables
+
+Pilot-relevant settings are documented in [`.env.example`](.env.example).
+
+| Variable | Compose default | Purpose |
+|----------|-----------------|--------|
+| `OLLAMA_HOST` | `http://ollama:11434` | Ollama API URL (Compose service name, not `localhost`) |
+| `USE_DUMMY_GENERATOR` | `false` | Must be `false` for real Ollama answers on Compose/VPS |
+| `OLLAMA_MODEL` | `phi3:mini` | Override; YAML default in `configs/config.yaml` is `llama3.1:8b` |
+
+To override via file: `cp .env.example .env`, edit values, and add `env_file: .env` under the `app` service. Generation tuning (`temperature`, `num_ctx`, etc.) follows `configs/config.yaml` → `rag.generation` unless set as `OLLAMA_*` in `.env`.
+
+See also [docs/architecture-pilot.md](docs/architecture-pilot.md#environment-variables-pilot).
+
+---
 
 ## Troubleshooting
 
 | Symptom | Likely cause | What to do |
 |--------|----------------|------------|
-| `app` never starts / stays "Waiting" | Ollama not healthy yet | `docker compose logs ollama`; wait for `healthy` in `docker compose ps`. Increase `start_period` on slow disks if needed. |
-| **Connection refused** / cannot connect to Ollama | Ollama down, wrong host, or app started before Ollama was ready | Use Compose (not `docker run` app alone) or set `OLLAMA_HOST` to a running server. Check `docker compose ps` shows `ollama` healthy. |
-| **Model not found** / pull errors in chat | No model in the volume | Run `docker compose exec ollama ollama pull phi3:mini` (or `llama3.1:8b`). Set `OLLAMA_MODEL` to the same name. |
-| Slow or OOM on first answer | Large default model on CPU | Use `phi3:mini` and/or lower `OLLAMA_NUM_CTX` in `.env`. |
+| `app` never starts / stays "Waiting" | Ollama not healthy yet | `docker compose logs ollama`; wait for `healthy` in `docker compose ps`. Slow disks may need more time within the healthcheck `start_period`. |
+| **Connection refused** to Ollama | Ollama down, wrong host, or app started before Ollama was ready | Use Compose (not `docker run` app alone). On VPS, app must use `OLLAMA_HOST=http://ollama:11434` — not `localhost`. Check `docker compose ps` shows `ollama` **healthy**. |
+| **Connection refused** on `YOUR_VPS_IP:8501` | Firewall, wrong IP, or app not running | `docker compose ps`; open port 8501 only to trusted CIDRs; confirm `curl http://127.0.0.1:8501/_stcore/health` on the VPS returns 200. |
+| **Model not found** / pull errors in chat | No model in the volume or name mismatch | `docker compose exec ollama ollama pull phi3:mini` (or `llama3.1:8b`). Set `OLLAMA_MODEL` to the same tag. Verify with `docker compose exec ollama ollama list`. |
+| **`/api/tags` empty or curl fails** | Model not pulled or wrong Docker network | Pull the model again; use the `docker run ... curlimages/curl` command under [Verify deployment → Ollama HTTP API](#verify-deployment) with the correct network name. |
+| Slow first answer | Cold model + embedding download | Normal once per deploy; subsequent questions faster. |
+| **OOM** / container killed / very slow on CPU | Model too large for RAM | Use `phi3:mini`; lower `OLLAMA_NUM_CTX` in `.env`; size up the VPS or move to a GPU instance with `llama3.1:8b`. Check `docker compose logs app` and `docker compose logs ollama`. |
+| Disk full during pull | Undersized volume | Ensure ~4 GB+ free for app image and models; `docker system df`; prune unused images only if safe. |
 
-Verify Ollama from the host (optional):
+Quick checks:
 
 ```bash
+docker compose ps
+docker compose logs --tail=50 ollama
+docker compose logs --tail=50 app
 docker compose exec ollama ollama list
 ```
 
+---
+
 ## Notes
 
-- No secrets are baked into the image; use runtime env vars or a mounted `.env` file.
-- First query may be slow while Hugging Face embedding weights download into the container cache.
+- No secrets are baked into the image; use runtime env vars or a mounted `.env` file (never commit `.env`).
+- First query may be slow while Hugging Face embedding weights download into the app container cache.
+- HTTPS, basic auth, and a public demo hostname are covered in M7-6 — see [docs/ROADMAP.md](docs/ROADMAP.md).

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -41,7 +41,7 @@ Model weights persist in the Docker volume `ollama_models` across restarts; pull
 
 ## Deploy on a VPS
 
-Replace `YOUR_VPS_IP` with your server’s public address. HTTPS and access control are planned for M7-6 (Caddy); until then, restrict port **8501** to trusted IPs.
+Replace `YOUR_VPS_IP` with your server’s public address. HTTPS and access control ship in a follow-up update; until then, restrict port **8501** to trusted IPs.
 
 ### 1. Prepare the server
 
@@ -269,4 +269,4 @@ docker compose exec ollama ollama list
 
 - No secrets are baked into the image; use runtime env vars or a mounted `.env` file (never commit `.env`).
 - First query may be slow while Hugging Face embedding weights download into the app container cache.
-- HTTPS, basic auth, and a public demo hostname are covered in M7-6 — see [docs/ROADMAP.md](docs/ROADMAP.md).
+- HTTPS, basic auth, and a public demo hostname — add in a follow-up deployment update; until then restrict port **8501** to trusted IPs (see [Deploy on a VPS](#deploy-on-a-vps)).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Private RAG chat for your PDFs** — upload contracts, invoices, or scans, ask questions in plain language, and get **grounded answers with page-level sources**. Built for teams that need **control over data and infrastructure**, not another public chatbot tab.
 
-**Want real answers on confidential documents?** The [public demo](https://ai-doc-to-chat-demo.streamlit.app) shows the interface only. [Contact me](#for-teams-and-consulting) for a **private pilot** with real local AI, or deployment inside your company.
+**Clients who care about privacy and control don't upload contracts or HR policies to ChatGPT — or a [public demo](https://ai-doc-to-chat-demo.streamlit.app).** [Contact me](#for-teams-and-consulting) for a **private pilot** with real local AI on your infrastructure (or mine).
 
 ---
 
@@ -109,9 +109,9 @@ I deploy **private document AI** for organizations that cannot send contracts or
 | **Reproducibility** | Docker Compose reference deployment your IT can audit and reproduce |
 | **Honesty** | Public demo shows the UI; private pilot delivers real generation — clearly separated |
 
-**Typical path:** pilot on your infrastructure → hardening and persistence → production with auth and runbooks. Local Ollama for air-gap; private cloud APIs when quality or procurement requires it.
+**Typical path:** evaluation on a [modest dedicated server](DEPLOYMENT.md) → hardening and persistence → production with auth and runbooks. Higher quality and scale mean more compute — either a larger VM you control or a scoped cloud API — chosen with your IT and legal team.
 
-**[Contact me](#for-teams-and-consulting)** for a live private demo, pilot setup, or scoping a production rollout.
+**[Contact me](#for-teams-and-consulting)** for a live private demo, pilot setup, or scoping a production rollout · [GitHub @RoxanaTapia](https://github.com/RoxanaTapia)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,27 @@ I deploy **private document AI** for organizations that cannot send contracts or
 
 ## Contributing
 
-Developed in small, tested increments so pilots can harden into production without surprises.
+This project is built **agentically in [Cursor](https://cursor.com)** — one GitHub issue, one branch, one reviewable PR — so pilot features ship in small, tested steps instead of ad-hoc prompts.
 
-Open-source contributors: [AGENTS.md](AGENTS.md) · [docs/ROADMAP.md](docs/ROADMAP.md)
+**How it works**
+
+| Cursor feature | Role in this repo |
+|----------------|-------------------|
+| **Rules** (`.cursor/rules/`) | Persistent standards — Python/RAG style, Docker deploy, docs tone, milestone workflow |
+| **Subagents** (`.cursor/agents/`) | Specialists with file ownership (`deploy-engineer`, `rag-core-engineer`, `docs-writer`, `verifier`, …) |
+| **Slash commands** (`.cursor/commands/`) | Repeatable flows — e.g. `/ship-m7-issue`, `/verify` |
+| **Orchestrator** | Reads issues, dispatches specialists, runs tests, splits granular commits |
+
+**Why bother**
+
+- **Clear ownership** — agents edit only their files; fewer merge conflicts and surprise diffs
+- **Production-shaped history** — granular commits and PRs that map to roadmap milestones
+- **Verify before merge** — pytest/ruff (and Docker checks when infra changes) before every PR
+- **Human in the loop** — you approve commits, pushes, and merges; agents propose, you decide
+
+**Get started:** [AGENTS.md](AGENTS.md) (playbook) · [docs/ROADMAP.md](docs/ROADMAP.md) (milestones M7–M12) · open a GitHub issue or pick one from the [M7 milestone](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/1).
+
+Using Cursor is optional for drive-by fixes — but matching the one-issue-one-PR workflow helps reviews stay fast.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ I deploy **private document AI** for organizations that cannot send contracts or
 
 **Typical path:** evaluation on a [modest dedicated server](DEPLOYMENT.md) → hardening and persistence → production with auth and runbooks. Higher quality and scale mean more compute — either a larger VM you control or a scoped cloud API — chosen with your IT and legal team.
 
-**How I deliver:** I build with **agentic workflows in [Cursor](https://cursor.com)** — rules, specialized agents, and automated tests — so features ship in small, reviewable steps. That means **faster iteration** on your pilot (deploy docs, Docker, RAG tweaks) while keeping **auditable PRs** and human sign-off on what goes to production. You get working software and a clear paper trail, not a one-off prompt dump.
+This reference pilot was built with **[Cursor](https://cursor.com)** — the same test-backed, reviewable workflow I use to ship client work without cutting corners. That is how the stack, deployment guide, and docs moved quickly while staying auditable in git. **Your PDFs and prompts are not part of that:** at runtime everything stays on **your** VM or VPC (local Ollama). My tooling builds the product; your data never leaves your environment.
 
 **Get in touch:** [Upwork](https://www.upwork.com/freelancers/roxanadev) (private pilot, consulting, production scoping) · [GitHub](https://github.com/RoxanaTapia) (OSS and technical questions)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Private RAG chat for your PDFs** — upload contracts, invoices, or scans, ask questions in plain language, and get **grounded answers with page-level sources**. Built for teams that need **control over data and infrastructure**, not another public chatbot tab.
 
-**Clients who care about privacy and control don't upload contracts or HR policies to ChatGPT — or a [public demo](https://ai-doc-to-chat-demo.streamlit.app).** For a **private pilot** with real local AI, [get in touch on GitHub](https://github.com/RoxanaTapia).
+**Clients who care about privacy and control don't upload contracts or HR policies to ChatGPT — or a [public demo](https://ai-doc-to-chat-demo.streamlit.app).** For a **private pilot** with real local AI, [hire on Upwork](https://www.upwork.com/freelancers/roxanadev) or [reach out on GitHub](https://github.com/RoxanaTapia).
 
 ---
 
@@ -111,7 +111,7 @@ I deploy **private document AI** for organizations that cannot send contracts or
 
 **Typical path:** evaluation on a [modest dedicated server](DEPLOYMENT.md) → hardening and persistence → production with auth and runbooks. Higher quality and scale mean more compute — either a larger VM you control or a scoped cloud API — chosen with your IT and legal team.
 
-**Get in touch:** [github.com/RoxanaTapia](https://github.com/RoxanaTapia) — use profile contact for a live private demo, pilot setup, or production scoping.
+**Get in touch:** [Upwork](https://www.upwork.com/freelancers/roxanadev) (private pilot, consulting, production scoping) · [GitHub](https://github.com/RoxanaTapia) (OSS and technical questions)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Private RAG chat for your PDFs** — upload contracts, invoices, or scans, ask questions in plain language, and get **grounded answers with page-level sources**. Built for teams that need **control over data and infrastructure**, not another public chatbot tab.
 
-**Clients who care about privacy and control don't upload contracts or HR policies to ChatGPT — or a [public demo](https://ai-doc-to-chat-demo.streamlit.app).** [Contact me](#for-teams-and-consulting) for a **private pilot** with real local AI on your infrastructure (or mine).
+**Clients who care about privacy and control don't upload contracts or HR policies to ChatGPT — or a [public demo](https://ai-doc-to-chat-demo.streamlit.app).** For a **private pilot** with real local AI, [get in touch on GitHub](https://github.com/RoxanaTapia).
 
 ---
 
@@ -111,7 +111,7 @@ I deploy **private document AI** for organizations that cannot send contracts or
 
 **Typical path:** evaluation on a [modest dedicated server](DEPLOYMENT.md) → hardening and persistence → production with auth and runbooks. Higher quality and scale mean more compute — either a larger VM you control or a scoped cloud API — chosen with your IT and legal team.
 
-**[Contact me](#for-teams-and-consulting)** for a live private demo, pilot setup, or scoping a production rollout · [GitHub @RoxanaTapia](https://github.com/RoxanaTapia)
+**Get in touch:** [github.com/RoxanaTapia](https://github.com/RoxanaTapia) — use profile contact for a live private demo, pilot setup, or production scoping.
 
 ---
 
@@ -129,4 +129,4 @@ Streamlit · LangChain · FAISS · sentence-transformers · PyMuPDF · Tesseract
 
 MIT licensed — free to use, modify, or build on commercially.
 
-Made with ❤️ by **Roxana Tapia** — 2026
+Made with ❤️ by **[Roxana Tapia](https://github.com/RoxanaTapia)** — 2026

--- a/README.md
+++ b/README.md
@@ -111,33 +111,15 @@ I deploy **private document AI** for organizations that cannot send contracts or
 
 **Typical path:** evaluation on a [modest dedicated server](DEPLOYMENT.md) → hardening and persistence → production with auth and runbooks. Higher quality and scale mean more compute — either a larger VM you control or a scoped cloud API — chosen with your IT and legal team.
 
+**How I deliver:** I build with **agentic workflows in [Cursor](https://cursor.com)** — rules, specialized agents, and automated tests — so features ship in small, reviewable steps. That means **faster iteration** on your pilot (deploy docs, Docker, RAG tweaks) while keeping **auditable PRs** and human sign-off on what goes to production. You get working software and a clear paper trail, not a one-off prompt dump.
+
 **Get in touch:** [Upwork](https://www.upwork.com/freelancers/roxanadev) (private pilot, consulting, production scoping) · [GitHub](https://github.com/RoxanaTapia) (OSS and technical questions)
 
 ---
 
 ## Contributing
 
-This project is built **agentically in [Cursor](https://cursor.com)** — one GitHub issue, one branch, one reviewable PR — so pilot features ship in small, tested steps instead of ad-hoc prompts.
-
-**How it works**
-
-| Cursor feature | Role in this repo |
-|----------------|-------------------|
-| **Rules** (`.cursor/rules/`) | Persistent standards — Python/RAG style, Docker deploy, docs tone, milestone workflow |
-| **Subagents** (`.cursor/agents/`) | Specialists with file ownership (`deploy-engineer`, `rag-core-engineer`, `docs-writer`, `verifier`, …) |
-| **Slash commands** (`.cursor/commands/`) | Repeatable flows — e.g. `/ship-m7-issue`, `/verify` |
-| **Orchestrator** | Reads issues, dispatches specialists, runs tests, splits granular commits |
-
-**Why bother**
-
-- **Clear ownership** — agents edit only their files; fewer merge conflicts and surprise diffs
-- **Production-shaped history** — granular commits and PRs that map to roadmap milestones
-- **Verify before merge** — pytest/ruff (and Docker checks when infra changes) before every PR
-- **Human in the loop** — you approve commits, pushes, and merges; agents propose, you decide
-
-**Get started:** [AGENTS.md](AGENTS.md) (playbook) · [docs/ROADMAP.md](docs/ROADMAP.md) (milestones M7–M12) · open a GitHub issue or pick one from the [M7 milestone](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/1).
-
-Using Cursor is optional for drive-by fixes — but matching the one-issue-one-PR workflow helps reviews stay fast.
+Pull requests welcome. For how this repo is organized (agents, milestones, verify-before-merge), see [AGENTS.md](AGENTS.md) and [docs/ROADMAP.md](docs/ROADMAP.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Team ──► HTTPS ──► Streamlit + Ollama (one VM or VPC)
 | **Hardening** | Backups, monitoring, model tuning |
 | **Production** | Client-owned cloud, persistent indexes, SSO, audit trail |
 
-Operational detail: [DEPLOYMENT.md](DEPLOYMENT.md) · [docs/architecture-pilot.md](docs/architecture-pilot.md)
+Deployment and architecture: [DEPLOYMENT.md](DEPLOYMENT.md)
 
 ---
 
@@ -76,14 +76,9 @@ Operational detail: [DEPLOYMENT.md](DEPLOYMENT.md) · [docs/architecture-pilot.m
 - **Ollama** for private generation, or dummy mode for the public demo
 - Optional developer view: retrieval metrics and context transparency
 
-**Reference deployment**
+**Reference deployment** — Docker Compose stack (app + local Ollama) with a full [deployment guide](DEPLOYMENT.md) for VPS or laptop pilots.
 
-- [`Dockerfile`](Dockerfile) — reproducible app image (Python 3.12, OCR runtime)
-- [`docker-compose.yml`](docker-compose.yml) — app + Ollama, health-gated startup, persistent model volume
-- [`DEPLOYMENT.md`](DEPLOYMENT.md) — VPS and local guide (sizing, deploy, verify, troubleshooting)
-- [`.env.example`](.env.example) — documented settings for self-hosted pilots
-
-**Coming next:** HTTPS + access control on the pilot URL, demo video assets.
+**Coming next:** HTTPS + access control on the pilot URL, demo video.
 
 ---
 
@@ -98,20 +93,9 @@ The current pilot is a **session-based** app (indexes per upload). Typical produ
 
 ---
 
-## Quick start (self-hosted)
+## Self-hosted pilot
 
-See [DEPLOYMENT.md](DEPLOYMENT.md) for the full walkthrough.
-
-```bash
-git clone https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline.git
-cd ai-doc-to-chat-pipeline
-
-docker compose up -d ollama
-docker compose exec ollama ollama pull phi3:mini
-docker compose up --build
-```
-
-Open [http://localhost:8501](http://localhost:8501) — real local generation with Docker Compose.
+Follow the [Deployment Guide](DEPLOYMENT.md) for prerequisites, sizing, and step-by-step setup on a VPS or your laptop.
 
 ---
 
@@ -131,11 +115,11 @@ I deploy **private document AI** for organizations that cannot send contracts or
 
 ---
 
-## How this project is built
+## Contributing
 
-Developed with **agentic workflows in Cursor** — milestone-driven delivery with automated review and verification, so pilots and production features ship in small, auditable steps rather than ad-hoc prompts.
+Developed in small, tested increments so pilots can harden into production without surprises.
 
-Open-source contributors: [AGENTS.md](AGENTS.md)
+Open-source contributors: [AGENTS.md](AGENTS.md) · [docs/ROADMAP.md](docs/ROADMAP.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ Operational detail: [DEPLOYMENT.md](DEPLOYMENT.md) · [docs/architecture-pilot.m
 - **Ollama** for private generation, or dummy mode for the public demo
 - Optional developer view: retrieval metrics and context transparency
 
-**Reference deployment (M7 — shipping now)**
+**Reference deployment**
 
 - [`Dockerfile`](Dockerfile) — reproducible app image (Python 3.12, OCR runtime)
 - [`docker-compose.yml`](docker-compose.yml) — app + Ollama, health-gated startup, persistent model volume
-- [`DEPLOYMENT.md`](DEPLOYMENT.md) — build, compose, model pull, environment setup, troubleshooting
+- [`DEPLOYMENT.md`](DEPLOYMENT.md) — VPS and local guide (sizing, deploy, verify, troubleshooting)
 - [`.env.example`](.env.example) — documented settings for self-hosted pilots
 
-**Next on the M7 finish line:** HTTPS + access control, full VPS guide, demo assets.
+**Coming next:** HTTPS + access control on the pilot URL, demo video assets.
 
 ---
 
@@ -133,9 +133,9 @@ I deploy **private document AI** for organizations that cannot send contracts or
 
 ## How this project is built
 
-Developed with **agentic workflows in Cursor** — specialized agents (orchestrator, deploy-engineer, docs-writer, config-guardian, verifier) own distinct parts of the stack and ship one GitHub issue per PR. That keeps delivery fast, reviewable, and aligned with a production roadmap rather than ad-hoc prompts.
+Developed with **agentic workflows in Cursor** — milestone-driven delivery with automated review and verification, so pilots and production features ship in small, auditable steps rather than ad-hoc prompts.
 
-Contributor playbook: [AGENTS.md](AGENTS.md)
+Open-source contributors: [AGENTS.md](AGENTS.md)
 
 ---
 

--- a/docs/architecture-pilot.md
+++ b/docs/architecture-pilot.md
@@ -1,6 +1,6 @@
-# Architecture — single-VM pilot (M7 target)
+# Architecture — single-VM pilot
 
-Reference layout for the self-hosted demo / small-office pilot.
+Reference layout for a self-hosted demo or small-office pilot.
 
 ```text
                     Internet
@@ -18,7 +18,7 @@ Reference layout for the self-hosted demo / small-office pilot.
   └──────────────┘ OLLAMA_HOST└──────────────┘
          │
          │  PDF upload → extract → chunk
-         │  FAISS + embeddings (in-process, M7)
+         │  FAISS + embeddings (in-process)
          ▼
    User browser (chat + sources)
 ```
@@ -29,10 +29,9 @@ Reference layout for the self-hosted demo / small-office pilot.
 2. User asks question → semantic/hybrid retrieval → context assembly.
 3. App POSTs prompt to Ollama → grounded answer + source chunks in UI.
 
-## M9+ evolution
+## Planned evolution
 
-Replace in-memory FAISS with **Postgres/pgvector** and **MinIO** for PDF storage;
-add **FastAPI** (M8) as the integration surface. Ollama or Anthropic (M12) as LLM backend.
+Production rollouts typically add persistent document storage, a REST API for integrations, and enterprise authentication — while keeping the same retrieval and generation core. Ollama remains the default LLM; cloud APIs can be swapped in where procurement requires it.
 
 ## Environment variables (pilot)
 
@@ -41,3 +40,5 @@ add **FastAPI** (M8) as the integration surface. Ollama or Anthropic (M12) as LL
 | `OLLAMA_HOST` | Ollama URL (e.g. `http://ollama:11434` in Compose) |
 | `USE_DUMMY_GENERATOR` | `false` for real generation |
 | `OLLAMA_MODEL` | Optional override (default from `configs/config.yaml`) |
+
+Full operator notes: see [DEPLOYMENT.md](../DEPLOYMENT.md#environment-variables).

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -1,37 +1,5 @@
-# 5-minute demo script (M7-7)
+# Demo video
 
-Use this script when recording a sales/portfolio video (Loom, OBS, or QuickTime).
+When a recorded walkthrough of the private pilot is published, it will be linked from the README.
 
-**Tools:** OBS Studio or Loom (record); DaVinci Resolve (optional trim); Excalidraw/Canva (architecture slide).
-
----
-
-## Storyboard
-
-| Time | Scene |
-|------|--------|
-| 0:00–0:30 | Title: *Private RAG — your PDFs, cited answers, dedicated infrastructure* |
-| 0:30–1:00 | Show architecture diagram (`docs/architecture-pilot.md` or slide) |
-| 1:00–2:00 | Open pilot URL; upload a real PDF (contract or policy sample) |
-| 2:00–2:30 | Indexing spinner (edit: jump-cut long waits) |
-| 2:30–3:30 | Ask two questions — one general, one specific (e.g. notice period) |
-| 3:30–4:15 | Expand **Sources** — page refs and similarity scores |
-| 4:15–4:45 | Privacy line: *Runs on dedicated server; documents not sent to public ChatGPT* |
-| 4:45–5:00 | CTA: pilot in client environment — contact / README link |
-
----
-
-## Checklist before recording
-
-- [ ] `USE_DUMMY_GENERATOR=false` on demo host
-- [ ] Ollama model pulled (`llama3.1:8b` or `phi3:mini`)
-- [ ] Sample PDF prepared (non-sensitive or redacted)
-- [ ] Browser zoom 100%; close unrelated tabs
-- [ ] Blur email/hostname in post if needed
-
----
-
-## Hosting the video
-
-- Unlisted YouTube, Loom link, or portfolio embed
-- Add URL to README under *Reference deployment demo*
+For step-by-step recording scripts, pre-flight checklists, and sample questions, maintain a local **`docs-private/demo-script.md`** (gitignored — not in the public repo).


### PR DESCRIPTION
## Main contribution

This PR turns the project from “developers can run it if they read the repo” into “someone with Docker and a VPS can deploy a real private pilot by following one guide.” `DEPLOYMENT.md` replaces the short M7-1 stub with end-to-end instructions—what machine to rent, how to clone and start the stack, how to confirm Ollama is working, and what to do when something breaks—while the README stays a client-facing sales page that simply points IT to that guide.

## Summary
- Replace the M7-1 `DEPLOYMENT.md` stub with a complete single-VM Ollama guide: prerequisites, VPS sizing (`phi3:mini` vs `llama3.1:8b`), step-by-step deploy, verification (including `/api/tags` curl), local dev, env notes, and troubleshooting.
- Keep README client-facing: link to the deployment guide without duplicating compose commands or operator jargon; trim public demo-script to a stub (full recording script stays in local `docs-private/`).
- Document README vs DEPLOYMENT vs `docs-private/` audience split in AGENTS.md, docs-writer agent, and docs-commercial rule.

## Test plan
- [x] Follow VPS deploy section on a fresh VM (or skim for completeness)
- [x] Confirm `docker compose` commands match `docker-compose.yml`
- [x] Verify `/api/tags` curl example uses internal Compose network
- [x] README links resolve; no milestone/issue numbers in client-facing copy
- [x] `docs/demo-script.md` is a stub only; operator detail not in public repo

Closes #37