### PR TITLE
M7.8-1: LLMProvider interface and LLM_PROVIDER env switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,18 @@ OLLAMA_HOST=
 # on Streamlit Cloud defaults to true (dummy). Compose sets false automatically.
 USE_DUMMY_GENERATOR=
 
+# Generation backend selector (optional override).
+# Allowed: ollama | anthropic | openai | dummy
+#   Empty (default) = derive from USE_DUMMY_GENERATOR / Streamlit dummy_mode
+#                     (backward compatible: dummy_mode True → dummy, else ollama)
+#   Compose / VPS / local self-host: leave empty or set ollama; keep
+#                     USE_DUMMY_GENERATOR=false (Compose sets false automatically)
+#   Streamlit Cloud: leave empty and rely on USE_DUMMY_GENERATOR (defaults true → dummy)
+#   anthropic: needs ANTHROPIC_API_KEY above; adapter lands in #54 (NotImplemented until then)
+#   openai: reserved; not implemented yet
+# Non-empty LLM_PROVIDER always wins over USE_DUMMY_GENERATOR / YAML provider.
+LLM_PROVIDER=
+
 # Optional Ollama generation overrides (empty = configs/config.yaml rag.generation)
 # Compose default: llama3.1:8b (matches configs/config.yaml).
 # CPU-only / low RAM: OLLAMA_MODEL=phi3:mini

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -35,6 +35,11 @@ rag:
       hard_context_filter: true   # R4-E: LLM context + Sources use section-matching chunks only
       context_min_chunks: 2
   generation:
+    # Informational / self-host default (ollama). Runtime selection:
+    #   1. Non-empty env LLM_PROVIDER wins (ollama|anthropic|openai|dummy)
+    #   2. Else dummy_mode / USE_DUMMY_GENERATOR → dummy vs ollama
+    # YAML alone does not select the backend when LLM_PROVIDER is unset.
+    provider: ollama
     model: "llama3.1:8b"     # default local Ollama model (override with OLLAMA_MODEL)
     max_new_tokens: 384      # room for bullet answers (Round 2)
     temperature: 0.3         # creativity when do_sample is true

--- a/src/rag.py
+++ b/src/rag.py
@@ -1,9 +1,9 @@
+import logging
 import os
 import re
-import logging
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 import yaml
 from langchain_ollama import ChatOllama
@@ -13,16 +13,33 @@ CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0B-\x1F\x7F]")
 APP_ROOT = Path(__file__).resolve().parent.parent
 PROMPTS_PATH = APP_ROOT / "configs" / "prompts.yaml"
 CONFIG_PATH = APP_ROOT / "configs" / "config.yaml"
+SUPPORTED_LLM_PROVIDERS = frozenset({"ollama", "anthropic", "openai", "dummy"})
 DEFAULT_PROMPT_TEMPLATE = (
     "You are a precise and concise legal assistant.\n"
     "Answer ONLY using information from the provided context.\n"
-    'If there is no relevant information, say: "I could not find enough information in the document to answer."\n\n'
+    "If there is no relevant information, say: "
+    '"I could not find enough information in the document to answer."\n\n'
     "Extracted context:\n"
     "{context}\n\n"
     "User question:\n"
     "{question}\n\n"
     "Answer (keep it short, clear, and cite the source when possible):"
 )
+DUMMY_UI_RESPONSE = (
+    "This is a UI demo — no AI model is running here.\n\n"
+    "Upload and search work, but answers are not generated on this host.\n\n"
+    "For real grounded answers on your documents, request access to the "
+    "[live pilot](https://ai-doc-pilot.roxanatapia.dev)."
+)
+
+
+@runtime_checkable
+class LLMProvider(Protocol):
+    """Swappable generation backend used by `generate_answer`."""
+
+    def generate(self, context: str, query: str) -> str:
+        """Return an answer string grounded in `context` for `query`."""
+        ...
 
 
 def _normalize_untrusted_text(text: str, max_chars: int) -> str:
@@ -97,8 +114,12 @@ def load_generation_config() -> dict[str, Any]:
 
     default_model = str(generation.get("model", "llama3.1:8b"))
     model_override = _env_text("OLLAMA_MODEL")
+    # Env wins when set; YAML `provider` is informational default for operators.
+    yaml_provider = str(generation.get("provider", "") or "").strip().lower()
+    env_provider = _env_text("LLM_PROVIDER")
 
     return {
+        "provider": (env_provider or yaml_provider or "").lower() or None,
         "model": model_override or default_model,
         "temperature": _env_float("OLLAMA_TEMPERATURE", float(generation.get("temperature", 0.3))),
         "top_p": _env_float("OLLAMA_TOP_P", float(generation.get("top_p", 0.9))),
@@ -129,6 +150,11 @@ def _format_prompt(template: str, context: str, query: str) -> str:
         return DEFAULT_PROMPT_TEMPLATE.format(context=context, question=query, query=query)
 
 
+def _dummy_response() -> str:
+    """Placeholder text for UI-demo / Streamlit Cloud (no local LLM)."""
+    return DUMMY_UI_RESPONSE
+
+
 def _generate_with_ollama(context: str, query: str, settings: dict[str, Any] | None = None) -> str:
     """Generate answer text using local Ollama runtime."""
     if settings is None:
@@ -149,8 +175,73 @@ def _generate_with_ollama(context: str, query: str, settings: dict[str, Any] | N
     return response.content.strip() if hasattr(response, "content") else str(response).strip()
 
 
+class DummyLLMProvider:
+    """UI-demo generator: fixed placeholder, no model calls."""
+
+    def generate(self, context: str, query: str) -> str:
+        return _dummy_response()
+
+
+class OllamaLLMProvider:
+    """Local Ollama generator with optional dummy fallback on errors."""
+
+    def __init__(self, settings: dict[str, Any] | None = None) -> None:
+        self._settings = settings
+
+    def generate(self, context: str, query: str) -> str:
+        settings = self._settings if self._settings is not None else load_generation_config()
+        try:
+            return _generate_with_ollama(context=context, query=query, settings=settings)
+        except Exception as exc:
+            logger.exception("Ollama generation failed: %s", exc)
+            if settings.get("fallback_to_dummy_on_error", False):
+                return (
+                    "Ollama unavailable, falling back to dummy mode.\n\n"
+                    f"{_dummy_response()}"
+                )
+            raise RuntimeError(f"Ollama generation unavailable: {exc}") from exc
+
+
+def resolve_llm_provider_name(dummy_mode: bool = True) -> str:
+    """Pick provider name from env, else map legacy dummy_mode / USE_DUMMY_GENERATOR.
+
+    Resolution:
+    1. `LLM_PROVIDER` env (non-empty) wins
+    2. Else `dummy` if `dummy_mode` else `ollama`
+    """
+    raw = os.getenv("LLM_PROVIDER")
+    if raw is not None and (normalized := raw.strip()):
+        return normalized.lower()
+    return "dummy" if dummy_mode else "ollama"
+
+
+def get_llm_provider(
+    name: str,
+    settings: dict[str, Any] | None = None,
+) -> LLMProvider:
+    """Factory for generation backends selected by `LLM_PROVIDER` / resolve helpers."""
+    normalized = (name or "").strip().lower()
+    if normalized == "dummy":
+        return DummyLLMProvider()
+    if normalized == "ollama":
+        return OllamaLLMProvider(settings=settings)
+    if normalized in {"anthropic", "openai"}:
+        raise NotImplementedError(
+            f"LLM provider {normalized!r} is not implemented yet "
+            f"(coming in a later milestone). Use 'ollama' or 'dummy' for now."
+        )
+    raise ValueError(
+        f"Unknown LLM provider {normalized!r}. "
+        f"Expected one of: {', '.join(sorted(SUPPORTED_LLM_PROVIDERS))}."
+    )
+
+
 def generate_answer(context: str, query: str, dummy_mode: bool = True) -> str:
-    """Generate a response from retrieved context and user question."""
+    """Generate a response from retrieved context and user question.
+
+    Provider selection: explicit `LLM_PROVIDER` env wins; when unset, `dummy_mode`
+    (and thus Streamlit's `USE_DUMMY_GENERATOR`) maps to dummy vs ollama.
+    """
     safe_query = _normalize_untrusted_text(query, max_chars=2000)
     if not safe_query:
         return "Please enter a non-empty question."
@@ -158,25 +249,6 @@ def generate_answer(context: str, query: str, dummy_mode: bool = True) -> str:
     if not safe_context:
         return "I could not find relevant information in the document to answer this question."
 
-    def _dummy_response() -> str:
-        return (
-            "This is a UI demo — no AI model is running here.\n\n"
-            "Upload and search work, but answers are not generated on this host.\n\n"
-            "For real grounded answers on your documents, request access to the "
-            "[live pilot](https://ai-doc-pilot.roxanatapia.dev)."
-        )
-
-    if dummy_mode:
-        return _dummy_response()
-
-    settings = load_generation_config()
-    try:
-        return _generate_with_ollama(context=safe_context, query=safe_query, settings=settings)
-    except Exception as exc:
-        logger.exception("Ollama generation failed: %s", exc)
-        if settings.get("fallback_to_dummy_on_error", False):
-            return (
-                "Ollama unavailable, falling back to dummy mode.\n\n"
-                f"{_dummy_response()}"
-            )
-        raise RuntimeError(f"Ollama generation unavailable: {exc}") from exc
+    provider_name = resolve_llm_provider_name(dummy_mode=dummy_mode)
+    provider = get_llm_provider(provider_name)
+    return provider.generate(safe_context, safe_query)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,8 +1,7 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
-from langchain.prompts import PromptTemplate
-
+from langchain_core.prompts import PromptTemplate
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_DIR = PROJECT_ROOT / "src"

--- a/tests/test_rag_generation.py
+++ b/tests/test_rag_generation.py
@@ -1,7 +1,8 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_DIR = PROJECT_ROOT / "src"
@@ -9,6 +10,13 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 import rag  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clear_llm_provider_env(monkeypatch) -> None:
+    """Keep legacy dummy_mode mapping tests independent of the host env."""
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    rag.load_generation_config.cache_clear()
 
 
 def test_generate_answer_dummy_mode_returns_placeholder() -> None:
@@ -128,7 +136,9 @@ def test_generate_answer_falls_back_to_dummy_when_enabled(monkeypatch) -> None:
     monkeypatch.setattr(
         rag,
         "_generate_with_ollama",
-        lambda context, query: (_ for _ in ()).throw(ConnectionError("connection refused")),
+        lambda context, query, settings=None: (_ for _ in ()).throw(
+            ConnectionError("connection refused")
+        ),
     )
     monkeypatch.setattr(
         rag,
@@ -150,7 +160,9 @@ def test_generate_answer_raises_structured_error_when_fallback_disabled(monkeypa
     monkeypatch.setattr(
         rag,
         "_generate_with_ollama",
-        lambda context, query, settings=None: (_ for _ in ()).throw(RuntimeError("model not found")),
+        lambda context, query, settings=None: (_ for _ in ()).throw(
+            RuntimeError("model not found")
+        ),
     )
     monkeypatch.setattr(
         rag,
@@ -195,3 +207,67 @@ def test_generate_answer_raises_structured_timeout_when_fallback_disabled(monkey
     else:
         raise AssertionError("Expected RuntimeError on timeout when fallback is disabled.")
 
+
+def test_resolve_llm_provider_name_env_wins_over_dummy_mode(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    assert rag.resolve_llm_provider_name(dummy_mode=True) == "ollama"
+
+    monkeypatch.setenv("LLM_PROVIDER", "dummy")
+    assert rag.resolve_llm_provider_name(dummy_mode=False) == "dummy"
+
+
+def test_resolve_llm_provider_name_maps_dummy_mode_when_env_unset() -> None:
+    assert rag.resolve_llm_provider_name(dummy_mode=True) == "dummy"
+    assert rag.resolve_llm_provider_name(dummy_mode=False) == "ollama"
+
+
+def test_get_llm_provider_dummy_and_ollama() -> None:
+    assert isinstance(rag.get_llm_provider("dummy"), rag.DummyLLMProvider)
+    assert isinstance(rag.get_llm_provider("OLLAMA"), rag.OllamaLLMProvider)
+
+
+def test_get_llm_provider_anthropic_and_openai_not_implemented() -> None:
+    with pytest.raises(NotImplementedError, match="anthropic"):
+        rag.get_llm_provider("anthropic")
+    with pytest.raises(NotImplementedError, match="openai"):
+        rag.get_llm_provider("openai")
+
+
+def test_get_llm_provider_unknown_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="Unknown LLM provider"):
+        rag.get_llm_provider("grok")
+
+
+def test_generate_answer_llm_provider_dummy_env(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "dummy")
+    answer = rag.generate_answer(
+        context="Section A says notice period is 30 days.",
+        query="What is the notice period?",
+        dummy_mode=False,
+    )
+    assert "no AI model is running here" in answer
+
+
+def test_generate_answer_llm_provider_ollama_env(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setattr(
+        rag,
+        "_generate_with_ollama",
+        lambda context, query, settings=None: "via env",
+    )
+    answer = rag.generate_answer(
+        context="Clause text",
+        query="What applies?",
+        dummy_mode=True,
+    )
+    assert answer == "via env"
+
+
+def test_generate_answer_llm_provider_anthropic_raises(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    with pytest.raises(NotImplementedError, match="anthropic"):
+        rag.generate_answer(
+            context="Clause text",
+            query="What applies?",
+            dummy_mode=False,
+        )


### PR DESCRIPTION
## Main contribution

This PR introduces a small `LLMProvider` seam and an `LLM_PROVIDER` env switch so generation can move between backends without rewriting RAG. Ollama stays the Compose default; `dummy` keeps local and CI paths working as before. Anthropic and OpenAI are reserved for follow-up adapters (#54), so the demo-ready tier can land one provider at a time without surprising deployers.

> **Takeaway:** One env value chooses the generator; retrieval and prompting stay shared.

## Summary
- Adds an `LLMProvider` protocol and factory in the generation path, selected by `LLM_PROVIDER` (`ollama` | `anthropic` | `openai` | `dummy`)
- Empty `LLM_PROVIDER` preserves today’s `USE_DUMMY_GENERATOR` / `dummy_mode` mapping
- `anthropic` and `openai` raise clear `NotImplementedError` until their adapters land
- Unit coverage for provider selection; prompt tests use a stable `langchain_core.prompts` import
- Documents the switch in `.env.example` and `configs/config.yaml` (no secrets in git)

## Test plan
- [ ] `LLM_PROVIDER=dummy` produces the same dummy-generator behavior as today
- [ ] `LLM_PROVIDER=ollama` (or unset with non-dummy config) keeps the existing Ollama path
- [ ] Unset / empty `LLM_PROVIDER` still honors `USE_DUMMY_GENERATOR` / `dummy_mode`
- [ ] `LLM_PROVIDER=anthropic` or `openai` fails with `NotImplementedError` (no silent fallback)
- [ ] `pytest` passes, including provider-selection unit tests
- [ ] Diff review: no API keys or real hostnames committed

Closes #53

Made with [Cursor](https://cursor.com)