### PR TITLE
docs: sync README with HTTPS pilot deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Deployment and architecture: [DEPLOYMENT.md](DEPLOYMENT.md)
 - **Ollama** for private generation, or dummy mode for the public demo
 - Optional developer view: retrieval metrics and context transparency
 
-**Reference deployment** — Docker Compose stack (app + local Ollama) with a full [deployment guide](DEPLOYMENT.md) for VPS or laptop pilots.
+**Reference deployment** — Docker Compose stack (app + local Ollama) with **HTTPS and basic auth** via Caddy; see the [deployment guide](DEPLOYMENT.md).
 
-**Coming next:** HTTPS + access control on the pilot URL, demo video.
+**Coming next:** demo video and architecture diagram for sales calls.
 
 ---
 
@@ -95,7 +95,7 @@ The current pilot is a **session-based** app (indexes per upload). Typical produ
 
 ## Self-hosted pilot
 
-Follow the [Deployment Guide](DEPLOYMENT.md) for prerequisites, sizing, and step-by-step setup on a VPS or your laptop.
+Follow the [Deployment Guide](DEPLOYMENT.md) for prerequisites, sizing, HTTPS with basic auth, and step-by-step setup on a VPS or your laptop.
 
 ---
 


### PR DESCRIPTION
## Main contribution

Updates the client-facing README so it matches the reference deployment story after M7-6: pilots are documented with HTTPS and basic auth via Caddy, not as a future item. Buyers and evaluators see the current capability clearly while demo video and architecture assets remain on the roadmap.

## Summary
- Reference deployment bullet now mentions HTTPS and basic auth via Caddy with a link to `DEPLOYMENT.md`
- Self-hosted pilot section points readers to the HTTPS setup in the deployment guide
- "Coming next" narrowed to demo video and architecture diagram (M7-7)

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Links to `DEPLOYMENT.md` resolve
- [ ] Merge after M7-6 Caddy PR (#38) so README and deployment guide stay aligned


Made with [Cursor](https://cursor.com)