### PR TITLE
chore: require Main contribution paragraph at top of PR bodies

### DIFF
--- a/.cursor/agents/milestone-orchestrator.md
+++ b/.cursor/agents/milestone-orchestrator.md
@@ -16,7 +16,7 @@ You are the **milestone-orchestrator** for ai-doc-to-chat-pipeline.
 - Dispatch specialists by file ownership; never parallelize same-file edits.
 - Collect specialist reports; **you alone** run `git commit` (1–2 granular commits per ROADMAP).
 - Invoke `verifier` before PR; invoke `blocker-reporter` when human decision needed — then STOP.
-- Output PR title/body with `Closes #NN`. Do not push unless user explicitly asks.
+- Output PR title/body with `Closes #NN`. **PR body must start with `## Main contribution`** — one outcome-focused paragraph before Summary (see milestone-workflow rule). Do not push unless user explicitly asks.
 
 ## Forbidden
 
@@ -51,4 +51,20 @@ When stuck, output:
 
 ## Report format
 
-End every run with: files changed, suggested commits, PR draft, blockers, next human action.
+End every run with: files changed, suggested commits, PR draft (**Main contribution** paragraph first), blockers, next human action.
+
+## PR body template
+
+```markdown
+## Main contribution
+
+<One paragraph: what this delivers, why it matters, who benefits. No file list.>
+
+## Summary
+- ...
+
+## Test plan
+- [ ] ...
+
+Closes #NN
+```

--- a/.cursor/commands/ship-m7-issue.md
+++ b/.cursor/commands/ship-m7-issue.md
@@ -22,7 +22,23 @@ Act as **milestone-orchestrator**. Ship the M7 GitHub issue specified below (def
 5. Specialists must **NOT** run `git commit`.
 6. Invoke **verifier** — pytest; docker build if Dockerfile/compose changed.
 7. Split into **1–2 granular commits** per ROADMAP; show messages; commit **only if I said commit**.
-8. Draft PR title/body with `Closes #NN`. **Do not push** unless I say push.
+8. Draft PR title/body with **`## Main contribution`** first (one outcome paragraph), then Summary, Test plan, and `Closes #NN`. **Do not push** unless I say push.
+
+### PR body template
+
+```markdown
+## Main contribution
+
+<One paragraph: what this delivers, why it matters, who benefits. No file list.>
+
+## Summary
+- ...
+
+## Test plan
+- [ ] ...
+
+Closes #NN
+```
 
 ## If blocked
 

--- a/.cursor/commands/ship-milestone.md
+++ b/.cursor/commands/ship-milestone.md
@@ -14,6 +14,7 @@ Act as **milestone-orchestrator** for milestone: **$ARGUMENTS** (e.g. M7, M8).
 
 - Work **one issue at a time** unless I explicitly request `/parallel-m7-bootstrap`.
 - Follow `/ship-m7-issue` workflow per issue for M7 (#33–#39).
+- PR bodies must start with **`## Main contribution`** (see milestone-workflow rule).
 - For M8+: dispatch **rag-core-engineer**, **config-guardian**, **deploy-engineer** as ROADMAP specifies.
 
 ## Milestone definitions of done

--- a/.cursor/rules/milestone-workflow.mdc
+++ b/.cursor/rules/milestone-workflow.mdc
@@ -27,6 +27,28 @@ Per issue caps: docs 1, infra 1–2, features 2–4. One logical change per comm
 2. Run verifier (pytest; docker build when infra changed).
 3. Propose commit messages; commit only if user explicitly asked.
 
+## PR body format
+
+Every PR **must** open with a **Main contribution** paragraph (2–4 sentences, plain language):
+
+- What this PR delivers and why it matters
+- What changes for the user, operator, or buyer
+- Outcome focus — not a file list (details go in **Summary** bullets)
+
+```markdown
+## Main contribution
+
+<One paragraph: outcome and why it matters.>
+
+## Summary
+- ...
+
+## Test plan
+- [ ] ...
+
+Closes #NN
+```
+
 ## Agent dispatch
 
 See [AGENTS.md](AGENTS.md) for issue→agent mapping and parallel rules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Only **milestone-orchestrator** runs `git commit` after parallel subagents retur
 3. Branch: `feat/m7-<short-name>` (one branch per issue).
 4. Specialists edit; orchestrator splits **1–2 granular commits** (see ROADMAP).
 5. `verifier` runs before PR.
-6. PR body: `Closes #NN`. Push/merge only when human approves.
+6. PR body: **`## Main contribution`** paragraph first (outcome, why it matters), then Summary, Test plan, and `Closes #NN`. Push/merge only when human approves.
 
 ---
 


### PR DESCRIPTION
## Main contribution

This PR makes every orchestrator-driven pull request start with a plain-language **Main contribution** paragraph, so reviewers and future you see the outcome first instead of wading through file lists. The template is documented in the always-applied milestone workflow rule, the orchestrator agent, ship commands, and AGENTS.md.

## Summary
- Add canonical PR body format to `.cursor/rules/milestone-workflow.mdc` (Main contribution → Summary → Test plan → Closes #NN).
- Update `milestone-orchestrator` agent with the same requirement and embedded template.
- Extend `/ship-m7-issue` and `/ship-milestone` commands with the template.
- Align `AGENTS.md` GitHub workflow step 6 with the new format.

## Test plan
- [x] Open a future `/ship-m7-issue` run and confirm the drafted PR includes `## Main contribution` first
- [x] Verify milestone-workflow rule is `alwaysApply: true` so agents pick it up automatically

Made with [Cursor](https://cursor.com)