### PR TITLE
feat(deploy): root-domain redirects for marketing links

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -15,3 +15,9 @@
 		header_up X-Real-IP {remote_host}
 	}
 }
+
+# Root domain marketing redirects (optional; set A/AAAA for apex to VPS).
+roxanatapia.dev, www.roxanatapia.dev {
+	redir /upwork https://www.upwork.com/freelancers/roxanadev 301
+	redir / https://ai-doc-pilot.roxanatapia.dev 302
+}


### PR DESCRIPTION
## Main contribution

Operators and visitors can use short marketing URLs on the apex domain: `/upwork` goes to the freelancer profile and `/` forwards to the live HTTPS pilot, with redirects defined in the repo Caddyfile so VPS redeploys stay reproducible.

## Summary
- Add `roxanatapia.dev` and `www` site block to `Caddyfile` with 301 `/upwork` → Upwork and 302 `/` → `ai-doc-pilot` subdomain
- Requires DNS A records for apex/www pointing at the pilot VPS (documented in comment)

## Test plan
- [x] `curl -4 -sI https://roxanatapia.dev/upwork` returns 301 to Upwork
- [x] Let's Encrypt cert issued for `roxanatapia.dev` on VPS
- [ ] After merge: `git pull` on VPS and restart Caddy


Made with [Cursor](https://cursor.com)