### PR TITLE
fix(rag): replace misleading dummy answer with clear UI-demo placeholder

### DIFF
--- a/src/rag.py
+++ b/src/rag.py
@@ -159,13 +159,11 @@ def generate_answer(context: str, query: str, dummy_mode: bool = True) -> str:
         return "I could not find relevant information in the document to answer this question."
 
     def _dummy_response() -> str:
-        context_preview = safe_context[:400]
-        truncation_suffix = "..." if len(safe_context) > 400 else ""
         return (
-            "Dummy answer:\n"
-            f"{safe_query}\n\n"
-            "Based on the document:\n"
-            f"{context_preview}{truncation_suffix}"
+            "This is a UI demo — no AI model is running here.\n\n"
+            "Upload and search work, but answers are not generated on this host.\n\n"
+            "For real grounded answers on your documents, request access to the "
+            "[live pilot](https://ai-doc-pilot.roxanatapia.dev)."
         )
 
     if dummy_mode:

--- a/tests/test_rag_generation.py
+++ b/tests/test_rag_generation.py
@@ -11,15 +11,14 @@ if str(SRC_DIR) not in sys.path:
 import rag  # noqa: E402
 
 
-def test_generate_answer_dummy_mode_returns_echo() -> None:
+def test_generate_answer_dummy_mode_returns_placeholder() -> None:
     answer = rag.generate_answer(
         context="Section A says notice period is 30 days.",
         query="What is the notice period?",
         dummy_mode=True,
     )
-    assert "Dummy answer:" in answer
-    assert "What is the notice period?" in answer
-    assert "Section A says notice period is 30 days." in answer
+    assert "no AI model is running here" in answer
+    assert "live pilot" in answer
 
 
 def test_generate_answer_real_mode_calls_ollama_wrapper(monkeypatch) -> None:
@@ -144,7 +143,7 @@ def test_generate_answer_falls_back_to_dummy_when_enabled(monkeypatch) -> None:
     )
 
     assert "Ollama unavailable, falling back to dummy mode." in answer
-    assert "Dummy answer:" in answer
+    assert "no AI model is running here" in answer
 
 
 def test_generate_answer_raises_structured_error_when_fallback_disabled(monkeypatch) -> None:


### PR DESCRIPTION
## Main contribution

The public Streamlit Cloud demo was showing a dummy response that echoed retrieved document chunks — it looked enough like a real answer to confuse viewers during a demo. This replaces it with a fixed, unambiguous message: "This is a UI demo — no AI model is running here." with a direct link to the live pilot.

## Summary
- Replace `_dummy_response()` in `src/rag.py` with a fixed placeholder string
- Remove context echo and question echo entirely
- Update two tests in `test_rag_generation.py` to match new text

## Test plan
- [ ] Public demo shows "This is a UI demo — no AI model is running here." after asking a question
- [ ] Live pilot unaffected (dummy_mode=False path unchanged)
- [ ] All 7 rag generation tests pass

Closes #39

Made with [Cursor](https://cursor.com)