### PR TITLE
chore(docs): remove docs root shims

### DIFF
--- a/docs/PROJECT-DIRECTION.md
+++ b/docs/PROJECT-DIRECTION.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page lives at **[operators/PROJECT-DIRECTION.md](operators/PROJECT-DIRECTION.md)**.
-
-Docs index: [README.md](README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,6 @@ docs/
 | [`operators/`](operators/) | Roadmap, project direction, contributor how-tos |
 | [`archive/`](archive/) | Historical eval rounds; keep for reference, not day-one reading |
 
-Old paths (for example `docs/ROADMAP.md`) keep short “Moved” stubs that point here, so bookmarks still work.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page lives at **[operators/ROADMAP.md](operators/ROADMAP.md)**.
-
-Docs index: [README.md](README.md)

--- a/docs/architecture-pilot.md
+++ b/docs/architecture-pilot.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page lives at **[product/architecture.md](product/architecture.md)**.
-
-Docs index: [README.md](README.md)

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -14,4 +14,4 @@ Older evaluation write-ups and plans. Useful if you need the full history of ret
 |------|------------|
 | [`eval-history/`](eval-history/) | Rounds 1–5 of NDA pilot evaluation (results + some plans) |
 
-Round-by-round files link to each other inside that folder. Paths elsewhere in the repo should point at `docs/archive/eval-history/`, not the old `docs/eval-history/` location.
+Round-by-round files link to each other inside that folder. Historical rounds live only under `docs/archive/eval-history/`.

--- a/docs/archive/eval-history/pilot-evaluation-round1.md
+++ b/docs/archive/eval-history/pilot-evaluation-round1.md
@@ -4,7 +4,7 @@
 
 This document records an **honest evaluation** of the reference stack on a realistic document type — not a marketing scorecard. It shows what the pilot does well today, where answers need human review, and how we test before a client engagement.
 
-Architecture and deployment: [architecture-pilot.md](architecture-pilot.md) · [DEPLOYMENT.md](../DEPLOYMENT.md)
+Architecture and deployment: [architecture.md](../../product/architecture.md) · [DEPLOYMENT.md](../../../DEPLOYMENT.md)
 
 ---
 

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page lives at **[product/demo-script.md](product/demo-script.md)**.
-
-Docs index: [README.md](README.md)

--- a/docs/eval-history/README.md
+++ b/docs/eval-history/README.md
@@ -1,5 +1,0 @@
-# Moved
-
-Eval history now lives at **[../archive/eval-history/](../archive/eval-history/)**.
-
-Current summary: [../product/pilot-evaluation.md](../product/pilot-evaluation.md)

--- a/docs/pilot-evaluation.md
+++ b/docs/pilot-evaluation.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page lives at **[product/pilot-evaluation.md](product/pilot-evaluation.md)**.
-
-Older rounds: [archive/eval-history/](archive/eval-history/). Docs index: [README.md](README.md)

--- a/docs/sample-nda.md
+++ b/docs/sample-nda.md
@@ -1,8 +1,0 @@
-# Moved
-
-Sample NDA files live under **[product/](product/)**:
-
-- [sample-nda.pdf](product/sample-nda.pdf)
-- [sample-nda.md](product/sample-nda.md)
-
-Docs index: [README.md](README.md)

--- a/docs/testing-ocr.md
+++ b/docs/testing-ocr.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page lives at **[operators/testing-ocr.md](operators/testing-ocr.md)**.
-
-Docs index: [README.md](README.md)


### PR DESCRIPTION
## Main contribution

Cleans up the public `docs/` tree after the restructure. Redirect stub files at the root (and the empty `eval-history/` shim) are gone, so GitHub shows only the real folders: `product/`, `operators/`, and `archive/`.

> **Takeaway:** Start at [docs/README.md](docs/README.md). Old root paths like `docs/architecture-pilot.md` are removed on purpose.

## Summary
- Delete Moved stubs: architecture, demo-script, pilot-evaluation, sample-nda, ROADMAP, PROJECT-DIRECTION, testing-ocr
- Remove `docs/eval-history/` shim folder
- Drop stub wording from the docs index

## Test plan
- [x] `docs/` on GitHub shows README + product + operators + archive only
- [x] [docs/README.md](docs/README.md) links still resolve
- [x] No remaining references to stub paths in active docs (archive history may mention old names)


Made with [Cursor](https://cursor.com)