### PR TITLE
M7.8-4: Broaden pitch docs + non-legal sample + demo-script update

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -6,7 +6,7 @@ For IT buyers and operators standing up a single-VM pilot: Docker Compose + Olla
 
 Architecture diagram: [docs/product/architecture.md](docs/product/architecture.md)
 
-> **Takeaway:** Start Ollama first, pull a small model on CPU hosts, then bring up the app (and Caddy for HTTPS). Verify with curl before you invite evaluators.
+> **Takeaway:** Two LLM tiers, one Compose app: **self-host** (Ollama, private / air-gap) and **demo** (Anthropic Haiku, low latency for recording). Start Ollama first for the default path, then bring up the app (and Caddy for HTTPS).
 
 ---
 
@@ -179,9 +179,18 @@ Full list: [`.env.example`](.env.example)
 
 ---
 
-## ⚡ Anthropic demo tier
+## ⚡ Demo tier vs self-host tier
 
-Use Anthropic when you need low-latency answers for demos or walkthrough recording. Ollama remains the self-host / air-gap path for private pilots.
+Same app and embeddings; only the answer-generation backend changes.
+
+| Tier | Env | Best for | Honest limit |
+|------|-----|----------|--------------|
+| **Self-host** | `LLM_PROVIDER` unset or `ollama` | Private pilots, air-gap, documents stay on your VM | CPU Ollama can take tens of seconds per answer |
+| **Demo** | `LLM_PROVIDER=anthropic` + API key in `.env` | Walkthrough recording, snappy demos | Generation uses Anthropic; do not treat this as air-gap |
+
+Walkthrough storyboard: [docs/product/demo-script.md](docs/product/demo-script.md). Record with the demo tier; show the Ollama architecture for self-host.
+
+### Anthropic demo tier
 
 In `.env` only (never commit keys):
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Live Pilot](https://ai-doc-pilot.roxanatapia.dev) · [Public Demo](https://ai-doc-to-chat-demo.streamlit.app) · [Deployment Guide](DEPLOYMENT.md) · [Docs](docs/README.md)
 
-Your team's contracts, policies, and reports stay on **your server**. Upload a PDF, ask questions in plain language, and get sourced answers with page-level citations. Local embeddings and a local LLM by default; no requirement to send documents to an external API.
+Upload a confidential PDF (policies, SOPs, reports, contracts, or internal handbooks), ask questions in plain language, and get sourced answers with page-level citations. Documents stay on **your server**. Local embeddings by default; choose a local LLM for air-gap pilots, or a fast API model for demos.
 
 ---
 
@@ -13,11 +13,11 @@ Your team's contracts, policies, and reports stay on **your server**. Upload a P
 | | Where | What you get |
 |-|--------|--------------|
 | **Public demo** | [Streamlit Cloud](https://ai-doc-to-chat-demo.streamlit.app) | UI walkthrough (no login, no LLM) |
-| **Live pilot** | [ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev) | Real local AI, HTTPS, password-protected |
+| **Live pilot** | [ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev) | Real answers, HTTPS, password-protected |
 | **Your deployment** | Your VPS or cloud | Full private stack under your control |
 
 The live pilot is password-protected. Credentials are not published here.
-[Request access on Upwork](https://www.upwork.com/freelancers/roxanadev) for a walkthrough, or use the [sample NDA](docs/product/sample-nda.pdf) once you have access.
+[Request access on Upwork](https://www.upwork.com/freelancers/roxanadev) for a walkthrough, or once you have access use the [sample NDA](docs/product/sample-nda.pdf) or the [sample retention policy](docs/product/sample-policy.md) (export the markdown to PDF).
 
 **Demo video:** Coming after the demo-ready recording pass. Storyboard: [docs/product/demo-script.md](docs/product/demo-script.md).
 
@@ -33,21 +33,19 @@ flowchart LR
   B --> C[Extract text]
   C --> D[Local embeddings]
   D --> E[FAISS search]
-  E --> F[Local LLM]
+  E --> F[LLM on your stack]
   F --> G[Sourced answer]
 ```
 
-Everything runs on one VM. Your documents never leave your environment.
-
-More detail: [Architecture](docs/product/architecture.md).
+Everything runs on one VM. Your documents never leave your environment (self-host tier), or you can use a fast demo-tier LLM when latency matters. Details: [DEPLOYMENT.md](DEPLOYMENT.md) · [Architecture](docs/product/architecture.md).
 
 ---
 
 ## ✨ What it does well
 
-- **Contracts, NDAs, policies, SOPs, reports:** find clauses, obligations, dates, definitions
+- **Policies, SOPs, reports, contracts, handbooks:** find rules, obligations, dates, and definitions in the PDF you uploaded
 - **Sourced answers:** every response cites the page and excerpt it used
-- **Private by design:** local embeddings, local LLM, no cloud API required for self-host
+- **Private by design:** local embeddings; local LLM for air-gap, or a swappable API model for demos
 - **Auditable:** Docker Compose stack your IT team can review and reproduce
 
 ## ⚠️ Known limits (evaluation pilot)
@@ -55,17 +53,15 @@ More detail: [Architecture](docs/product/architecture.md).
 - **Session-based:** re-upload after restart; no shared document library yet
 - **Read, don't calculate:** finds printed numbers; does not sum or verify math
 - **Single document per session:** not enterprise search across file stores
-- **Assistant, not agent:** answers questions; does not integrate with CRM, email, or ticketing
+- **Document Q&A, not a support bot:** answers questions about the uploaded PDF; does not integrate with CRM, email, or ticketing
 
 ---
 
-## 🤝 For teams and consulting
+## 🤝 For teams evaluating a private stack
 
-> Organisations that can't send contracts to ChatGPT need a private stack they can evaluate, audit, and own. That's what this is.
+> Teams that cannot paste confidential PDFs into a public chatbot need a stack they can run, audit, and own. That is the aim here.
 
-I deploy private document AI from single-VM pilots to production-shaped stacks on your infrastructure: Docker Compose, HTTPS, basic auth, local Ollama. Evaluation usually takes a week; production hardening adds auth, persistence, and runbooks scoped to your environment.
-
-**Typical path:** pilot on a modest VM → validate answers on real documents → harden for production with your IT and legal team.
+Typical path: pilot on a modest VM → validate answers on your own sample documents → harden for production with your IT team (auth, persistence, runbooks) when you are ready.
 
 **Get in touch:** [Upwork](https://www.upwork.com/freelancers/roxanadev) · [GitHub](https://github.com/RoxanaTapia)
 
@@ -73,9 +69,9 @@ I deploy private document AI from single-VM pilots to production-shaped stacks o
 
 ## 🛠️ Self-host
 
-Follow the [Deployment Guide](DEPLOYMENT.md). It covers VPS sizing, HTTPS with Caddy, basic auth, and a step-by-step walkthrough.
+Follow the [Deployment Guide](DEPLOYMENT.md). It covers VPS sizing, HTTPS with Caddy, basic auth, the Anthropic **demo tier**, and the Ollama **self-host tier**.
 
-Evaluated on a sample NDA: [pilot evaluation](docs/product/pilot-evaluation.md).
+Eval corpus: [sample NDA](docs/product/sample-nda.pdf) · [sample retention policy](docs/product/sample-policy.md) · [pilot evaluation](docs/product/pilot-evaluation.md).
 
 **What's next on this product:** demo-ready recording and a calm walkthrough video. Deeper production (persistence, SSO, ops) lands when a pilot needs it. Full sequencing for contributors: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Start here when you want to understand the product, deploy it, or contribute. Do
 |-------------|------------|------|
 | **Evaluating the product** | [How it works](product/architecture.md) | [Demo storyboard](product/demo-script.md), [Pilot evaluation](product/pilot-evaluation.md) |
 | **Deploying on a VPS** | [DEPLOYMENT.md](../DEPLOYMENT.md) | [Architecture](product/architecture.md) |
-| **Browsing as a buyer** | [README](../README.md) | Live pilot + [sample NDA](product/sample-nda.pdf) |
+| **Browsing as a buyer** | [README](../README.md) | Live pilot + [sample NDA](product/sample-nda.pdf) / [sample policy](product/sample-policy.md) |
 | **Shipping milestones** | [PROJECT-DIRECTION](operators/PROJECT-DIRECTION.md) | [ROADMAP](operators/ROADMAP.md), [AGENTS.md](../AGENTS.md) |
 | **Testing OCR** | [Testing OCR](operators/testing-ocr.md) | Local Docker steps |
 
@@ -35,14 +35,14 @@ flowchart LR
 ```text
 docs/
   README.md          ← you are here
-  product/           ← how it works, demo, evaluation, sample NDA
+  product/           ← how it works, demo, evaluation, sample docs
   operators/         ← roadmap, direction, OCR testing
   archive/           ← older eval rounds (not primary reading)
 ```
 
 | Folder | Role |
 |--------|------|
-| [`product/`](product/) | Client-readable: architecture, demo script, evaluation summary, sample NDA |
+| [`product/`](product/) | Client-readable: architecture, demo script, evaluation, sample NDA + policy |
 | [`operators/`](operators/) | Roadmap, project direction, contributor how-tos |
 | [`archive/`](archive/) | Historical eval rounds; keep for reference, not day-one reading |
 
@@ -54,4 +54,4 @@ docs/
 - **Live pilot:** [ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev)
 - **Public UI demo:** [Streamlit Cloud](https://ai-doc-to-chat-demo.streamlit.app)
 - **Self-host:** [DEPLOYMENT.md](../DEPLOYMENT.md)
-- **Sample upload:** [product/sample-nda.pdf](product/sample-nda.pdf)
+- **Sample uploads:** [product/sample-nda.pdf](product/sample-nda.pdf) · [product/sample-policy.md](product/sample-policy.md) (export to PDF)

--- a/docs/product/demo-script.md
+++ b/docs/product/demo-script.md
@@ -4,24 +4,26 @@
 
 Public outline for a short walkthrough of the live pilot. A fuller recording script (pre-flight checks, operator notes, extended Q&A) lives in local **`docs-private/demo-script.md`** (gitignored, not in this repo).
 
-> **Takeaway:** Show privacy, upload, cited answers, and honest limits. Deploy proof and demo speed are different stories; say so on camera.
+> **Takeaway:** Show privacy, upload, cited answers, and honest limits. Record on the Anthropic demo tier for pace; close with the Ollama self-host architecture so buyers know both paths.
 
 ---
 
 ## 🎯 Audience
 
-A technical buyer or evaluator who saw the [public Streamlit demo](https://ai-doc-to-chat-demo.streamlit.app) and wants proof of grounded answers on infrastructure you control.
+A technical buyer or evaluator who saw the [public Streamlit demo](https://ai-doc-to-chat-demo.streamlit.app) and wants proof of grounded answers on infrastructure you control. Pitch is **confidential document Q&A** (policies, SOPs, reports, contracts), not a legal-only tool and not a website support chatbot.
 
 ---
 
 ## ✅ Before you record
 
 - Live pilot reachable at your password-protected URL ([DEPLOYMENT.md](../../DEPLOYMENT.md))
-- [Sample NDA](sample-nda.pdf) ready to upload
+- **Demo tier for recording:** `LLM_PROVIDER=anthropic` with `ANTHROPIC_API_KEY` in `.env` only (never on camera or in git). Prefer Haiku for snappy answers. See [Anthropic demo tier](../../DEPLOYMENT.md#anthropic-demo-tier).
+- Sample PDF ready: [sample NDA](sample-nda.pdf) and/or export [sample retention policy](sample-policy.md) to PDF
 - Model warm (one throwaway question after login)
 - Browser window about 1280×720; hide bookmarks and unrelated tabs
+- Architecture slide or tab ready: [architecture.md](architecture.md) for the Ollama self-host close
 
-> **Deploy ≠ demo.** CPU Ollama on a small VPS can take tens of seconds per answer. For a polished video, use a fast demo-tier model when that option is available, and still show the self-host path in the close.
+> **Two tiers.** Demo tier (Anthropic) is for smooth recording and low latency. Self-host tier (Compose + Ollama) is for private / air-gap evaluation. Say both on camera; do not imply the video latency is what CPU Ollama always feels like.
 
 ---
 
@@ -33,21 +35,23 @@ flowchart LR
   T --> U[Upload]
   U --> Q[Q&A]
   Q --> L[Limits]
-  L --> C[Close]
+  L --> C[Close + tiers]
 ```
 
 | Time | Scene | Show | Say (gist) |
 |------|-------|------|------------|
 | 0:00–0:30 | Hook | Public demo dummy banner → live pilot login | “The free demo is UI-only. Here is the same app with a real model on a private VM.” |
 | 0:30–1:00 | Trust | HTTPS lock, basic-auth login, privacy note | “Documents stay in memory for the session. Nothing is stored on the shared pilot.” |
-| 1:00–2:00 | Upload | Upload sample NDA; expand extracted text | “Upload a PDF. The app extracts text, chunks it, and builds a searchable index in-process.” |
-| 2:00–3:30 | Q&A | Two or three grounded questions with sources | Ask about parties, term, or a clause; point to page citations. |
-| 3:30–4:30 | Limits | One question the model should refuse or hedge | Show “not in document” or session scope. Contrast with generic chatbots. |
-| 4:30–5:00 | Close | [Architecture](architecture.md) or deployment guide | “Same Compose stack deploys on your VPS. Next step is evaluation on your documents.” |
+| 1:00–2:00 | Upload | Upload sample NDA or retention policy; expand extracted text | “Upload a PDF. Policies, SOPs, reports, contracts. The app extracts text, chunks it, and builds a searchable index in-process.” |
+| 2:00–3:30 | Q&A | Two or three grounded questions with sources | Ask about retention, parties, or a clause; point to page citations. Fast answers because this recording uses the Anthropic demo tier. |
+| 3:30–4:20 | Limits | One question the model should refuse or hedge | Show “not in document” or session scope. Contrast with generic chatbots that invent answers. |
+| 4:20–5:00 | Close + tiers | [Architecture](architecture.md) (Ollama box) + [DEPLOYMENT](../../DEPLOYMENT.md) | “What you saw used a fast demo-tier LLM for recording. For air-gap and full privacy, the same Compose stack runs Ollama on your VPS. Next step is evaluation on your documents.” |
 
 ---
 
-## 💬 Sample questions (sample NDA)
+## 💬 Sample questions
+
+### Sample NDA
 
 Use questions that match numbered sections so citations are obvious:
 
@@ -55,7 +59,24 @@ Use questions that match numbered sections so citations are obvious:
 2. What is the term or duration?
 3. What obligations apply to confidentiality?
 
+### Sample retention policy
+
+1. How long are customer contracts retained after the relationship ends?
+2. What happens to project working notes after a project closes?
+3. What rule applies when Legal issues a litigation hold?
+
 Expected answer quality: [Pilot evaluation](pilot-evaluation.md).
+
+---
+
+## 🗺️ Two-tier LLM story (say this once, clearly)
+
+| Tier | When | Backend |
+|------|------|---------|
+| **Demo** | Walkthrough video, snappy pilot demos | `LLM_PROVIDER=anthropic` (Haiku default) |
+| **Self-host** | Private eval, air-gap, documents must not leave your network | Compose + Ollama (`phi3:mini` on CPU, larger models if you have RAM/GPU) |
+
+Embeddings stay local either way. Switching tiers is an env change, not a rewrite. Details: [DEPLOYMENT.md](../../DEPLOYMENT.md).
 
 ---
 

--- a/docs/product/sample-policy.md
+++ b/docs/product/sample-policy.md
@@ -1,0 +1,72 @@
+# Sample internal document retention policy (fictional)
+
+## Background
+
+A short **fictional** internal policy so you can evaluate the pilot on something other than a legal agreement. Company names, roles, and dates are invented. Not real advice.
+
+For upload, export this file to PDF (Print → Save as PDF in a browser or editor, or `pandoc sample-policy.md -o sample-policy.pdf` if you have Pandoc). The [sample NDA](sample-nda.pdf) remains available for contract-style questions.
+
+> **Takeaway:** Use this for demos that show policies and SOPs, not only NDAs. Never upload real company documents to the shared pilot.
+
+---
+
+**NORTHWIND LABS: INTERNAL DOCUMENT RETENTION POLICY**
+
+**Effective date:** 1 March 2025  
+**Owner:** Information Governance Office  
+**Applies to:** All employees, contractors, and temporary staff with access to Northwind systems
+
+---
+
+## 1. Purpose
+
+This policy sets how long Northwind Labs keeps business documents and when they must be deleted or archived. It covers electronic files, shared drives, and scanned paper records stored in company systems.
+
+---
+
+## 2. Retention periods
+
+| Document type | Keep for | Then |
+|---------------|----------|------|
+| Customer contracts and amendments | 7 years after end of relationship | Archive or destroy per Legal |
+| Internal SOPs and process manuals | Until superseded + 2 years | Archive current version; delete obsolete copies |
+| Financial reports (board packs, audits) | 10 years | Secure archive |
+| Project working notes and drafts | 18 months after project close | Delete unless marked “retain for audit” |
+| HR performance records | Per HR handbook (usually 5 years after departure) | Restricted HR storage only |
+
+If a document type is not listed, ask the Information Governance Office before deleting.
+
+---
+
+## 3. Access and handling
+
+- Confidential documents must stay in approved company systems (SharePoint, encrypted drives). Personal cloud accounts are not allowed for company records.
+- Access is limited to people with a job-related need. Managers approve shared-folder access.
+- When an employee leaves, their manager and IT revoke access within one business day and transfer ownership of shared folders.
+
+---
+
+## 4. Remote work
+
+Staff may view approved documents on company-managed devices. Downloading confidential PDFs to personal laptops is prohibited unless the device is enrolled in MDM and disk encryption is enabled. Printouts of confidential material must be shredded when no longer needed.
+
+---
+
+## 5. Exceptions and holds
+
+Legal or Compliance may issue a **litigation hold**. While a hold is active, do not delete or alter covered documents, even if the normal retention period has ended. Holds are announced by email from Legal and remain until formally released.
+
+---
+
+## 6. Questions
+
+Contact `governance@northwind.example` (fictional address) for retention questions. Escalations go to the Chief Operating Officer.
+
+---
+
+> **Note for pilot testers:** Export to PDF, upload, and try:
+> 1. How long are customer contracts retained after the relationship ends?
+> 2. What happens to project working notes after a project closes?
+> 3. What rule applies when Legal issues a litigation hold?
+
+More on expected quality: [pilot evaluation](pilot-evaluation.md).


### PR DESCRIPTION
## Main contribution

This PR reframes the product as confidential document Q&A across policies, SOPs, reports, and contracts, not a legal-only tool. It adds a short non-legal sample policy for demos and updates the walkthrough script and deployment notes so recording uses the Anthropic demo tier while Ollama stays the honest self-host story.

## Summary
- README use cases broadened; calm framing, not a support chatbot pitch
- New `docs/product/sample-policy.md` for non-legal eval / demo questions
- Demo script: record with `LLM_PROVIDER=anthropic`; Ollama architecture close
- DEPLOYMENT: brief demo tier vs self-host tier table

## Test plan
- [ ] README does not read as legal-only
- [ ] Demo script reflects two-tier LLM story (Anthropic demo / Ollama self-host)
- [ ] Sample policy is present and linked from docs index / README as appropriate
- [ ] No secrets or client hostnames added

Closes #56

Made with [Cursor](https://cursor.com)