### PR TITLE
M7.8-2: Anthropic adapter (Haiku demo tier)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,10 +36,14 @@ USE_DUMMY_GENERATOR=
 #   Compose / VPS / local self-host: leave empty or set ollama; keep
 #                     USE_DUMMY_GENERATOR=false (Compose sets false automatically)
 #   Streamlit Cloud: leave empty and rely on USE_DUMMY_GENERATOR (defaults true → dummy)
-#   anthropic: needs ANTHROPIC_API_KEY above; adapter lands in #54 (NotImplemented until then)
+#   anthropic: implemented; requires ANTHROPIC_API_KEY above (demo/video default)
 #   openai: reserved; not implemented yet
 # Non-empty LLM_PROVIDER always wins over USE_DUMMY_GENERATOR / YAML provider.
 LLM_PROVIDER=
+
+# Optional Anthropic model override when LLM_PROVIDER=anthropic.
+# Empty = claude-haiku-4-5-20251001 (code default in src/rag.py).
+ANTHROPIC_MODEL=
 
 # Optional Ollama generation overrides (empty = configs/config.yaml rag.generation)
 # Compose default: llama3.1:8b (matches configs/config.yaml).

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -35,7 +35,7 @@ Architecture diagram: [docs/product/architecture.md](docs/product/architecture.m
 
 Model weights persist in the `ollama_models` Docker volume across restarts.
 
-> **Deploy ≠ demo.** CPU Ollama is fine for private evaluation. For a polished walkthrough video, prefer a faster demo-tier model when available (see operator notes). Do not expect YouTube-smooth latency from `phi3:mini` on a small VPS.
+> **Deploy ≠ demo.** CPU Ollama is fine for private evaluation. For a polished walkthrough video, use the [Anthropic demo tier](#anthropic-demo-tier). Do not expect YouTube-smooth latency from `phi3:mini` on a small VPS.
 
 ---
 
@@ -171,8 +171,28 @@ Settings cascade: `.env` overrides → `configs/config.yaml` → built-in defaul
 | `SITE_ADDRESS` | *(empty)* | Subdomain for Let's Encrypt (e.g. `demo.example.com`) |
 | `ACME_EMAIL` | *(empty)* | Let's Encrypt registration email |
 | `CADDYFILE` | `./Caddyfile` | Set to `./Caddyfile.ip` for bare-IP mode |
+| `LLM_PROVIDER` | *(empty → ollama)* | Set to `anthropic` for the fast demo tier |
+| `ANTHROPIC_API_KEY` | *(empty)* | Required when `LLM_PROVIDER=anthropic`; `.env` only, never git |
+| `ANTHROPIC_MODEL` | `claude-haiku-4-5-20251001` | Optional Haiku override |
 
 Full list: [`.env.example`](.env.example)
+
+---
+
+## ⚡ Anthropic demo tier
+
+Use Anthropic when you need low-latency answers for demos or walkthrough recording. Ollama remains the self-host / air-gap path for private pilots.
+
+In `.env` only (never commit keys):
+
+```bash
+LLM_PROVIDER=anthropic
+ANTHROPIC_API_KEY=your-key-here
+# Optional; default is Claude Haiku
+# ANTHROPIC_MODEL=claude-haiku-4-5-20251001
+```
+
+Restart the app container after changing provider or key. Leave `LLM_PROVIDER` unset (or `ollama`) for the Compose + Ollama flow above.
 
 ---
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -39,6 +39,8 @@ rag:
     #   1. Non-empty env LLM_PROVIDER wins (ollama|anthropic|openai|dummy)
     #   2. Else dummy_mode / USE_DUMMY_GENERATOR → dummy vs ollama
     # YAML alone does not select the backend when LLM_PROVIDER is unset.
+    # anthropic: needs ANTHROPIC_API_KEY; model via ANTHROPIC_MODEL
+    #   (default claude-haiku-4-5-20251001). openai: not implemented yet.
     provider: ollama
     model: "llama3.1:8b"     # default local Ollama model (override with OLLAMA_MODEL)
     max_new_tokens: 384      # room for bullet answers (Round 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ python-dotenv>=1.2.1                       # .env support for API keys
 # Optional LLM providers (uncomment when needed for faster inference)
 # langchain-openai>=0.3.0                  # OpenAI GPT
 # langchain-groq>=0.2.0                    # Groq (fast & cheap)
-# langchain-anthropic>=0.3.0               # Claude models
+langchain-anthropic>=0.3.0                 # Claude models (M7.8 demo / video tier)
 langchain-ollama                           # Local Ollama integration (safest local start)
 ollama                                     # Ollama Python client
 

--- a/src/rag.py
+++ b/src/rag.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 import yaml
+from langchain_anthropic import ChatAnthropic
 from langchain_ollama import ChatOllama
 
 logger = logging.getLogger(__name__)
@@ -14,6 +15,8 @@ APP_ROOT = Path(__file__).resolve().parent.parent
 PROMPTS_PATH = APP_ROOT / "configs" / "prompts.yaml"
 CONFIG_PATH = APP_ROOT / "configs" / "config.yaml"
 SUPPORTED_LLM_PROVIDERS = frozenset({"ollama", "anthropic", "openai", "dummy"})
+# Current Anthropic Haiku (fast demo/video). Override with ANTHROPIC_MODEL.
+DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
 DEFAULT_PROMPT_TEMPLATE = (
     "You are a precise and concise legal assistant.\n"
     "Answer ONLY using information from the provided context.\n"
@@ -117,10 +120,12 @@ def load_generation_config() -> dict[str, Any]:
     # Env wins when set; YAML `provider` is informational default for operators.
     yaml_provider = str(generation.get("provider", "") or "").strip().lower()
     env_provider = _env_text("LLM_PROVIDER")
+    anthropic_model = _env_text("ANTHROPIC_MODEL") or DEFAULT_ANTHROPIC_MODEL
 
     return {
         "provider": (env_provider or yaml_provider or "").lower() or None,
         "model": model_override or default_model,
+        "anthropic_model": anthropic_model,
         "temperature": _env_float("OLLAMA_TEMPERATURE", float(generation.get("temperature", 0.3))),
         "top_p": _env_float("OLLAMA_TOP_P", float(generation.get("top_p", 0.9))),
         "max_new_tokens": _env_int(
@@ -175,6 +180,55 @@ def _generate_with_ollama(context: str, query: str, settings: dict[str, Any] | N
     return response.content.strip() if hasattr(response, "content") else str(response).strip()
 
 
+def _require_anthropic_api_key() -> str:
+    """Return ANTHROPIC_API_KEY or raise a clear operator-facing error."""
+    key = (os.getenv("ANTHROPIC_API_KEY") or "").strip()
+    if not key:
+        raise RuntimeError(
+            "ANTHROPIC_API_KEY is not set. Add it to your local .env "
+            "(never commit the key). Required when LLM_PROVIDER=anthropic."
+        )
+    return key
+
+
+def _generate_with_anthropic(
+    context: str,
+    query: str,
+    settings: dict[str, Any] | None = None,
+) -> str:
+    """Generate answer text using Anthropic Claude (ChatAnthropic)."""
+    if settings is None:
+        settings = load_generation_config()
+    api_key = _require_anthropic_api_key()
+    prompt_template = load_rag_prompt() if PROMPTS_PATH.exists() else DEFAULT_PROMPT_TEMPLATE
+    prompt = _format_prompt(prompt_template, context=context, query=query)
+    effective_temperature = settings["temperature"] if settings["do_sample"] else 0.0
+    model = str(settings.get("anthropic_model") or DEFAULT_ANTHROPIC_MODEL)
+
+    llm = ChatAnthropic(
+        model=model,
+        api_key=api_key,
+        temperature=effective_temperature,
+        max_tokens=int(settings["max_new_tokens"]),
+        top_p=settings["top_p"],
+        timeout=float(settings["timeout_seconds"]),
+    )
+    response = llm.invoke(prompt)
+    content = response.content if hasattr(response, "content") else response
+    if isinstance(content, list):
+        # ChatAnthropic may return a list of content blocks.
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+            elif hasattr(block, "text"):
+                parts.append(str(block.text))
+        return "".join(parts).strip()
+    return str(content).strip()
+
+
 class DummyLLMProvider:
     """UI-demo generator: fixed placeholder, no model calls."""
 
@@ -195,11 +249,26 @@ class OllamaLLMProvider:
         except Exception as exc:
             logger.exception("Ollama generation failed: %s", exc)
             if settings.get("fallback_to_dummy_on_error", False):
-                return (
-                    "Ollama unavailable, falling back to dummy mode.\n\n"
-                    f"{_dummy_response()}"
-                )
+                return f"Ollama unavailable, falling back to dummy mode.\n\n{_dummy_response()}"
             raise RuntimeError(f"Ollama generation unavailable: {exc}") from exc
+
+
+class AnthropicLLMProvider:
+    """Anthropic Claude generator (Haiku default) for fast demo / video recording."""
+
+    def __init__(self, settings: dict[str, Any] | None = None) -> None:
+        self._settings = settings
+
+    def generate(self, context: str, query: str) -> str:
+        settings = self._settings if self._settings is not None else load_generation_config()
+        try:
+            return _generate_with_anthropic(context=context, query=query, settings=settings)
+        except Exception as exc:
+            # Missing-key RuntimeError already has a clear message; keep it readable.
+            if isinstance(exc, RuntimeError) and "ANTHROPIC_API_KEY" in str(exc):
+                raise
+            logger.exception("Anthropic generation failed: %s", exc)
+            raise RuntimeError(f"Anthropic generation unavailable: {exc}") from exc
 
 
 def resolve_llm_provider_name(dummy_mode: bool = True) -> str:
@@ -225,10 +294,12 @@ def get_llm_provider(
         return DummyLLMProvider()
     if normalized == "ollama":
         return OllamaLLMProvider(settings=settings)
-    if normalized in {"anthropic", "openai"}:
+    if normalized == "anthropic":
+        return AnthropicLLMProvider(settings=settings)
+    if normalized == "openai":
         raise NotImplementedError(
-            f"LLM provider {normalized!r} is not implemented yet "
-            f"(coming in a later milestone). Use 'ollama' or 'dummy' for now."
+            "LLM provider 'openai' is not implemented yet "
+            "(optional after Anthropic). Use 'ollama', 'anthropic', or 'dummy'."
         )
     raise ValueError(
         f"Unknown LLM provider {normalized!r}. "

--- a/tests/test_rag_generation.py
+++ b/tests/test_rag_generation.py
@@ -16,6 +16,8 @@ import rag  # noqa: E402
 def _clear_llm_provider_env(monkeypatch) -> None:
     """Keep legacy dummy_mode mapping tests independent of the host env."""
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
     rag.load_generation_config.cache_clear()
 
 
@@ -221,14 +223,13 @@ def test_resolve_llm_provider_name_maps_dummy_mode_when_env_unset() -> None:
     assert rag.resolve_llm_provider_name(dummy_mode=False) == "ollama"
 
 
-def test_get_llm_provider_dummy_and_ollama() -> None:
+def test_get_llm_provider_dummy_ollama_and_anthropic() -> None:
     assert isinstance(rag.get_llm_provider("dummy"), rag.DummyLLMProvider)
     assert isinstance(rag.get_llm_provider("OLLAMA"), rag.OllamaLLMProvider)
+    assert isinstance(rag.get_llm_provider("anthropic"), rag.AnthropicLLMProvider)
 
 
-def test_get_llm_provider_anthropic_and_openai_not_implemented() -> None:
-    with pytest.raises(NotImplementedError, match="anthropic"):
-        rag.get_llm_provider("anthropic")
+def test_get_llm_provider_openai_not_implemented() -> None:
     with pytest.raises(NotImplementedError, match="openai"):
         rag.get_llm_provider("openai")
 
@@ -263,11 +264,105 @@ def test_generate_answer_llm_provider_ollama_env(monkeypatch) -> None:
     assert answer == "via env"
 
 
-def test_generate_answer_llm_provider_anthropic_raises(monkeypatch) -> None:
+def test_generate_answer_llm_provider_anthropic_env(monkeypatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "anthropic")
-    with pytest.raises(NotImplementedError, match="anthropic"):
-        rag.generate_answer(
-            context="Clause text",
-            query="What applies?",
-            dummy_mode=False,
-        )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(
+        rag,
+        "_generate_with_anthropic",
+        lambda context, query, settings=None: "via anthropic",
+    )
+    answer = rag.generate_answer(
+        context="Clause text",
+        query="What applies?",
+        dummy_mode=True,
+    )
+    assert answer == "via anthropic"
+
+
+def test_generate_with_anthropic_respects_config_and_prompt(monkeypatch) -> None:
+    created = {}
+
+    class FakeChatAnthropic:
+        def __init__(self, **kwargs):
+            created["kwargs"] = kwargs
+
+        def invoke(self, prompt):
+            created["prompt"] = prompt
+            return SimpleNamespace(content=" Cited answer. ")
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-not-real")
+    monkeypatch.setattr(rag, "ChatAnthropic", FakeChatAnthropic)
+    monkeypatch.setattr(
+        rag,
+        "load_generation_config",
+        lambda: {
+            "anthropic_model": "claude-haiku-4-5-20251001",
+            "temperature": 0.55,
+            "top_p": 0.9,
+            "max_new_tokens": 128,
+            "do_sample": False,
+            "timeout_seconds": 30,
+        },
+    )
+    monkeypatch.setattr(
+        rag,
+        "load_rag_prompt",
+        lambda: "CTX={context}\nQ={question}\nA=",
+    )
+
+    output = rag._generate_with_anthropic("Context text", "Question text")
+
+    assert output == "Cited answer."
+    assert created["kwargs"]["model"] == "claude-haiku-4-5-20251001"
+    assert created["kwargs"]["api_key"] == "test-key-not-real"
+    assert created["kwargs"]["max_tokens"] == 128
+    assert created["kwargs"]["timeout"] == 30.0
+    assert created["kwargs"]["top_p"] == 0.9
+    assert created["kwargs"]["temperature"] == 0.0
+    assert "CTX=Context text" in created["prompt"]
+    assert "Q=Question text" in created["prompt"]
+
+
+def test_generate_with_anthropic_missing_api_key_raises(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+        rag._generate_with_anthropic("context", "query")
+
+
+def test_anthropic_provider_generate_routes_and_invokes(monkeypatch) -> None:
+    captured = {}
+
+    def _fake_generate(context: str, query: str, settings=None) -> str:
+        captured["context"] = context
+        captured["query"] = query
+        captured["settings"] = settings
+        return "anthropic answer"
+
+    monkeypatch.setattr(rag, "_generate_with_anthropic", _fake_generate)
+    provider = rag.AnthropicLLMProvider(
+        settings={
+            "anthropic_model": "claude-haiku-4-5-20251001",
+            "temperature": 0.3,
+            "top_p": 0.9,
+            "max_new_tokens": 64,
+            "do_sample": False,
+            "timeout_seconds": 30,
+        }
+    )
+    answer = provider.generate("Section A: 30 days notice.", "Notice period?")
+    assert answer == "anthropic answer"
+    assert captured["query"] == "Notice period?"
+    assert "30 days" in captured["context"]
+
+
+def test_load_generation_config_anthropic_model_default_and_env(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
+    rag.load_generation_config.cache_clear()
+    cfg = rag.load_generation_config()
+    assert cfg["anthropic_model"] == rag.DEFAULT_ANTHROPIC_MODEL
+
+    monkeypatch.setenv("ANTHROPIC_MODEL", "claude-haiku-4-5")
+    rag.load_generation_config.cache_clear()
+    cfg = rag.load_generation_config()
+    assert cfg["anthropic_model"] == "claude-haiku-4-5"


### PR DESCRIPTION
## Main contribution

This PR adds an Anthropic generation backend (Haiku by default) so demos and walkthrough recordings get fast, cited answers without waiting on CPU Ollama. Operators flip `LLM_PROVIDER=anthropic` and keep `ANTHROPIC_API_KEY` in local `.env` only; self-host and air-gap deployments stay on Ollama. Deploy docs include a short stub for the switch.

## Summary
- Implements `AnthropicLLMProvider` on the shared prompt/context path (`LLM_PROVIDER=anthropic`)
- Default model `claude-haiku-4-5-20251001`; override with `ANTHROPIC_MODEL`
- Clear error when `ANTHROPIC_API_KEY` is missing; OpenAI remains unimplemented
- Enables `langchain-anthropic` in requirements; unit tests mock the API
- Documents env vars and a DEPLOYMENT.md demo-tier stub (no secrets in git)

## Test plan
- [x] pytest passes with mocked Anthropic (no live API calls in CI)
- [ ] Local optional: `LLM_PROVIDER=anthropic` with a real key returns a cited-style answer in <10s
- [ ] `.env.example` documents `ANTHROPIC_MODEL`; all secret values empty
- [ ] Diff review: no API keys or real hostnames committed

Closes #54

Made with [Cursor](https://cursor.com)