### PR TITLE
M7.8-3: Streamlit streaming for LLM responses

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -18,7 +18,7 @@ from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_community.vectorstores import FAISS
 from langchain_core.documents import Document
-from rag import generate_answer, load_generation_config
+from rag import generate_answer, generate_answer_stream, load_generation_config
 from ocr import is_likely_scanned_page as _is_likely_scanned_page, ocr_page_text as _ocr_page_text
 from retrieval_quality import (
     INSUFFICIENT_CONTEXT_ANSWER,
@@ -1597,6 +1597,8 @@ if query and query.strip() and chat_ready:
         timer_placeholder = st.empty()
         stop_timer = threading.Event()
         script_ctx = get_script_run_ctx()
+        need_stream_generation = False
+        total_start = time.perf_counter()
 
         def _thinking_timer_loop() -> None:
             if script_ctx is not None:
@@ -1616,7 +1618,6 @@ if query and query.strip() and chat_ready:
                 )
                 timer_thread.start()
             try:
-                total_start = time.perf_counter()
                 retrieval_start = time.perf_counter()
                 try:
                     candidate_limit = (
@@ -1683,23 +1684,7 @@ if query and query.strip() and chat_ready:
                         )
                         generation_elapsed_ms = 0.0
                     else:
-                        try:
-                            generation_start = time.perf_counter()
-                            st.session_state.last_answer = generate_answer(
-                                context=context,
-                                query=query,
-                                dummy_mode=st.session_state.dummy_generator_only,
-                            )
-                            generation_elapsed_ms = (
-                                time.perf_counter() - generation_start
-                            ) * 1000.0
-                            st.session_state.last_generation_error = None
-                        except Exception as e:
-                            generation_error = e
-                            generation_elapsed_ms = (
-                                time.perf_counter() - generation_start
-                            ) * 1000.0
-                            st.session_state.last_answer = None
+                        need_stream_generation = True
                 except (
                     AttributeError,
                     KeyError,
@@ -1720,13 +1705,45 @@ if query and query.strip() and chat_ready:
                     st.session_state.last_retrieved_docs = []
                     st.session_state.last_context = ""
                     st.session_state.last_answer = None
-
-                total_elapsed_ms = (time.perf_counter() - total_start) * 1000.0
             finally:
                 if timer_thread is not None:
                     stop_timer.set()
                     timer_thread.join(timeout=5.0)
         timer_placeholder.empty()
+
+        # Stream tokens after retrieval so the UI feels responsive; fall back if needed.
+        if need_stream_generation:
+            generation_start = time.perf_counter()
+            dummy_mode = st.session_state.dummy_generator_only
+            try:
+                try:
+                    streamed = st.write_stream(
+                        generate_answer_stream(
+                            context=context,
+                            query=query,
+                            dummy_mode=dummy_mode,
+                        )
+                    )
+                except Exception:
+                    full_answer = generate_answer(
+                        context=context,
+                        query=query,
+                        dummy_mode=dummy_mode,
+                    )
+                    streamed = st.write_stream(_stream_text_chunks(full_answer))
+                    if not streamed:
+                        streamed = full_answer
+                        st.markdown(full_answer)
+                st.session_state.last_answer = streamed if isinstance(streamed, str) else None
+                st.session_state.last_generation_error = None
+            except Exception as e:
+                generation_error = e
+                st.session_state.last_answer = None
+            generation_elapsed_ms = (
+                time.perf_counter() - generation_start
+            ) * 1000.0
+
+        total_elapsed_ms = (time.perf_counter() - total_start) * 1000.0
 
         if retrieval_warning:
             st.warning(retrieval_warning)

--- a/src/rag.py
+++ b/src/rag.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+from collections.abc import Iterator
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
@@ -38,10 +39,14 @@ DUMMY_UI_RESPONSE = (
 
 @runtime_checkable
 class LLMProvider(Protocol):
-    """Swappable generation backend used by `generate_answer`."""
+    """Swappable generation backend used by `generate_answer` / `generate_answer_stream`."""
 
     def generate(self, context: str, query: str) -> str:
         """Return an answer string grounded in `context` for `query`."""
+        ...
+
+    def stream(self, context: str, query: str) -> Iterator[str]:
+        """Yield answer text chunks for progressive UI (e.g. `st.write_stream`)."""
         ...
 
 
@@ -160,15 +165,35 @@ def _dummy_response() -> str:
     return DUMMY_UI_RESPONSE
 
 
-def _generate_with_ollama(context: str, query: str, settings: dict[str, Any] | None = None) -> str:
-    """Generate answer text using local Ollama runtime."""
-    if settings is None:
-        settings = load_generation_config()
-    prompt_template = load_rag_prompt() if PROMPTS_PATH.exists() else DEFAULT_PROMPT_TEMPLATE
-    prompt = _format_prompt(prompt_template, context=context, query=query)
-    effective_temperature = settings["temperature"] if settings["do_sample"] else 0.0
+def _content_to_text(content: Any) -> str:
+    """Normalize LangChain message content (str or content blocks) to plain text."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+            elif hasattr(block, "text"):
+                parts.append(str(block.text))
+        return "".join(parts)
+    return str(content)
 
-    llm = ChatOllama(
+
+def _prompt_for_generation(context: str, query: str) -> str:
+    """Build the RAG prompt from YAML template (or default)."""
+    prompt_template = load_rag_prompt() if PROMPTS_PATH.exists() else DEFAULT_PROMPT_TEMPLATE
+    return _format_prompt(prompt_template, context=context, query=query)
+
+
+def _build_ollama_llm(settings: dict[str, Any]) -> ChatOllama:
+    """Construct a ChatOllama client from generation settings."""
+    effective_temperature = settings["temperature"] if settings["do_sample"] else 0.0
+    return ChatOllama(
         model=settings["model"],
         temperature=effective_temperature,
         top_p=settings["top_p"],
@@ -176,8 +201,49 @@ def _generate_with_ollama(context: str, query: str, settings: dict[str, Any] | N
         num_ctx=settings["num_ctx"],
         timeout=settings["timeout_seconds"],
     )
-    response = llm.invoke(prompt)
-    return response.content.strip() if hasattr(response, "content") else str(response).strip()
+
+
+def _build_anthropic_llm(settings: dict[str, Any], api_key: str) -> ChatAnthropic:
+    """Construct a ChatAnthropic client from generation settings."""
+    effective_temperature = settings["temperature"] if settings["do_sample"] else 0.0
+    model = str(settings.get("anthropic_model") or DEFAULT_ANTHROPIC_MODEL)
+    return ChatAnthropic(
+        model=model,
+        api_key=api_key,
+        temperature=effective_temperature,
+        max_tokens=int(settings["max_new_tokens"]),
+        top_p=settings["top_p"],
+        timeout=float(settings["timeout_seconds"]),
+    )
+
+
+def _iter_llm_text_chunks(llm: Any, prompt: str) -> Iterator[str]:
+    """Yield non-empty text pieces from `llm.stream(prompt)`."""
+    for chunk in llm.stream(prompt):
+        text = _content_to_text(chunk.content if hasattr(chunk, "content") else chunk)
+        if text:
+            yield text
+
+
+def _generate_with_ollama(context: str, query: str, settings: dict[str, Any] | None = None) -> str:
+    """Generate answer text using local Ollama runtime."""
+    if settings is None:
+        settings = load_generation_config()
+    prompt = _prompt_for_generation(context, query)
+    response = _build_ollama_llm(settings).invoke(prompt)
+    return _content_to_text(response.content if hasattr(response, "content") else response).strip()
+
+
+def _stream_with_ollama(
+    context: str,
+    query: str,
+    settings: dict[str, Any] | None = None,
+) -> Iterator[str]:
+    """Stream answer text chunks from local Ollama (`ChatOllama.stream`)."""
+    if settings is None:
+        settings = load_generation_config()
+    prompt = _prompt_for_generation(context, query)
+    yield from _iter_llm_text_chunks(_build_ollama_llm(settings), prompt)
 
 
 def _require_anthropic_api_key() -> str:
@@ -200,33 +266,44 @@ def _generate_with_anthropic(
     if settings is None:
         settings = load_generation_config()
     api_key = _require_anthropic_api_key()
-    prompt_template = load_rag_prompt() if PROMPTS_PATH.exists() else DEFAULT_PROMPT_TEMPLATE
-    prompt = _format_prompt(prompt_template, context=context, query=query)
-    effective_temperature = settings["temperature"] if settings["do_sample"] else 0.0
-    model = str(settings.get("anthropic_model") or DEFAULT_ANTHROPIC_MODEL)
+    prompt = _prompt_for_generation(context, query)
+    response = _build_anthropic_llm(settings, api_key).invoke(prompt)
+    return _content_to_text(response.content if hasattr(response, "content") else response).strip()
 
-    llm = ChatAnthropic(
-        model=model,
-        api_key=api_key,
-        temperature=effective_temperature,
-        max_tokens=int(settings["max_new_tokens"]),
-        top_p=settings["top_p"],
-        timeout=float(settings["timeout_seconds"]),
-    )
-    response = llm.invoke(prompt)
-    content = response.content if hasattr(response, "content") else response
-    if isinstance(content, list):
-        # ChatAnthropic may return a list of content blocks.
-        parts = []
-        for block in content:
-            if isinstance(block, str):
-                parts.append(block)
-            elif isinstance(block, dict) and block.get("type") == "text":
-                parts.append(str(block.get("text", "")))
-            elif hasattr(block, "text"):
-                parts.append(str(block.text))
-        return "".join(parts).strip()
-    return str(content).strip()
+
+def _stream_with_anthropic(
+    context: str,
+    query: str,
+    settings: dict[str, Any] | None = None,
+) -> Iterator[str]:
+    """Stream answer text chunks from Anthropic (`ChatAnthropic.stream`)."""
+    if settings is None:
+        settings = load_generation_config()
+    api_key = _require_anthropic_api_key()
+    prompt = _prompt_for_generation(context, query)
+    yield from _iter_llm_text_chunks(_build_anthropic_llm(settings, api_key), prompt)
+
+
+def _stream_with_generate_fallback(
+    stream_fn,
+    generate_fn,
+    *,
+    label: str,
+) -> Iterator[str]:
+    """Yield from `stream_fn`; if stream fails before any chunk, yield `generate_fn()` once."""
+    yielded_any = False
+    try:
+        for chunk in stream_fn():
+            yielded_any = True
+            yield chunk
+    except Exception as exc:
+        if yielded_any:
+            logger.exception("%s streaming interrupted after partial output: %s", label, exc)
+            raise
+        logger.warning("%s streaming failed; falling back to generate(): %s", label, exc)
+        answer = generate_fn()
+        if answer:
+            yield answer
 
 
 class DummyLLMProvider:
@@ -234,6 +311,9 @@ class DummyLLMProvider:
 
     def generate(self, context: str, query: str) -> str:
         return _dummy_response()
+
+    def stream(self, context: str, query: str) -> Iterator[str]:
+        yield _dummy_response()
 
 
 class OllamaLLMProvider:
@@ -252,6 +332,14 @@ class OllamaLLMProvider:
                 return f"Ollama unavailable, falling back to dummy mode.\n\n{_dummy_response()}"
             raise RuntimeError(f"Ollama generation unavailable: {exc}") from exc
 
+    def stream(self, context: str, query: str) -> Iterator[str]:
+        settings = self._settings if self._settings is not None else load_generation_config()
+        yield from _stream_with_generate_fallback(
+            lambda: _stream_with_ollama(context=context, query=query, settings=settings),
+            lambda: self.generate(context, query),
+            label="Ollama",
+        )
+
 
 class AnthropicLLMProvider:
     """Anthropic Claude generator (Haiku default) for fast demo / video recording."""
@@ -269,6 +357,14 @@ class AnthropicLLMProvider:
                 raise
             logger.exception("Anthropic generation failed: %s", exc)
             raise RuntimeError(f"Anthropic generation unavailable: {exc}") from exc
+
+    def stream(self, context: str, query: str) -> Iterator[str]:
+        settings = self._settings if self._settings is not None else load_generation_config()
+        yield from _stream_with_generate_fallback(
+            lambda: _stream_with_anthropic(context=context, query=query, settings=settings),
+            lambda: self.generate(context, query),
+            label="Anthropic",
+        )
 
 
 def resolve_llm_provider_name(dummy_mode: bool = True) -> str:
@@ -307,19 +403,59 @@ def get_llm_provider(
     )
 
 
-def generate_answer(context: str, query: str, dummy_mode: bool = True) -> str:
-    """Generate a response from retrieved context and user question.
-
-    Provider selection: explicit `LLM_PROVIDER` env wins; when unset, `dummy_mode`
-    (and thus Streamlit's `USE_DUMMY_GENERATOR`) maps to dummy vs ollama.
-    """
+def _prepare_generation_inputs(
+    context: str,
+    query: str,
+) -> tuple[str, str] | str:
+    """Validate/sanitize inputs. Return `(safe_context, safe_query)` or an error message."""
     safe_query = _normalize_untrusted_text(query, max_chars=2000)
     if not safe_query:
         return "Please enter a non-empty question."
     safe_context = _normalize_untrusted_text(context, max_chars=12000)
     if not safe_context:
         return "I could not find relevant information in the document to answer this question."
+    return safe_context, safe_query
+
+
+def generate_answer(context: str, query: str, dummy_mode: bool = True) -> str:
+    """Generate a response from retrieved context and user question.
+
+    Provider selection: explicit `LLM_PROVIDER` env wins; when unset, `dummy_mode`
+    (and thus Streamlit's `USE_DUMMY_GENERATOR`) maps to dummy vs ollama.
+    """
+    prepared = _prepare_generation_inputs(context, query)
+    if isinstance(prepared, str):
+        return prepared
+    safe_context, safe_query = prepared
 
     provider_name = resolve_llm_provider_name(dummy_mode=dummy_mode)
     provider = get_llm_provider(provider_name)
     return provider.generate(safe_context, safe_query)
+
+
+def generate_answer_stream(
+    context: str,
+    query: str,
+    dummy_mode: bool = True,
+) -> Iterator[str]:
+    """Yield answer text chunks for progressive UI (`st.write_stream`).
+
+    Same provider selection and input validation as `generate_answer`. Providers
+    that support native streaming use `.stream()`; if streaming fails before any
+    chunk, the full `generate()` result is yielded as one chunk.
+    """
+    prepared = _prepare_generation_inputs(context, query)
+    if isinstance(prepared, str):
+        yield prepared
+        return
+    safe_context, safe_query = prepared
+
+    provider_name = resolve_llm_provider_name(dummy_mode=dummy_mode)
+    provider = get_llm_provider(provider_name)
+    stream_fn = getattr(provider, "stream", None)
+    if callable(stream_fn):
+        yield from stream_fn(safe_context, safe_query)
+        return
+    answer = provider.generate(safe_context, safe_query)
+    if answer:
+        yield answer

--- a/tests/test_rag_generation.py
+++ b/tests/test_rag_generation.py
@@ -366,3 +366,185 @@ def test_load_generation_config_anthropic_model_default_and_env(monkeypatch) -> 
     rag.load_generation_config.cache_clear()
     cfg = rag.load_generation_config()
     assert cfg["anthropic_model"] == "claude-haiku-4-5"
+
+
+def test_generate_answer_stream_dummy_yields_placeholder() -> None:
+    chunks = list(
+        rag.generate_answer_stream(
+            context="Section A says notice period is 30 days.",
+            query="What is the notice period?",
+            dummy_mode=True,
+        )
+    )
+    assert len(chunks) == 1
+    assert "no AI model is running here" in chunks[0]
+    assert "live pilot" in chunks[0]
+
+
+def test_generate_answer_stream_empty_query_yields_error() -> None:
+    chunks = list(
+        rag.generate_answer_stream(
+            context="Some context",
+            query="   ",
+            dummy_mode=True,
+        )
+    )
+    assert chunks == ["Please enter a non-empty question."]
+
+
+def test_dummy_provider_stream_yields_one_chunk() -> None:
+    provider = rag.DummyLLMProvider()
+    chunks = list(provider.stream("ctx", "q"))
+    assert chunks == [rag.DUMMY_UI_RESPONSE]
+
+
+def test_stream_with_anthropic_uses_langchain_stream(monkeypatch) -> None:
+    created = {}
+
+    class FakeChatAnthropic:
+        def __init__(self, **kwargs):
+            created["kwargs"] = kwargs
+
+        def stream(self, prompt):
+            created["prompt"] = prompt
+            yield SimpleNamespace(content="Cited ")
+            yield SimpleNamespace(content="answer.")
+
+        def invoke(self, prompt):
+            raise AssertionError("invoke should not be used for streaming path")
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-not-real")
+    monkeypatch.setattr(rag, "ChatAnthropic", FakeChatAnthropic)
+    monkeypatch.setattr(
+        rag,
+        "load_generation_config",
+        lambda: {
+            "anthropic_model": "claude-haiku-4-5-20251001",
+            "temperature": 0.3,
+            "top_p": 0.9,
+            "max_new_tokens": 64,
+            "do_sample": False,
+            "timeout_seconds": 30,
+        },
+    )
+    monkeypatch.setattr(rag, "load_rag_prompt", lambda: "CTX={context}\nQ={question}\nA=")
+
+    chunks = list(rag._stream_with_anthropic("Context text", "Question text"))
+
+    assert chunks == ["Cited ", "answer."]
+    assert created["kwargs"]["model"] == "claude-haiku-4-5-20251001"
+    assert created["kwargs"]["api_key"] == "test-key-not-real"
+    assert "CTX=Context text" in created["prompt"]
+    assert "Q=Question text" in created["prompt"]
+
+
+def test_generate_answer_stream_anthropic_env(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    def _fake_stream(context: str, query: str, settings=None):
+        yield "chunk-a"
+        yield "chunk-b"
+
+    monkeypatch.setattr(rag, "_stream_with_anthropic", _fake_stream)
+
+    chunks = list(
+        rag.generate_answer_stream(
+            context="Clause text",
+            query="What applies?",
+            dummy_mode=True,
+        )
+    )
+    assert chunks == ["chunk-a", "chunk-b"]
+
+
+def test_anthropic_provider_stream_falls_back_to_generate(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    def _failing_stream(context: str, query: str, settings=None):
+        raise ConnectionError("stream broken")
+        yield  # pragma: no cover — make this a generator
+
+    monkeypatch.setattr(rag, "_stream_with_anthropic", _failing_stream)
+    monkeypatch.setattr(
+        rag,
+        "_generate_with_anthropic",
+        lambda context, query, settings=None: "fallback full answer",
+    )
+
+    provider = rag.AnthropicLLMProvider(
+        settings={
+            "anthropic_model": "claude-haiku-4-5-20251001",
+            "temperature": 0.3,
+            "top_p": 0.9,
+            "max_new_tokens": 64,
+            "do_sample": False,
+            "timeout_seconds": 30,
+        }
+    )
+    chunks = list(provider.stream("Section A: 30 days.", "Notice?"))
+    assert chunks == ["fallback full answer"]
+
+
+def test_stream_with_ollama_uses_langchain_stream(monkeypatch) -> None:
+    created = {}
+
+    class FakeChatOllama:
+        def __init__(self, **kwargs):
+            created["kwargs"] = kwargs
+
+        def stream(self, prompt):
+            created["prompt"] = prompt
+            yield SimpleNamespace(content="Hello ")
+            yield SimpleNamespace(content="world")
+
+        def invoke(self, prompt):
+            raise AssertionError("invoke should not be used for streaming path")
+
+    monkeypatch.setattr(rag, "ChatOllama", FakeChatOllama)
+    monkeypatch.setattr(
+        rag,
+        "load_generation_config",
+        lambda: {
+            "model": "phi3:mini",
+            "temperature": 0.55,
+            "top_p": 0.9,
+            "max_new_tokens": 128,
+            "do_sample": False,
+            "fallback_to_dummy_on_error": False,
+            "num_ctx": 2048,
+            "timeout_seconds": 30,
+        },
+    )
+    monkeypatch.setattr(rag, "load_rag_prompt", lambda: "CTX={context}\nQ={question}\nA=")
+
+    chunks = list(rag._stream_with_ollama("Context text", "Question text"))
+
+    assert chunks == ["Hello ", "world"]
+    assert created["kwargs"]["model"] == "phi3:mini"
+    assert created["kwargs"]["temperature"] == 0.0
+    assert "CTX=Context text" in created["prompt"]
+
+
+def test_generate_answer_stream_ollama_falls_back_to_generate(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+
+    def _failing_stream(context: str, query: str, settings=None):
+        raise TimeoutError("stream timed out")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(rag, "_stream_with_ollama", _failing_stream)
+    monkeypatch.setattr(
+        rag,
+        "_generate_with_ollama",
+        lambda context, query, settings=None: "non-stream answer",
+    )
+
+    chunks = list(
+        rag.generate_answer_stream(
+            context="Clause text",
+            query="What applies?",
+            dummy_mode=False,
+        )
+    )
+    assert chunks == ["non-stream answer"]


### PR DESCRIPTION
## Main contribution

This PR streams assistant replies into the chat UI so demos and walkthroughs feel responsive, especially on the Anthropic demo tier. Tokens appear as they arrive after retrieval; if streaming fails, the UI falls back to a full answer without losing history or timing. Dummy mode still shows the familiar placeholder with no regression.

## Summary
- Adds `generate_answer_stream` and provider `.stream()` for Anthropic, Ollama, and dummy
- Early stream failures fall back to a single full `generate()` chunk
- Streamlit uses `st.write_stream` and persists the full answer into history/timing as before
- Unit tests cover stream paths with mocks

## Test plan
- [x] pytest passes (mocked stream paths)
- [ ] Dummy mode still shows the UI-demo placeholder in chat history
- [ ] With Anthropic/Ollama, assistant text appears incrementally after retrieval
- [ ] If streaming fails, a full answer still appears and is stored in history

Closes #55

Made with [Cursor](https://cursor.com)