### PR TITLE
chore: show active LLM in sidebar + streamlit-ux-designer roster

### DIFF
--- a/.cursor/agents/streamlit-ux-designer.md
+++ b/.cursor/agents/streamlit-ux-designer.md
@@ -1,0 +1,53 @@
+---
+name: streamlit-ux-designer
+description: >-
+  Streamlit UX specialist for an attractive, elegant private-RAG interface.
+  Plans short UI milestones, proposes GitHub issues, and implements visual/IA
+  polish in src/app.py (and small CSS/theme helpers if needed). Use for layout,
+  hierarchy, calm branding, chat readability, and client-facing presentation.
+  Must not edit Docker, FastAPI internals, or RAG provider logic.
+---
+
+You are the **streamlit-ux-designer** for ai-doc-to-chat-pipeline.
+
+## Owns
+
+- Visual and interaction design of `src/app.py` (layout, typography cues, spacing, sidebar IA, empty states, chat readability)
+- Short UX milestone plans and GitHub issue drafts (Outcome / Scope / DoD)
+- Optional small theme helpers colocated with the app (e.g. `src/ui_theme.py`) when needed for CSS injection — keep minimal
+
+## Must NOT touch
+
+- `Dockerfile`, `docker-compose*.yml`, Caddy
+- `src/rag.py` provider / generation logic (coordinate via orchestrator if a UI need requires a rag helper)
+- `src/api/**` internals
+- Secrets, real hostnames, or salesy “hire-me” chrome in the product UI
+
+## Design standards
+
+- Calm, confident, buyer-safe. One clear job per viewport region.
+- Prefer Streamlit-native patterns first; custom CSS only when it clearly improves hierarchy.
+- Client mode stays clean; developer diagnostics stay behind the existing toggle.
+- Preserve accessibility of sources, ready-state, and generator status (operators must see which LLM is active).
+- Match product pitch: confidential document Q&A with citations — not a support chatbot skin.
+- Follow `.cursor/rules/pythonic-rag-streamlit.mdc`.
+
+## Planning workflow (when asked to plan a milestone)
+
+1. Inspect current `src/app.py` UX (sidebar, upload, chat, sources, errors).
+2. Propose a **short** milestone (3–5 issues max), each shippable as one PR.
+3. For each issue: Outcome, Scope, DoD checkboxes, agent map (`streamlit-ux-designer` primary; `streamlit-engineer` only if wiring is heavy).
+4. Call out risks (regression on Cloud dummy mode, session state, citations).
+5. **Do not** open GitHub issues unless the orchestrator asks you to; draft markdown the orchestrator can paste.
+6. **Do not run `git commit`.**
+
+## Implementation workflow
+
+1. Minimal, reviewable diffs; prefer progressive polish over a rewrite.
+2. Manual test steps for client + developer modes.
+3. Report: UX before/after intent, files changed, suggested commits.
+
+## Blockers
+
+- Brand assets / copy the human must supply (logo, preferred accent) → Blocker card shape for orchestrator.
+- Conflicts with packaging / demo video framing → defer to docs-writer + human.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,14 +60,15 @@ Full detail: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
 | `deploy-engineer` | M7, M11 | `Dockerfile`, `docker-compose*.yml`, `Caddyfile`, `deploy/` | `src/app.py`, `src/rag.py` |
 | `config-guardian` | M7–M12 | `configs/**`, `.env.example` | Application logic |
 | `rag-core-engineer` | M7.8, M8, M9, M12 | `src/rag.py`, `src/rag/**`, `src/api/**` | Streamlit UI, Docker |
-| `streamlit-engineer` | All UI | `src/app.py` | Docker, FastAPI internals |
+| `streamlit-engineer` | Feature UI wiring | `src/app.py` session/chat/upload wiring | Docker, FastAPI internals, visual redesigns |
+| `streamlit-ux-designer` | M7.9 UI polish | Layout, IA, microcopy, chat/sources readability | Docker, FastAPI, RAG providers |
 | `docs-writer` | M7, M7.8, M10–M12 | `docs/**`, `DEPLOYMENT*.md`, **README**, PR/issue prose, **blocker card polish** | Python except docstrings |
 | `verifier` | All | Runs pytest/ruff; `tests/**` fixes only | Feature implementation |
 | `blocker-reporter` | All | Blocker summaries (structured) | Code changes |
 
 Invoke by role name. Files live in `.cursor/agents/`.
 
-**Train roster:** orchestrator always on; rag-core on #53/#54/#58/#59; config on #53/#54/#59; streamlit on #55/#60; docs-writer on #56/#57/packaging + pulses/blockers; verifier every issue; deploy-engineer idle unless compose/env deploy notes change.
+**Train roster:** orchestrator always on; rag-core on #53/#54/#58/#59; config on #53/#54/#59; streamlit on #55/#60; **streamlit-ux-designer on M7.9**; docs-writer on #56/#57/packaging + pulses/blockers; verifier every issue; deploy-engineer idle unless compose/env deploy notes change.
 
 ---
 
@@ -88,6 +89,15 @@ Invoke by role name. Files live in `.cursor/agents/`.
 | #55 M7.8-3 Streamlit streaming | streamlit-engineer | rag-core-engineer (review) | 1–2 | after #54 |
 | #56 M7.8-4 docs + sample doc | docs-writer | - | 1–2 | parallel #55 |
 | #57 M7.8-5 demo video + README | docs-writer | human records | 1 | after #54–#56 |
+
+### M7.9: Interface polish (short UX pass)
+
+| Issue | Primary | Secondary | Est. commits | Serial |
+|-------|---------|-----------|--------------|--------|
+| M7.9-1 visual foundation | streamlit-ux-designer | - | 1–2 | - |
+| M7.9-2 copy + empty/ready states | streamlit-ux-designer | docs-writer (tone) | 1 | after M7.9-1 |
+| M7.9-3 sidebar IA | streamlit-ux-designer | - | 1 | after M7.9-2 |
+| M7.9-4 chat + Sources readability | streamlit-ux-designer | streamlit-engineer (edge) | 1–2 | after M7.9-3 |
 
 ### M8: Thin FastAPI contract (after video + packaging)
 

--- a/docs/operators/ROADMAP.md
+++ b/docs/operators/ROADMAP.md
@@ -126,6 +126,25 @@ GitHub milestone: [M7.8](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/
 
 ---
 
+## M7.9: Interface polish (short UX pass)
+
+**Target:** part-time · **4 issues** · primary `streamlit-ux-designer` · serial on `src/app.py`
+
+Calm, elegant client UI for confidential document Q&A. Progressive polish only; preserve Generator status, ready-state, Sources, Cloud dummy banner, and developer diagnostics.
+
+| Issue | Outcome |
+|-------|---------|
+| M7.9-1 | Calm visual foundation (hero + light theme) |
+| M7.9-2 | Client copy and empty / ready states |
+| M7.9-3 | Sidebar information architecture |
+| M7.9-4 | Chat and Sources readability |
+
+**Serial order:** M7.9-1 → 2 → 3 → 4. Nice-to-have before demo recording (#57); does not block thin M8.
+
+**Out of scope:** Docker, FastAPI, RAG accuracy, inventing brand logos.
+
+---
+
 ## Demo video (after M7.8)
 
 Storyboard: [`docs/product/demo-script.md`](../product/demo-script.md). Record using **Anthropic demo tier**; show architecture slide for **Ollama self-host**. Tracked as [#57](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/57).

--- a/src/app.py
+++ b/src/app.py
@@ -18,7 +18,12 @@ from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_community.vectorstores import FAISS
 from langchain_core.documents import Document
-from rag import generate_answer, generate_answer_stream, load_generation_config
+from rag import (
+    generate_answer,
+    generate_answer_stream,
+    load_generation_config,
+    resolve_llm_provider_name,
+)
 from ocr import is_likely_scanned_page as _is_likely_scanned_page, ocr_page_text as _ocr_page_text
 from retrieval_quality import (
     INSUFFICIENT_CONTEXT_ANSWER,
@@ -106,6 +111,21 @@ def _presentation_mode() -> str:
 def _dev_toggle_allowed() -> bool:
     """Whether the sidebar shows the developer-mode toggle (opt-in only)."""
     return _env_bool("APP_ALLOW_DEV_TOGGLE", False)
+
+
+def _active_generator_label(dummy_mode: bool) -> str:
+    """Calm caption for the active generation backend (no secrets)."""
+    provider = resolve_llm_provider_name(dummy_mode=dummy_mode)
+    if provider == "dummy":
+        return "Dummy · UI placeholder (no LLM)"
+    settings = load_generation_config()
+    if provider == "anthropic":
+        model = settings.get("anthropic_model") or ""
+        return f"Anthropic · {model}" if model else "Anthropic"
+    if provider == "ollama":
+        model = settings.get("model") or ""
+        return f"Ollama · {model}" if model else "Ollama"
+    return provider
 
 
 def _inject_demo_styles() -> None:
@@ -1194,6 +1214,10 @@ if _dev_toggle_allowed():
     st.sidebar.caption(
         f"Presentation mode: {'Developer' if st.session_state.developer_mode else 'Client'}"
     )
+
+st.sidebar.markdown("**Generator**")
+st.sidebar.caption(_active_generator_label(st.session_state.dummy_generator_only))
+
 with st.sidebar.expander("About", expanded=False):
     st.markdown(
         """
@@ -1250,7 +1274,11 @@ if st.session_state.developer_mode:
         st.session_state.dummy_generator_only = st.checkbox(
             "Use dummy generator only (for testing)",
             value=st.session_state.dummy_generator_only,
-            help="ON: echo mode answer. OFF: try local Ollama and fallback if unavailable.",
+            help=(
+                "Used only when LLM_PROVIDER is unset. ON: placeholder answers. "
+                "OFF: Ollama. Non-empty LLM_PROVIDER (e.g. anthropic) always wins — "
+                "see Generator in the sidebar."
+            ),
         )
         st.caption(
             f"**Chunking:** header split **{'ON' if SPLIT_ON_LEGAL_HEADERS else 'OFF'}** "


### PR DESCRIPTION
## Main contribution

Operators can now see which generator is active (Dummy, Ollama, or Anthropic, plus model) in the Streamlit sidebar, so a local Anthropic setup is no longer invisible. The agent roster gains a Streamlit UX specialist and a short M7.9 interface-polish track for a calmer, more elegant client UI.

## Summary
- Sidebar **Generator** caption from `LLM_PROVIDER` / dummy mode (no secrets)
- Dummy-checkbox help clarifies that non-empty `LLM_PROVIDER` wins
- New agent: `streamlit-ux-designer` · AGENTS.md + ROADMAP M7.9 sketch

## Test plan
- [x] pytest passes
- [ ] Local: `LLM_PROVIDER=anthropic` → sidebar shows Anthropic · model
- [ ] Local: unset provider + dummy on → Dummy caption
- [ ] Client mode: Generator visible without developer toggle

Closes N/A (chore + roster; M7.9 issues opened separately)

Made with [Cursor](https://cursor.com)