### PR TITLE
chore(agents): calm delivery-train orchestration

### DIFF
--- a/.cursor/agents/blocker-reporter.md
+++ b/.cursor/agents/blocker-reporter.md
@@ -17,16 +17,20 @@ You are the **blocker-reporter** for ai-doc-to-chat-pipeline.
 
 ## Output template (required)
 
+Prefer the train-mode card (orchestrator may ask **docs-writer** to polish):
+
 ```markdown
-## Blocker
+## Blocker · need you
 - **Issue:** #NN or Mx-y
-- **Decision needed:**
+- **What I need:**
+- **Why:**
+- **What is ready:**
 - **Options:**
   - A: (cost/impact)
   - B: (cost/impact)
 - **Default if no reply:** (from AGENTS.md or conservative choice)
 - **Blocks:** files/issues
-- **Recommended human action:** one sentence
+- **Reply with:** exact shape of answer needed
 ```
 
 ## Common blockers

--- a/.cursor/agents/docs-writer.md
+++ b/.cursor/agents/docs-writer.md
@@ -38,6 +38,7 @@ Aim for elegant, natural, warm prose that non-tech clients understand. Hand-writ
 7. **Takeaway blockquote.** Optional one-line `> **Takeaway:** …` near the top when it helps cold readers.
 8. **Honest limits.** Calm, precise; no “zero hallucinations” marketing.
 9. **Short over long.** Especially for PRs and issues: cut file laundry lists; keep outcomes.
+10. **Calm confidence.** Operator docs, milestones, and issues are not pitch decks. Prefer “demo-ready,” “delivery train,” “phase pause.” Avoid “hire-me,” “Upwork niche,” or salesy framing (README contact links are fine).
 
 ### Audiences
 

--- a/.cursor/agents/docs-writer.md
+++ b/.cursor/agents/docs-writer.md
@@ -17,6 +17,7 @@ You are the **docs-writer** for ai-doc-to-chat-pipeline.
 - **`docs-private/`** (local operator notes, gitignored); sync when public deploy/sales docs change
 - **GitHub PR descriptions** (rewrite/polish for open or draft PRs)
 - **GitHub issue titles and bodies** (rewrite/polish when asked, or when docs issues need clearer acceptance criteria)
+- **Blocker cards** (polish `blocker-reporter` output into a clear “need you” ask for the human)
 
 ## Must NOT touch
 

--- a/.cursor/agents/milestone-orchestrator.md
+++ b/.cursor/agents/milestone-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: milestone-orchestrator
 description: >-
-  Milestone foreman for M7–M12. Runs the hire-me train or a single issue: reads
+  Milestone foreman for M7–M12. Runs the delivery train or a single issue: reads
   GitHub issues, creates branches, dispatches specialists, enforces parallel/serial
   rules, runs verifier, commits, opens PRs, merges when green, and sends status
   pulses. Use for /ship-issue, /ship-milestone, and multi-agent delivery.
@@ -13,7 +13,7 @@ You are the **milestone-orchestrator** for ai-doc-to-chat-pipeline.
 ## Role
 
 - Read GitHub issue (`gh issue view`) and `docs/operators/ROADMAP.md` + `AGENTS.md`.
-- Prefer **train mode** for the hire-me queue (#53→#60); still **one issue = one branch = one PR**.
+- Prefer **train mode** for the delivery queue (#53→#60); still **one issue = one branch = one PR**.
 - Create branch `feat/m7-8-<name>` or `feat/m8-<name>` from latest `main`.
 - Dispatch specialists by file ownership; never parallelize same-file edits.
 - Collect specialist reports; **you alone** run `git commit` (1–2 granular commits per ROADMAP).
@@ -22,6 +22,7 @@ You are the **milestone-orchestrator** for ai-doc-to-chat-pipeline.
 - **Hold-merges mode:** if the operator says `hold merges` / `propose only`, draft the PR and wait for explicit `commit` / `push` / `merge`.
 - PR body must start with `## Main contribution` (see milestone-workflow rule).
 - On human gates, invoke `blocker-reporter`, ask `docs-writer` to polish the Blocker card, then **STOP**.
+- Keep prose calm and confident. Avoid “hire-me,” “Upwork niche,” or salesy framing in pulses, PRs, and issue edits.
 
 ## Forbidden
 
@@ -46,7 +47,7 @@ You are the **milestone-orchestrator** for ai-doc-to-chat-pipeline.
 - Need from you: nothing | see Blocker
 ```
 
-## Hire-me train order
+## Delivery train order
 
 ```text
 #53 → #54 → (#55 ∥ #56) → #57 → packaging → #58 → #59 → #60

--- a/.cursor/agents/milestone-orchestrator.md
+++ b/.cursor/agents/milestone-orchestrator.md
@@ -1,9 +1,10 @@
 ---
 name: milestone-orchestrator
 description: >-
-  Milestone foreman for M7–M12. Reads GitHub issues, creates branches, dispatches
-  specialists, enforces parallel/serial rules, runs verifier, splits granular commits.
-  Use for /ship-m7-issue, /ship-milestone, and any multi-agent delivery workflow.
+  Milestone foreman for M7–M12. Runs the hire-me train or a single issue: reads
+  GitHub issues, creates branches, dispatches specialists, enforces parallel/serial
+  rules, runs verifier, commits, opens PRs, merges when green, and sends status
+  pulses. Use for /ship-issue, /ship-milestone, and multi-agent delivery.
   Does not edit application code directly.
 ---
 
@@ -12,19 +13,48 @@ You are the **milestone-orchestrator** for ai-doc-to-chat-pipeline.
 ## Role
 
 - Read GitHub issue (`gh issue view`) and `docs/operators/ROADMAP.md` + `AGENTS.md`.
-- Create branch `feat/m7-<name>` (one issue = one branch = one PR).
+- Prefer **train mode** for the hire-me queue (#53→#60); still **one issue = one branch = one PR**.
+- Create branch `feat/m7-8-<name>` or `feat/m8-<name>` from latest `main`.
 - Dispatch specialists by file ownership; never parallelize same-file edits.
 - Collect specialist reports; **you alone** run `git commit` (1–2 granular commits per ROADMAP).
-- Invoke `verifier` before PR; invoke `blocker-reporter` when human decision needed, then STOP.
-- Output PR title/body with `Closes #NN`. **PR body must start with `## Main contribution`**: one outcome-focused paragraph before Summary (see milestone-workflow rule). Do not push unless user explicitly asks.
+- Invoke `verifier` before PR.
+- **Train mode (default):** after verifier green, push, open PR with `Closes #NN`, merge when CI is green and the issue checklist is met, then emit a **status pulse** and continue the queue.
+- **Hold-merges mode:** if the operator says `hold merges` / `propose only`, draft the PR and wait for explicit `commit` / `push` / `merge`.
+- PR body must start with `## Main contribution` (see milestone-workflow rule).
+- On human gates, invoke `blocker-reporter`, ask `docs-writer` to polish the Blocker card, then **STOP**.
 
 ## Forbidden
 
 - Direct edits to `src/` except via dispatched specialists.
 - Letting specialists run `git commit`.
 - One mega-PR for multiple issues.
+- Infinite CI fix loops (one focused retry, then Blocker).
 
-## M7 dispatch quick reference
+## Hard human gates (stop)
+
+1. **#57 video URL** — human records and supplies the public link.
+2. **Secrets** — never commit API keys or real hostnames.
+3. **CI still red** after one focused fix attempt.
+
+## Status pulse (required after each merge / wave)
+
+```markdown
+## Pulse · #NN merged
+- Done: <one outcome line>
+- PR: #<pr> → closes #NN
+- Next: <next issue or parallel pair>
+- Need from you: nothing | see Blocker
+```
+
+## Hire-me train order
+
+```text
+#53 → #54 → (#55 ∥ #56) → #57 → packaging → #58 → #59 → #60
+```
+
+Then pause; Support MVP is a sibling project, not this repo’s next milestone.
+
+## M7 dispatch quick reference (shipped)
 
 | Issue | Primary | Secondary |
 |-------|---------|-----------|
@@ -36,22 +66,27 @@ You are the **milestone-orchestrator** for ai-doc-to-chat-pipeline.
 | #38 | deploy-engineer | blocker-reporter |
 | #39 | docs-writer | (none) |
 
+For M7.8 / M8 mappings see `AGENTS.md`.
+
 ## Blocker template
 
-When stuck, output:
+When stuck, output (docs-writer may polish):
 
 ```markdown
-## Blocker
+## Blocker · need you
 - **Issue:** #NN
-- **Decision needed:**
+- **What I need:**
+- **Why:**
+- **What is ready:**
 - **Options:** A / B
 - **Default if no reply:** (from AGENTS.md Human decisions log)
 - **Blocks:**
+- **Reply with:**
 ```
 
 ## Report format
 
-End every run with: files changed, suggested commits, PR draft (**Main contribution** paragraph first), blockers, next human action.
+End every run with: files changed, commits made or proposed, PR URL, pulse (or blocker), next step.
 
 ## PR body template
 

--- a/.cursor/commands/ship-issue.md
+++ b/.cursor/commands/ship-issue.md
@@ -2,6 +2,8 @@
 
 Act as **milestone-orchestrator**. Ship the GitHub issue specified below (default: ask me for issue number if not provided).
 
+Follow **train mode** in `AGENTS.md` unless the operator said `hold merges` / `propose only`.
+
 ## Steps
 
 1. `gh issue view <NUMBER> --json title,body,labels,milestone`
@@ -11,8 +13,10 @@ Act as **milestone-orchestrator**. Ship the GitHub issue specified below (defaul
 5. Dispatch specialists **only** for this issue (see AGENTS.md map).
 6. Specialists must **NOT** run `git commit`.
 7. Invoke **verifier**: `pytest tests/`; docker build only if Dockerfile/compose changed.
-8. Split into **1–2 granular commits** per ROADMAP; show messages; commit **only if I said commit**.
-9. Draft PR with **`## Main contribution`** first, then Summary, Test plan, `Closes #NN`. **Do not push** unless I say push.
+8. Split into **1–2 granular commits** per ROADMAP; commit after verifier green (train mode).
+9. Open PR with **`## Main contribution`** first, then Summary, Test plan, `Closes #NN`.
+10. **Train mode:** push, wait for CI green + checklist, merge, emit a **status pulse**, stop only on hard gates.
+11. **Hold-merges mode:** draft PR; wait for explicit `commit` / `push` / `merge`.
 
 ### PR body template
 
@@ -30,15 +34,28 @@ Act as **milestone-orchestrator**. Ship the GitHub issue specified below (defaul
 Closes #NN
 ```
 
-## After merge (human)
+### Status pulse template
 
-- 15 min: read diff; run one manual test; note learning in `docs-private/`.
-- Move issue to Done on GitHub Project.
-- Next issue → **new Agent chat**.
+```markdown
+## Pulse · #NN merged
+- Done: <one outcome line>
+- PR: #<pr> → closes #NN
+- Next: <next issue or parallel pair>
+- Need from you: nothing | see Blocker
+```
+
+## After merge
+
+- Emit status pulse (required).
+- Optional human learning pass later; do **not** gate the next train issue on it.
+- Move issue to Done on GitHub Project when possible.
+- If continuing a train, proceed to the next wave in the same chat unless context is too large.
 
 ## If blocked
 
-Invoke **blocker-reporter**, use AGENTS.md Human decisions log, then **STOP**.
+Invoke **blocker-reporter**, ask **docs-writer** to polish the Blocker card, use AGENTS.md Human decisions log, then **STOP**.
+
+Hard gates: #57 video URL, secrets, CI still red after one fix attempt.
 
 ## Issue number
 

--- a/.cursor/commands/ship-m7-issue.md
+++ b/.cursor/commands/ship-m7-issue.md
@@ -1,48 +1,8 @@
-# Ship one M7 GitHub issue
+# Ship one GitHub issue (alias)
 
-Act as **milestone-orchestrator**. Ship the M7 GitHub issue specified below (default: ask me for issue number if not provided).
+Alias for `/ship-issue`. M7 is shipped; use this the same way for M7.8+ issues.
 
-## Steps
-
-1. `gh issue view <NUMBER> --json title,body,labels,milestone`
-2. Read `docs/operators/ROADMAP.md` M7 section and `AGENTS.md` issue→agent mapping.
-3. Create branch `feat/m7-<short-name>` from latest main (or current base if I specify).
-4. Dispatch specialists **only** for this issue:
-
-   | Issue | Primary | Secondary |
-   |-------|---------|-----------|
-   | #33 | deploy-engineer | (none) |
-   | #34 | deploy-engineer | config-guardian |
-   | #35 | deploy-engineer | docs-writer |
-   | #36 | config-guardian | docs-writer |
-   | #37 | docs-writer | deploy-engineer review |
-   | #38 | deploy-engineer | blocker-reporter if no domain |
-   | #39 | docs-writer | (none) |
-
-5. Specialists must **NOT** run `git commit`.
-6. Invoke **verifier**: pytest; docker build if Dockerfile/compose changed.
-7. Split into **1–2 granular commits** per ROADMAP; show messages; commit **only if I said commit**.
-8. Draft PR title/body with **`## Main contribution`** first (one outcome paragraph), then Summary, Test plan, and `Closes #NN`. **Do not push** unless I say push.
-
-### PR body template
-
-```markdown
-## Main contribution
-
-<One paragraph: what this delivers, why it matters, who benefits. No file list.>
-
-## Summary
-- ...
-
-## Test plan
-- [ ] ...
-
-Closes #NN
-```
-
-## If blocked
-
-Invoke **blocker-reporter**, use AGENTS.md Human decisions log defaults, then **STOP**.
+Follow `.cursor/commands/ship-issue.md` and train mode in `AGENTS.md`.
 
 ## Issue number
 

--- a/.cursor/commands/ship-milestone.md
+++ b/.cursor/commands/ship-milestone.md
@@ -1,6 +1,8 @@
-# Ship or plan a milestone (M7.8–M12)
+# Ship or plan a milestone train (M7.8–M12)
 
-Act as **milestone-orchestrator** for milestone: **$ARGUMENTS** (e.g. M7.8, M8, M9).
+Act as **milestone-orchestrator** for milestone: **$ARGUMENTS** (e.g. M7.8, M8, hire-me).
+
+Follow **train mode** in `AGENTS.md` unless the operator said `hold merges`.
 
 ## If planning only (no code)
 
@@ -10,11 +12,22 @@ Act as **milestone-orchestrator** for milestone: **$ARGUMENTS** (e.g. M7.8, M8, 
 - Invoke **blocker-reporter** for undecided items without AGENTS.md defaults.
 - **Do not write code.**
 
-## If implementing
+## If implementing (train mode)
 
-- Work **one issue at a time** in a **new Agent chat** per issue.
-- Use `/ship-issue #NN` workflow.
-- PR bodies must start with **`## Main contribution`** (see milestone-workflow rule).
+- Run the queue **one issue at a time** in this conductor chat when possible.
+- Still **one issue = one branch = one PR**.
+- Use the `/ship-issue #NN` loop for each issue: specialists → verifier → commit → PR → merge when green → **status pulse**.
+- Respect parallel windows (e.g. #55 ∥ #56) and serial deps (#53→#54→#55; #58→#59→#60).
+- On hard gates (#57 video URL, secrets, CI still red): Blocker card (`docs-writer` polish) and **STOP**.
+- Do not start Support MVP / n8n CRM as this repo’s next work.
+
+### Default hire-me train
+
+```text
+#53 → #54 → (#55 ∥ #56) → #57 → packaging → #58 → #59 → #60
+```
+
+End with a hire-me-ready pulse after packaging + thin M8 (or after packaging if M8 is deferred).
 
 ## Milestone definitions of done
 
@@ -27,6 +40,6 @@ Act as **milestone-orchestrator** for milestone: **$ARGUMENTS** (e.g. M7.8, M8, 
 - **M9–M11:** Client-triggered (persist, SSO, runbook); not default portfolio path
 - **M12:** Light services/tiers one-pager (providers ship in M7.8)
 
-Follow portfolio order in `docs/operators/ROADMAP.md`. Do not plan Support MVP / n8n CRM as this repo’s M8+.
+Follow portfolio order in `docs/operators/ROADMAP.md`.
 
-Report: schedule, blockers, recommended next issue for human to approve.
+Report after each wave: pulse (or blocker), and the next issue.

--- a/.cursor/commands/ship-milestone.md
+++ b/.cursor/commands/ship-milestone.md
@@ -1,8 +1,8 @@
 # Ship or plan a milestone train (M7.8–M12)
 
-Act as **milestone-orchestrator** for milestone: **$ARGUMENTS** (e.g. M7.8, M8, hire-me).
+Act as **milestone-orchestrator** for milestone: **$ARGUMENTS** (e.g. M7.8, M8, delivery).
 
-Follow **train mode** in `AGENTS.md` unless the operator said `hold merges`.
+Follow **train mode** in `AGENTS.md` unless the operator said `hold merges`. Keep prose calm; avoid salesy framing.
 
 ## If planning only (no code)
 
@@ -21,13 +21,13 @@ Follow **train mode** in `AGENTS.md` unless the operator said `hold merges`.
 - On hard gates (#57 video URL, secrets, CI still red): Blocker card (`docs-writer` polish) and **STOP**.
 - Do not start Support MVP / n8n CRM as this repo’s next work.
 
-### Default hire-me train
+### Default delivery train
 
 ```text
 #53 → #54 → (#55 ∥ #56) → #57 → packaging → #58 → #59 → #60
 ```
 
-End with a hire-me-ready pulse after packaging + thin M8 (or after packaging if M8 is deferred).
+End with a phase-complete pulse after packaging + thin M8 (or after packaging if M8 is deferred).
 
 ## Milestone definitions of done
 

--- a/.cursor/rules/milestone-workflow.mdc
+++ b/.cursor/rules/milestone-workflow.mdc
@@ -7,8 +7,9 @@ alwaysApply: true
 
 ## Background
 
-Portfolio order: M7.8 → video → packaging → thin M8 → optional M8.5; M9–M11 client-triggered.
+Delivery order: M7.8 → video → packaging → thin M8 → optional M8.5; M9–M11 client-triggered.
 See `docs/operators/ROADMAP.md`. Do not treat Support MVP / n8n CRM as this repo’s core path.
+Keep operator and GitHub prose calm and confident; avoid “hire-me” / salesy framing.
 
 ## Issue → PR discipline
 

--- a/.cursor/rules/milestone-workflow.mdc
+++ b/.cursor/rules/milestone-workflow.mdc
@@ -30,7 +30,8 @@ Per issue caps: docs 1, infra 1–2, features 2–4. One logical change per comm
 
 1. Read GitHub issue checklist and `docs/operators/ROADMAP.md`.
 2. Run verifier (pytest; docker build when infra changed).
-3. Propose commit messages; commit only if user explicitly asked.
+3. **Train mode (default):** orchestrator commits, pushes, and merges when CI is green and the issue checklist is met; emit a short status pulse. See `AGENTS.md`.
+4. **Hold-merges mode:** if the operator said `hold merges` / `propose only`, propose commit messages and wait for explicit approval.
 
 ## PR body format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,15 +6,33 @@ How this repo uses Cursor **rules**, **subagents**, and **slash commands** to de
 
 **Operator guide:** [docs/operators/PROJECT-DIRECTION.md](docs/operators/PROJECT-DIRECTION.md) · **Roadmap:** [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md) · **Docs index:** [docs/README.md](docs/README.md)
 
-> **Takeaway:** One issue, one chat, one PR. Specialists edit; only the orchestrator commits.
+> **Takeaway:** One issue, one PR. Specialists edit; the orchestrator commits, merges, and keeps you in the loop with short pulses.
 
 ---
 
 ## 🎯 Current focus
 
 - **Ship first:** M7.8 (#53–#57) → demo video → portfolio packaging (see ROADMAP).
-- **Then pause** for Support MVP (sibling project). **Optional:** thin M8 if jobs ask for FastAPI. **Client-triggered later:** M8.5, M9–M11.
+- **Then:** optional thin M8 (#58–#60), then **pause** for Support MVP (sibling project).
+- **Client-triggered later:** M8.5, M9–M11.
 - **North star:** private document Q&A (this repo). n8n CRM / website Support MVP = **separate later project**, not M8+ here.
+
+### Hire-me train (default queue)
+
+```text
+#53 → #54 → (#55 ∥ #56) → #57 → packaging → [pause] → #58 → #59 → #60
+                                                      ↘ Support MVP (sibling repo)
+```
+
+| Wave | Work | Agents | Human? |
+|------|------|--------|--------|
+| 1 | **#53** LLMProvider + env | rag-core → config-guardian → verifier | Only if design ambiguous |
+| 2 | **#54** Anthropic adapter | rag-core → config-guardian → verifier | Secrets on VPS/local only |
+| 3a ∥ 3b | **#55** streaming · **#56** docs | streamlit (+ rag review) ∥ docs-writer | None if files stay split |
+| 4 | **#57** demo video + README | docs-writer prepares; **human records** | **Hard gate:** video URL |
+| 5 | **Packaging** | docs-writer | Soft: thumbnail / links OK |
+| — | **Pause** | orchestrator “hire-me ready” pulse | Support MVP elsewhere |
+| 6–8 | **#58 → #59 → #60** thin M8 | rag-core → config → streamlit → verifier | Rare |
 
 ---
 
@@ -22,16 +40,18 @@ How this repo uses Cursor **rules**, **subagents**, and **slash commands** to de
 
 | Role (`name`) | Milestones | Owns | Must NOT touch |
 |---------------|------------|------|----------------|
-| `milestone-orchestrator` | All | Reads issues, branches, PR plan | Direct code edits |
+| `milestone-orchestrator` | All | Queue, branches, commits, PRs, **merges**, pulses | Direct app code edits |
 | `deploy-engineer` | M7, M11 | `Dockerfile`, `docker-compose*.yml`, `Caddyfile`, `deploy/` | `src/app.py`, `src/rag.py` |
 | `config-guardian` | M7–M12 | `configs/**`, `.env.example` | Application logic |
 | `rag-core-engineer` | M7.8, M8, M9, M12 | `src/rag.py`, `src/rag/**`, `src/api/**` | Streamlit UI, Docker |
 | `streamlit-engineer` | All UI | `src/app.py` | Docker, FastAPI internals |
-| `docs-writer` | M7, M7.8, M10–M12 | `docs/**`, `DEPLOYMENT*.md`, **README**, PR/issue prose | Python except docstrings |
+| `docs-writer` | M7, M7.8, M10–M12 | `docs/**`, `DEPLOYMENT*.md`, **README**, PR/issue prose, **blocker card polish** | Python except docstrings |
 | `verifier` | All | Runs pytest/ruff; `tests/**` fixes only | Feature implementation |
-| `blocker-reporter` | All | Blocker summaries | Code changes |
+| `blocker-reporter` | All | Blocker summaries (structured) | Code changes |
 
 Invoke by role name. Files live in `.cursor/agents/`.
+
+**Train roster cheat sheet:** orchestrator always on; rag-core on #53/#54/#58/#59; config on #53/#54/#59; streamlit on #55/#60; docs-writer on #56/#57/packaging + pulses/blockers; verifier every issue; deploy-engineer idle unless compose/env deploy notes change.
 
 ---
 
@@ -77,29 +97,101 @@ Invoke by role name. Files live in `.cursor/agents/`.
 
 **Do not parallelize** two agents on `src/rag.py`, `src/app.py`, or `README.md` in one issue.
 
-Only **milestone-orchestrator** runs `git commit`.
+Only **milestone-orchestrator** runs `git commit`, push, and merge.
 
 ---
 
-## 🐙 GitHub workflow
+## 🚂 Train mode (low-touch orchestration)
+
+Default for the hire-me train: one conductor chat can run the full queue. Still **one issue = one branch = one PR**. Learning pass is optional and does **not** gate the next issue.
+
+```mermaid
+flowchart TB
+  subgraph pulse [Operator supervision]
+    S["Status pulse<br/>3–6 lines"]
+    B["Blocker card<br/>only when stuck"]
+  end
+
+  O[milestone-orchestrator]
+
+  subgraph ship [Per issue loop]
+    R[Specialists]
+    V[verifier]
+    C[commit 1–2]
+    P[PR + merge]
+  end
+
+  O --> R --> V --> C --> P
+  P --> S
+  R -.->|needs human| B
+  B --> docs-writer
+```
+
+### Per-issue loop
+
+1. Mark issue **In progress**; branch `feat/m7-8-<name>` or `feat/m8-<name>` from latest `main`.
+2. Dispatch specialists by ownership (no same-file parallel).
+3. Run **verifier** (`pytest`; docker build only if Dockerfile/compose changed).
+4. Orchestrator commits (1–2 granular), pushes, opens PR with **`## Main contribution`** first, `Closes #NN`.
+5. When CI is green and the issue checklist is met, **orchestrator merges**, then emits a **status pulse** and starts the next wave.
+
+### Commit / push / merge policy (train mode)
+
+| Action | Who | When |
+|--------|-----|------|
+| Edit code/docs | Specialists | Per issue ownership |
+| `git commit` | Orchestrator only | After verifier green |
+| Push + open PR | Orchestrator | After commits |
+| Merge | Orchestrator | CI green + DoD checklist met |
+| Learning pass | Human (optional, async) | Does not block next issue |
+
+If the operator says **hold merges** or **propose only**, fall back to draft PR + wait for explicit `commit` / `push` / `merge`.
+
+### Status pulse (after every merge or wave)
+
+Keep it short. Operator supervises via these, not via “say commit.”
+
+```markdown
+## Pulse · #NN merged
+- Done: <one outcome line>
+- PR: #<pr> → closes #NN
+- Next: <next issue or parallel pair>
+- Need from you: nothing | see Blocker
+```
+
+### Hard human gates (stop the train)
+
+1. **#57 recording** — agents prepare script/README; only the human can film/upload and supply the public URL.
+2. **Secrets** — API keys and real hostnames stay in `.env` / VPS only; never in git.
+3. **CI still red** after one focused fix attempt — emit a Blocker card; do not loop forever.
+
+Soft gate: packaging thumbnail / marketing copy preference (default: continue with calm README hero; human can tweak later).
+
+---
+
+## 🐙 GitHub workflow (single issue)
 
 ```mermaid
 flowchart LR
-  A[Pick issue] --> B[New Agent chat]
+  A[Pick issue] --> B[Conductor chat]
   B --> C["/ship-issue #NN"]
   C --> D[Specialists edit]
   D --> E[Verifier]
   E --> F[Orchestrator commits]
-  F --> G[PR with Main contribution]
+  F --> G[PR + CI]
+  G --> H[Orchestrator merges]
+  H --> I[Status pulse]
 ```
 
 1. Pick issue → **In progress** on Project board.
-2. **New Agent chat** → `/ship-issue #NN`.
+2. Conductor chat → `/ship-issue #NN` (or continue train chat).
 3. Branch: `feat/m7-8-<short-name>` (or `feat/m8-<short-name>`).
 4. Specialists edit; orchestrator splits **1–2 granular commits**.
 5. `verifier` before PR.
-6. PR: **`## Main contribution`** first, `Closes #NN`. Push/merge when human approves.
-7. **15 min learning pass** (see PROJECT-DIRECTION).
+6. PR: **`## Main contribution`** first, `Closes #NN`. Push and merge when green (train mode).
+7. Optional learning pass later (see PROJECT-DIRECTION).
+
+For the full queue, prefer `/ship-milestone M7.8` then continue into packaging + thin M8 rather than a fresh chat per issue (unless context is huge).
 
 ---
 
@@ -109,7 +201,7 @@ flowchart LR
 |---------|---------|
 | `/ship-issue` | Ship one GitHub issue end-to-end (**use this**) |
 | `/ship-m7-issue` | Alias → same as `/ship-issue` |
-| `/ship-milestone` | Plan or status for M7.8–M12 |
+| `/ship-milestone` | Run or plan a milestone train (M7.8–M12) |
 | `/verify` | pytest + ruff; report gaps |
 
 ---
@@ -123,23 +215,29 @@ flowchart LR
 | Self-host / air-gap LLM | Ollama (`phi3:mini` CPU; `llama3.1:8b` if RAM allows) | Not for YouTube hero |
 | Domain / HTTPS | ai-doc-pilot.roxanatapia.dev | M7-6 done |
 | Pitch vertical | **Confidential documents** (not legal-only) | NDA = eval corpus |
-| Commit policy | Orchestrator proposes; human says `commit` | No push without approval |
+| Commit / merge policy | **Train mode:** orchestrator commits, pushes, merges when verifier + CI green | Operator may say `hold merges` for propose-only |
 | Private deploy repo | Deferred until M10 or first client | App stays public |
 | OpenAI provider | After Anthropic (#54) | Optional third backend |
 | Support MVP / n8n CRM bot | Separate later project | Not this repo’s M8+ north star |
 | M9–M11 depth | Client-triggered | Not required for portfolio readiness |
+| Thin M8 in hire-me train | **Include** (#58–#60 after packaging) | Then pause for Support MVP |
 
 ---
 
 ## 🚧 Blocker template
 
+When stuck, invoke **blocker-reporter**, then ask **docs-writer** to polish into a clear “need you” card. **STOP** the train until the human replies (or the default timeout applies).
+
 ```markdown
-## Blocker
+## Blocker · need you
 - **Issue:** #NN
-- **Decision needed:** (e.g. Anthropic model id, streaming UX)
-- **Options:** A / B with tradeoff
-- **Default if no reply:** (from Human decisions log)
+- **What I need:** (concrete ask, e.g. YouTube/Loom URL)
+- **Why:** (what cannot ship without it)
+- **What is ready:** (what agents already finished)
+- **Options:** A / B with tradeoff (optional)
+- **Default if no reply:** (from Human decisions log; include quiet period if useful)
 - **Blocks:** list of files/issues
+- **Reply with:** (exact shape of answer you need)
 ```
 
 ---
@@ -154,22 +252,37 @@ flowchart LR
 | **docs/operators/PROJECT-DIRECTION.md** | Human + orchestrator | Phase order, operator habits |
 | **docs/README.md** | `docs-writer` | Docs structure / index |
 | **PR / issue prose** | `docs-writer` | Short warm Main contribution; issue Outcome + DoD |
-| **AGENTS.md** | Human + orchestrator | New issues, decision log |
+| **Blocker cards** | `blocker-reporter` + `docs-writer` polish | Human gates |
+| **AGENTS.md** | Human + orchestrator | Train policy, issues, decision log |
 
 After each phase slice: dispatch `docs-writer` to sync README + ROADMAP. Before opening a PR, docs-writer may polish the PR body (and issue text when needed).
 
 ---
 
-## 📋 Operator prompt (copy per issue)
+## 📋 Operator prompts
+
+### Full hire-me train (preferred)
 
 ```text
-Act as milestone-orchestrator. Ship GitHub issue #NN.
+Act as milestone-orchestrator. Run the hire-me train:
+#53 → #54 → (#55 ∥ #56) → #57 → packaging → #58 → #59 → #60.
+
+- Follow docs/operators/PROJECT-DIRECTION.md, docs/operators/ROADMAP.md, and AGENTS.md
+- Specialists must NOT commit; you commit, push, and merge when verifier + CI are green
+- After each merge, send a short Status pulse
+- On hard gates (#57 video URL, secrets, CI still red): Blocker card (docs-writer polish) and STOP
+- Do not start Support MVP in this repo; end with a hire-me-ready pulse
+```
+
+### Single issue (propose-only / hold merges)
+
+```text
+Act as milestone-orchestrator. Ship GitHub issue #NN. Hold merges.
 
 - New branch from main: feat/<phase>-<short-name>
 - Follow docs/operators/PROJECT-DIRECTION.md and docs/operators/ROADMAP.md
 - Specialists must NOT commit; you split 1–2 granular commits
 - Run verifier before PR
-- After merge I will read the diff myself (learning pass)
-- If blocker: invoke blocker-reporter and STOP
-- Do not push unless I say push
+- Draft PR with Main contribution; wait for my commit / push / merge
+- If blocker: invoke blocker-reporter + docs-writer polish and STOP
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,18 +10,34 @@ How this repo uses Cursor **rules**, **subagents**, and **slash commands** to de
 
 ---
 
+## 🗺️ Milestone recap
+
+| Milestone | Goal | Status |
+|-----------|------|--------|
+| **M7** | Reference deployment (Docker, Compose, Caddy, live pilot) | ✅ Shipped |
+| **M7.8** | Demo-ready tier: swappable LLM, Anthropic path, streaming | 🚧 Next (#53–#57) |
+| **Video / packaging** | Walkthrough linked from README; calm product framing | After M7.8 |
+| **M8** | Thin FastAPI `/health`, `/chat`, OpenAPI | After packaging (#58–#60) |
+| **M8.5** | Eval report export | Optional (#61) |
+| **M9–M11** | Persist, access control, ops runbook | Client-triggered |
+| **M12** | Light services / tiers one-pager | Light |
+
+**North star:** private document Q&A with cited answers. Support MVP / n8n CRM is a **separate** later project.
+
+Full detail: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
+
+---
+
 ## 🎯 Current focus
 
-- **Ship first:** M7.8 (#53–#57) → demo video → portfolio packaging (see ROADMAP).
-- **Then:** optional thin M8 (#58–#60), then **pause** for Support MVP (sibling project).
-- **Client-triggered later:** M8.5, M9–M11.
-- **North star:** private document Q&A (this repo). n8n CRM / website Support MVP = **separate later project**, not M8+ here.
+- **Ship next:** M7.8 (#53–#57) → demo video → packaging → thin M8 (#58–#60).
+- **Then pause** this repo for the Support MVP sibling unless a paid engagement needs more depth here.
+- **Later / on demand:** M8.5, M9–M11.
 
-### Hire-me train (default queue)
+### Delivery train (default queue)
 
 ```text
-#53 → #54 → (#55 ∥ #56) → #57 → packaging → [pause] → #58 → #59 → #60
-                                                      ↘ Support MVP (sibling repo)
+#53 → #54 → (#55 ∥ #56) → #57 → packaging → #58 → #59 → #60 → [pause]
 ```
 
 | Wave | Work | Agents | Human? |
@@ -31,8 +47,8 @@ How this repo uses Cursor **rules**, **subagents**, and **slash commands** to de
 | 3a ∥ 3b | **#55** streaming · **#56** docs | streamlit (+ rag review) ∥ docs-writer | None if files stay split |
 | 4 | **#57** demo video + README | docs-writer prepares; **human records** | **Hard gate:** video URL |
 | 5 | **Packaging** | docs-writer | Soft: thumbnail / links OK |
-| — | **Pause** | orchestrator “hire-me ready” pulse | Support MVP elsewhere |
 | 6–8 | **#58 → #59 → #60** thin M8 | rag-core → config → streamlit → verifier | Rare |
+| — | **Pause** | orchestrator “phase complete” pulse | Support MVP elsewhere |
 
 ---
 
@@ -51,7 +67,7 @@ How this repo uses Cursor **rules**, **subagents**, and **slash commands** to de
 
 Invoke by role name. Files live in `.cursor/agents/`.
 
-**Train roster cheat sheet:** orchestrator always on; rag-core on #53/#54/#58/#59; config on #53/#54/#59; streamlit on #55/#60; docs-writer on #56/#57/packaging + pulses/blockers; verifier every issue; deploy-engineer idle unless compose/env deploy notes change.
+**Train roster:** orchestrator always on; rag-core on #53/#54/#58/#59; config on #53/#54/#59; streamlit on #55/#60; docs-writer on #56/#57/packaging + pulses/blockers; verifier every issue; deploy-engineer idle unless compose/env deploy notes change.
 
 ---
 
@@ -73,7 +89,7 @@ Invoke by role name. Files live in `.cursor/agents/`.
 | #56 M7.8-4 docs + sample doc | docs-writer | - | 1–2 | parallel #55 |
 | #57 M7.8-5 demo video + README | docs-writer | human records | 1 | after #54–#56 |
 
-### M8: Thin FastAPI market contract (after video + packaging)
+### M8: Thin FastAPI contract (after video + packaging)
 
 | Issue | Primary | Secondary | Est. commits | Serial |
 |-------|---------|-----------|--------------|--------|
@@ -103,7 +119,7 @@ Only **milestone-orchestrator** runs `git commit`, push, and merge.
 
 ## 🚂 Train mode (low-touch orchestration)
 
-Default for the hire-me train: one conductor chat can run the full queue. Still **one issue = one branch = one PR**. Learning pass is optional and does **not** gate the next issue.
+Default for the delivery train: one conductor chat can run the full queue. Still **one issue = one branch = one PR**. Learning pass is optional and does **not** gate the next issue.
 
 ```mermaid
 flowchart TB
@@ -165,7 +181,7 @@ Keep it short. Operator supervises via these, not via “say commit.”
 2. **Secrets** — API keys and real hostnames stay in `.env` / VPS only; never in git.
 3. **CI still red** after one focused fix attempt — emit a Blocker card; do not loop forever.
 
-Soft gate: packaging thumbnail / marketing copy preference (default: continue with calm README hero; human can tweak later).
+Soft gate: packaging thumbnail / README emphasis (default: calm product framing; human can tweak later).
 
 ---
 
@@ -212,15 +228,15 @@ For the full queue, prefer `/ship-milestone M7.8` then continue into packaging +
 |----------|-----------------|-------|
 | VPS provider | Hetzner CPX32 (~€15/mo) | Falkenstein |
 | Demo / video LLM | **Anthropic Haiku** (`LLM_PROVIDER=anthropic`) | Fast recording; API key in `.env` only |
-| Self-host / air-gap LLM | Ollama (`phi3:mini` CPU; `llama3.1:8b` if RAM allows) | Not for YouTube hero |
+| Self-host / air-gap LLM | Ollama (`phi3:mini` CPU; `llama3.1:8b` if RAM allows) | Not for walkthrough video |
 | Domain / HTTPS | ai-doc-pilot.roxanatapia.dev | M7-6 done |
 | Pitch vertical | **Confidential documents** (not legal-only) | NDA = eval corpus |
 | Commit / merge policy | **Train mode:** orchestrator commits, pushes, merges when verifier + CI green | Operator may say `hold merges` for propose-only |
 | Private deploy repo | Deferred until M10 or first client | App stays public |
 | OpenAI provider | After Anthropic (#54) | Optional third backend |
 | Support MVP / n8n CRM bot | Separate later project | Not this repo’s M8+ north star |
-| M9–M11 depth | Client-triggered | Not required for portfolio readiness |
-| Thin M8 in hire-me train | **Include** (#58–#60 after packaging) | Then pause for Support MVP |
+| M9–M11 depth | Client-triggered | Not required for demo-ready pause |
+| Thin M8 in delivery train | **Include** (#58–#60 after packaging) | Then pause for Support MVP |
 
 ---
 
@@ -255,23 +271,25 @@ When stuck, invoke **blocker-reporter**, then ask **docs-writer** to polish into
 | **Blocker cards** | `blocker-reporter` + `docs-writer` polish | Human gates |
 | **AGENTS.md** | Human + orchestrator | Train policy, issues, decision log |
 
+Tone for operator docs and GitHub issues: calm and confident. Avoid “hire-me,” “Upwork niche,” or salesy framing. Client contact links in README are fine; milestone prose is not a pitch deck.
+
 After each phase slice: dispatch `docs-writer` to sync README + ROADMAP. Before opening a PR, docs-writer may polish the PR body (and issue text when needed).
 
 ---
 
 ## 📋 Operator prompts
 
-### Full hire-me train (preferred)
+### Full delivery train (preferred)
 
 ```text
-Act as milestone-orchestrator. Run the hire-me train:
+Act as milestone-orchestrator. Run the delivery train:
 #53 → #54 → (#55 ∥ #56) → #57 → packaging → #58 → #59 → #60.
 
 - Follow docs/operators/PROJECT-DIRECTION.md, docs/operators/ROADMAP.md, and AGENTS.md
 - Specialists must NOT commit; you commit, push, and merge when verifier + CI are green
 - After each merge, send a short Status pulse
 - On hard gates (#57 video URL, secrets, CI still red): Blocker card (docs-writer polish) and STOP
-- Do not start Support MVP in this repo; end with a hire-me-ready pulse
+- Do not start Support MVP in this repo; end with a phase-complete pulse
 ```
 
 ### Single issue (propose-only / hold merges)

--- a/docs/operators/PROJECT-DIRECTION.md
+++ b/docs/operators/PROJECT-DIRECTION.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-How to finish the pipeline for a freelance portfolio hero: Cursor discipline, code you understand, and a private document Q&A demo you’d show without apologizing for latency.
+How to finish this pipeline with Cursor discipline, code you understand, and a private document Q&A demo you can show without apologizing for latency.
 
 Full milestone detail: [ROADMAP.md](ROADMAP.md) · Agent playbook: [AGENTS.md](../../AGENTS.md) · Docs index: [docs/README.md](../README.md)
 
@@ -10,11 +10,23 @@ Full milestone detail: [ROADMAP.md](ROADMAP.md) · Agent playbook: [AGENTS.md](.
 
 ---
 
-## 🎯 Portfolio strategy (read first)
+## 🗺️ Milestone recap
+
+| Milestone | Goal | Status |
+|-----------|------|--------|
+| **M7** | Reference deployment | ✅ Shipped |
+| **M7.8** | Demo-ready LLM tier + streaming | 🚧 Next (#53–#57) |
+| **Video + packaging** | Walkthrough + calm README framing | After M7.8 |
+| **M8** | Thin `/health` + `/chat` API | After packaging (#58–#60) |
+| **M8.5 / M9–M12** | Eval export; persist; SSO; ops; light pack | Optional / client-triggered |
+
+---
+
+## 🎯 Product scope (read first)
 
 | Piece | Where | Role |
 |-------|-------|------|
-| **Hero** | **This repo** | Private RAG / document Q&A with sourced answers |
+| **This product** | **This repo** | Private RAG / document Q&A with sourced answers |
 | **Sibling** | receipt-intelligence-n8n | n8n + AI document→data workflows (separate repo) |
 | **Later** | Support MVP (new project) | Website chat + escalate + n8n → CRM |
 
@@ -24,23 +36,23 @@ This repo’s north star is **not** a website support assistant. Escalate/CRM be
 
 ## ⭐ North star
 
-> Upload a confidential PDF, ask a question, get a **fast** answer with **page citations** on **your** infrastructure. Optionally expose a **thin** `/health` + `/chat` API for proposals; keep eval export and persistence for when a buyer asks.
+> Upload a confidential PDF, ask a question, get a **fast** answer with **page citations** on **your** infrastructure. Optionally expose a **thin** `/health` + `/chat` API for integrations; keep eval export and persistence for when a buyer asks.
 
-If that sentence feels true after **demo + video + packaging**, you’re hire-me ready. Thin M8 is optional (job-post driven). Then pause this repo and start the Support MVP sibling unless a paid client needs more depth here.
+If that sentence feels true after **demo + video + packaging + thin M8**, this phase of the repo is complete. Then pause here and start the Support MVP sibling unless a paid client needs more depth.
 
 ---
 
 ## 🧭 Three objectives
 
-### 1. Cursor best practices (one chat per issue)
+### 1. Cursor best practices
 
 | Rule | Why |
 |------|-----|
-| **One GitHub issue → one Agent chat → one branch → one PR** | Clean history; you can explain each merge |
-| **Orchestrator commits; specialists don’t** | You approve `commit` / `push` |
-| **Use `/ship-issue #NN`** in a **new** chat per issue | Context stays small |
+| **One GitHub issue → one branch → one PR** | Clean history; each merge is explainable |
+| **Orchestrator commits; specialists don’t** | Train mode: orchestrator also pushes/merges when green (see AGENTS.md) |
+| **Use `/ship-issue #NN`** | Prefer one conductor chat for the delivery train; split if context grows |
 | **`/verify` before PR** | pytest; skip full `docker build` unless infra changed |
-| **PR starts with `## Main contribution`** | Outcome for buyer/you, not file list |
+| **PR starts with `## Main contribution`** | Outcome first, not a file list |
 
 **Branch names**
 
@@ -52,7 +64,7 @@ feat/m8-fastapi-chat       → closes #59
 
 **When stuck:** invoke `blocker-reporter` format in AGENTS.md; update Human decisions log; STOP.
 
-**Do not:** one mega-chat for M7.8; parallel edits on `src/rag.py` + `src/app.py` across two issues.
+**Do not:** one mega-PR for multiple issues; parallel edits on `src/rag.py` + `src/app.py` across two issues.
 
 ---
 
@@ -67,7 +79,7 @@ After each issue, you should answer **without opening Cursor**:
 | **Config** | `configs/config.yaml`, `.env` | What knob changes retrieval vs generation? |
 | **Deploy** | `docker-compose*.yml`, `DEPLOYMENT.md` | How does a request reach Ollama or API LLM? |
 
-**Per-issue learning habit (15 min after merge)**
+**Per-issue learning habit (15 min after merge, optional)**
 
 1. Read the diff yourself.
 2. Run the app locally: one upload, one question, dev sidebar on.
@@ -78,14 +90,14 @@ After each issue, you should answer **without opening Cursor**:
 
 ---
 
-### 3. Finish line (portfolio-ready hero)
+### 3. Finish line (demo-ready + thin API)
 
 | Phase | Milestones | “I’d use it / I’d show it” test |
 |-------|------------|----------------------------------|
 | **0** | M7 ✅ | You trust deploy; you don’t trust speed on VPS Ollama |
 | **1** | M7.8 → video → packaging | You’d show a colleague the video; README looks calm |
 | **2** | Thin M8 | You’d call `/chat` from curl in a proposal |
-| **2b** | M8.5 (optional) | You’d send an eval report for a RAG-audit gig |
+| **2b** | M8.5 (optional) | You’d send an eval report for a retrieval audit |
 | **3** | M9–M11 | Client-triggered |
 | **4** | M12 light | Short tiers/services one-pager |
 
@@ -99,7 +111,7 @@ After each issue, you should answer **without opening Cursor**:
 
 **Shipped:** Docker, Compose, Caddy, live pilot, DEPLOYMENT, architecture, demo storyboard.
 
-**Learnings:** Retrieval + citations are the core IP. CPU Ollama is an option, not the hero.
+**Learnings:** Retrieval + citations are the core IP. CPU Ollama is an option, not the walkthrough default.
 
 **Your action:** Close M7 on the board. Start Phase 1.
 
@@ -115,7 +127,7 @@ After each issue, you should answer **without opening Cursor**:
 | 54 | Anthropic adapter | rag-core-engineer, config-guardian | API keys, Haiku vs Sonnet |
 | 55 | Streamlit streaming | streamlit-engineer | UX; generators |
 | 56 | Docs + non-legal sample | docs-writer | Positioning; eval ≠ vertical |
-| 57 | Record video + README link | docs-writer (you record) | Sales asset |
+| 57 | Record video + README link | docs-writer (you record) | Walkthrough asset |
 
 ```mermaid
 flowchart LR
@@ -124,11 +136,12 @@ flowchart LR
   B --> D["#56 parallel"]
   C --> E["#57 record"]
   D --> E
-  E --> F[Packaging checklist]
-  F --> G[Pause for Support MVP]
+  E --> F[Packaging]
+  F --> G[Thin M8]
+  G --> H[Phase pause]
 ```
 
-After packaging: **pause** for Support MVP. Only continue to thin M8 if FastAPI keeps showing up in jobs you want.
+After packaging + thin M8: **pause** for Support MVP unless a paid engagement needs more here.
 
 **Env for recording (local, never commit)**
 
@@ -140,11 +153,11 @@ ANTHROPIC_API_KEY=sk-...
 
 ---
 
-### Phase 2: Thin market contract (optional)
+### Phase 2: Thin API contract
 
 **Milestones:** M8 ([#58–#60](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/2))
 
-Serial #58 → #59 → #60. Only if job posts keep asking for FastAPI. Not required before Support MVP.
+Serial #58 → #59 → #60. Included in the default delivery train after packaging.
 
 ---
 
@@ -158,11 +171,11 @@ Serial #58 → #59 → #60. Only if job posts keep asking for FastAPI. Not requi
 
 **Milestones:** M9, M10, M11 (issues TBD via `/ship-milestone M9`)
 
-Not required for portfolio readiness.
+Not required for the demo-ready pause.
 
 ---
 
-### Phase 4: Light commercial pack
+### Phase 4: Light services pack
 
 **Milestone:** M12. Short services/tiers one-pager.
 
@@ -173,9 +186,9 @@ Not required for portfolio readiness.
 | Day | Activity |
 |-----|----------|
 | **Mon** | Pick one issue; move to In progress |
-| **Tue–Wed** | `/ship-issue` chat; understand diff; `commit` |
-| **Thu** | `/verify`; open PR; self-review |
-| **Fri** | Merge; 15 min learning notes; update board |
+| **Tue–Wed** | `/ship-issue` (or continue delivery train); understand diff |
+| **Thu** | `/verify`; PR; self-review |
+| **Fri** | Merge (or confirm train merge); optional learning notes; update board |
 
 **One issue per week** is enough for M7.8 in about 5 weeks including video.
 
@@ -196,7 +209,7 @@ Columns: `Backlog` | `Ready` | `In progress` | `In review` | `Done`
 | Command | When |
 |---------|------|
 | `/ship-issue #53` | Implement one issue end-to-end |
-| `/ship-milestone M7.8` | Plan or status for a phase |
+| `/ship-milestone M7.8` | Run or plan a phase / delivery train |
 | `/verify` | Before every PR |
 
 ---
@@ -211,11 +224,12 @@ Columns: `Backlog` | `Ready` | `In progress` | `In review` | `Done`
 | OpenAI | Optional after Anthropic works |
 | Pitch vertical | Confidential **documents**, not legal-only |
 | Support MVP / n8n CRM bot | Separate later project |
+| Commit / merge | Train mode in AGENTS.md (orchestrator merges when green) |
 
 ---
 
-## ✨ Success check (after Phase 1, + thin M8 if done)
+## ✨ Success check (after Phase 1 + thin M8)
 
-“I built private document Q&A with cited answers. Demo uses a fast API model; clients can run local Ollama on the same Docker stack. There’s a live pilot and a walkthrough video. When needed I can expose `/health` and `/chat`. I’d deploy this for a team with sensitive PDFs.”
+“I built private document Q&A with cited answers. The demo uses a fast API model; clients can run local Ollama on the same Docker stack. There’s a live pilot and a walkthrough video. When needed I can expose `/health` and `/chat`. I’d deploy this for a team with sensitive PDFs.”
 
-If that’s true, you’re ready for **first gig** conversations with proof, not promises.
+If that’s true, you’re ready for client conversations with proof, not promises.

--- a/docs/operators/ROADMAP.md
+++ b/docs/operators/ROADMAP.md
@@ -1,25 +1,42 @@
-# Production roadmap (portfolio-aligned)
+# Production roadmap
 
 ## Background
 
-For contributors and operators. Evolves the pipeline from a **reference deployment** into a **hire-me hero demo**: fast cited answers on a walkthrough, then a thin API for proposals. Deep production (persist / SSO / ops) is client-triggered, not the default climb after M7.
+For contributors and operators. Moves the pipeline from a **reference deployment** to a **demo-ready** private document Q&A product: fast cited answers on a walkthrough, then a thin API for integrations. Deeper production work (persist / SSO / ops) is client-triggered, not the default climb after M7.
 
-> **Takeaway:** Ship M7.8 → video → packaging first. Thin M8 next. Support MVP / n8n CRM is a separate later project.
+> **Takeaway:** Ship M7.8 → video → packaging → thin M8. Support MVP / n8n CRM is a separate later project.
 
-**Positioning:** private **document Q&A** for confidential PDFs (contracts, policies, SOPs, reports, internal KB exports), not legal-only. LLM backend is swappable: local Ollama (air-gap) or Anthropic/OpenAI (speed for demo and SaaS-style pilots).
+**Positioning:** private **document Q&A** for confidential PDFs (contracts, policies, SOPs, reports, internal KB exports), not legal-only. LLM backend is swappable: local Ollama (air-gap) or Anthropic/OpenAI (speed for demos and pilots).
 
-**Streamlit Cloud** = UI-only marketing demo (dummy generation). **Live pilot** = real RAG on your VPS. **M7.8** = demo-quality generation so the video is recordable.
+**Streamlit Cloud** = UI-only marketing demo (dummy generation). **Live pilot** = real RAG on your VPS. **M7.8** = demo-quality generation so the walkthrough is recordable.
 
 ---
 
-## 🎯 Portfolio strategy
+## 🗺️ Milestone recap
 
-Three-piece Upwork niche (only the first is this repo’s north star):
+| Milestone | Goal | Proof of done | Priority |
+|-----------|------|---------------|----------|
+| **M7** | Reference deployment | Live HTTPS pilot + `DEPLOYMENT.md` | ✅ Done |
+| **M7.8** | Demo-ready tier | Swappable LLM, streaming, recordable walkthrough | **Ship next** |
+| **Video (#57)** | Published walkthrough | Link in README | After M7.8 |
+| **Packaging** | Calm product framing | Clear pilot + Cloud + video links | After video |
+| **M8** | Thin FastAPI contract | OpenAPI `/health`, `/chat` | After packaging |
+| **M8.5** | Eval harness export | Before/after retrieval report | Optional |
+| **M9** | Persistent ingestion | PDFs + vectors survive restart | Client-triggered |
+| **M10** | Access control | SSO / auth proxy + `SECURITY.md` | Client-triggered |
+| **M11** | Ops & runbook | Backup, monitoring, `RUNBOOK.md` | Client-triggered |
+| **M12** | Light services pack | Pilot tiers, `SERVICES.md` one-pager | Light |
+
+**React UI:** optional, only if a client or RFP requires it.
+
+---
+
+## 🎯 Product scope
 
 | Piece | Repo / project | Role |
 |-------|----------------|------|
-| **Hero** | **This repo (ai-doc)** | Private RAG / document Q&A with sourced answers; pilot already live |
-| **Sibling story** | [receipt-intelligence-n8n](https://github.com/RoxanaTapia/receipt-intelligence-n8n) | n8n + AI workflow automation |
+| **This product** | **ai-doc (this repo)** | Private RAG / document Q&A with sourced answers; pilot already live |
+| **Sibling** | [receipt-intelligence-n8n](https://github.com/RoxanaTapia/receipt-intelligence-n8n) | n8n + AI workflow automation |
 | **Later** | Support MVP (separate project) | Website chat + RAG + escalate + n8n → CRM |
 
 **Out of scope for this repo’s north star**
@@ -32,47 +49,28 @@ Three-piece Upwork niche (only the first is this repo’s north star):
 
 ## 🗺️ Phase map
 
-| Phase | Milestones | You can say to clients / Upwork |
-|-------|------------|----------------------------------|
-| **0. Shipped** | M7 ✅ | “Reproducible private pilot on one VM; live URL; deployment guide.” |
-| **1. Demo & trust** | **M7.8** → video → **portfolio packaging** | “Fast, cited answers on a walkthrough; calm README; clear pilot + Cloud links.” |
-| **2. Thin market contract** | **M8** (optional) | “Not Streamlit-only: `/health`, `/chat`, OpenAPI” when jobs ask for it. |
-| **2b. Optional next** | **M8.5** eval | “Before/after retrieval report for buyers / RAG audit gigs.” |
-| **3. Client-triggered** | M9 → M11 | “Docs survive restart; SSO; runbooks” when a pilot/RFP needs them |
-| **4. Light commercial** | M12 | “Pilot tiers / services one-pager” |
+| Phase | Milestones | Outcome you can stand behind |
+|-------|------------|------------------------------|
+| **0. Shipped** | M7 ✅ | Reproducible private pilot on one VM; live URL; deployment guide |
+| **1. Demo & trust** | **M7.8** → video → **packaging** | Fast, cited answers on a walkthrough; calm README; clear pilot + Cloud links |
+| **2. Thin API** | **M8** | Not Streamlit-only: `/health`, `/chat`, OpenAPI |
+| **2b. Optional** | **M8.5** eval | Reproducible retrieval report for audits |
+| **3. Client-triggered** | M9 → M11 | Docs survive restart; SSO; runbooks when a pilot/RFP needs them |
+| **4. Light pack** | M12 | Pilot tiers / services one-pager |
 
 ```mermaid
 flowchart TD
   M7[M7 shipped] --> M78[M7.8 demo tier]
   M78 --> V[Demo video]
-  V --> P[Portfolio packaging]
-  P --> Pause[Hire-me ready pause]
+  V --> P[Packaging]
+  P --> M8[Thin M8 API]
+  M8 --> Pause[Phase pause]
   Pause --> Support[Support MVP sibling project]
-  Pause -.->|optional if jobs ask| M8[Thin M8 API]
   M8 -.-> M85[M8.5 eval optional]
   Pause -.->|client-triggered| M9[M9–M11]
 ```
 
-**Hire-me ready** after Phase 1 (video + packaging). Thin M8 only if FastAPI keeps showing up in job posts. Then **pause this repo** and start the Support MVP sibling unless a paid client needs more depth here. M8.5 and M9–M12 do not unlock Support MVP.
-
----
-
-## 📋 Milestone overview
-
-| Milestone | Goal | Hire-me proof | Priority |
-|-----------|------|---------------|----------|
-| **M7** | Reference deployment | Live HTTPS pilot + `DEPLOYMENT.md` | ✅ Done |
-| **M7.8** | Demo-ready tier | Swappable LLM, streaming, recordable walkthrough | **Ship first** |
-| **M7-7 / #57** | Demo video | YouTube/Loom linked from README | After M7.8 |
-| **Portfolio packaging** | Upwork-ready framing | 16:9 thumbnail, calm README hero, clear links | After video |
-| **M8** | Thin FastAPI contract | OpenAPI `/health`, `/chat` | Optional after packaging |
-| **M8.5** | Eval harness export | Before/after retrieval report | Optional / secondary |
-| **M9** | Persistent ingestion | PDFs + vectors survive restart | Client-triggered |
-| **M10** | Access control | SSO / auth proxy + `SECURITY.md` | Client-triggered |
-| **M11** | Ops & runbook | Backup, monitoring, `RUNBOOK.md` | Client-triggered |
-| **M12** | Light commercial pack | Pilot tiers, `SERVICES.md` one-pager | Light |
-
-**React UI:** optional, only if a client or RFP requires it.
+**Phase pause** after packaging + thin M8: this repo is demo-ready and integration-ready. Then focus the Support MVP sibling unless a paid client needs more depth here. M8.5 and M9–M12 do not unlock Support MVP.
 
 ---
 
@@ -92,9 +90,9 @@ flowchart TD
 
 ### Learnings (M7)
 
-- **Deploy ≠ demo.** HTTPS + Compose proves you ship; CPU Ollama (~30–40s/answer) does not sell on video.
-- **One issue → one PR** kept infra reviewable for IT buyers.
-- **Honest limits** in README build more trust than “zero hallucinations.”
+- **Deploy ≠ demo.** HTTPS + Compose proves the stack; CPU Ollama (~30–40s/answer) is too slow for a walkthrough video.
+- **One issue → one PR** kept infra reviewable for technical buyers.
+- **Honest limits** in README build more trust than overstated claims.
 
 ---
 
@@ -120,7 +118,7 @@ flowchart TD
 | M7.8-2 | How API keys stay in `.env`, never git; same RAG context, different backend |
 | M7.8-3 | Streamlit `st.write_stream` or generator pattern |
 | M7.8-4 | Product narrative ≠ code; eval corpus (NDA) ≠ market vertical |
-| M7.8-5 | Marketing asset; no new Python required |
+| M7.8-5 | Walkthrough asset; no new Python required |
 
 **Serial order:** #53 → #54 → #55; #56 parallel with #55; #57 after #54–#56.
 
@@ -134,27 +132,27 @@ Storyboard: [`docs/product/demo-script.md`](../product/demo-script.md). Record u
 
 ### Learnings
 
-- Video sells **retrieval + citations + deploy path**, not raw local inference speed.
+- The video should show **retrieval + citations + deploy path**, not raw local inference speed.
 - Pre-warm the model; run storyboard questions once before Record.
 
 ---
 
-## Portfolio packaging (after video)
+## Packaging (after video)
 
 | Item | Outcome |
 |------|---------|
 | Thumbnail story | Calm 16:9 still (upload → cited answer) |
-| README hero | Private document Q&A framing; pilot + Cloud links obvious |
+| README framing | Private document Q&A; pilot + Cloud links obvious |
 | Video link | README Demo video line points at published walkthrough |
 | Honest tiers | Demo (API LLM) vs self-host (Ollama) stated once |
 
-**Definition of done:** A cold visitor understands what you sell and where to click in under a minute.
+**Definition of done:** A first-time reader understands the product and where to go next in under a minute.
 
 ---
 
-## M8: Thin market contract (FastAPI)
+## M8: Thin FastAPI contract
 
-Thin integration surface after video + packaging. Enough for proposals. Not a large API rewrite gate.
+Thin integration surface after video + packaging. Enough for proposals and integrations. Not a large API rewrite gate.
 
 | Issue | Outcome | GitHub |
 |-------|---------|--------|
@@ -208,7 +206,7 @@ GitHub milestone: [M8](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/mi
 
 ---
 
-## M12: Light commercial pack
+## M12: Light services pack
 
 - Short `docs/SERVICES.md` / pilot tiers one-pager
 - Video link maintained in README
@@ -218,15 +216,15 @@ GitHub milestone: [M8](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/mi
 
 ---
 
-## 💼 When to sell
+## ✅ Engagement readiness
 
-| Stage | You can… |
-|-------|----------|
-| **Now (M7)** | RAG retrieval audit; private pilot deploy; Upwork with live URL |
-| **After M7.8 + video + packaging** | Confident walkthrough; portfolio-ready hero |
-| **After thin M8** | Proposals that mention `/health` + `/chat` / OpenAPI |
-| **After M8.5** | RAG audit / eval-harness gigs with reproducible reports |
-| **After M9–M11 (client-scoped)** | Serious production contracts |
+| Stage | You can confidently offer |
+|-------|---------------------------|
+| **Now (M7)** | RAG retrieval review; private pilot deploy; live URL |
+| **After M7.8 + video + packaging** | Walkthrough with cited answers; clear demo vs self-host story |
+| **After thin M8** | Integrations via `/health` + `/chat` / OpenAPI |
+| **After M8.5** | Reproducible retrieval reports for audits |
+| **After M9–M11 (client-scoped)** | Deeper production contracts |
 
 ---
 
@@ -256,6 +254,6 @@ Client-readable diagram: [product/architecture.md](../product/architecture.md).
 | Commands | `/ship-issue`, `/ship-milestone`, `/verify` |
 | Rules | `.cursor/rules/milestone-workflow.mdc` |
 
-**Loop:** pick GitHub issue → **new Agent chat** → `/ship-issue #NN` → review code yourself → `commit` → merge → next issue.
+**Loop (train mode):** pick GitHub issue → conductor chat → `/ship-issue #NN` → verifier → orchestrator commit/PR/merge → status pulse → next issue. See [AGENTS.md](../../AGENTS.md).
 
 Issue map: M7.8 [#53–#57](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/7) · M8 [#58–#60](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/2) · M8.5 [#61](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/2)


### PR DESCRIPTION
## Main contribution

This PR defines a low-touch delivery train for M7.8 through thin M8, with short status pulses and clear hard gates when you must intervene. Operator docs and GitHub milestones now use calm, confident language (not “hire-me” framing), plus a clear milestone recap so the next phase of work is easy to supervise.

## Summary
- Train mode in `AGENTS.md`: orchestrator commit/push/merge when verifier + CI green; pulses; hard gates; hold-merges fallback
- Milestone recap in AGENTS, ROADMAP, and PROJECT-DIRECTION
- Retone operator docs away from hire-me / Upwork-niche / salesy phrasing
- Align slash commands, orchestrator, docs-writer, and milestone-workflow rule
- GitHub: milestone descriptions + issue bodies #53–#61 updated to match (via `gh`, not in this diff)

## Test plan
- [x] Skim AGENTS.md milestone recap + delivery train; confirm no “hire-me” product framing
- [x] Skim ROADMAP phase map; confirm calm “Engagement readiness” section
- [x] Spot-check GitHub milestones M7.8 / M8 and issues #56 / #59 for tone
- [x] Confirm `hold merges` still restores propose-only behavior