### PR TITLE
docs: link M7.9 issues #70–#73

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,10 +94,10 @@ Invoke by role name. Files live in `.cursor/agents/`.
 
 | Issue | Primary | Secondary | Est. commits | Serial |
 |-------|---------|-----------|--------------|--------|
-| M7.9-1 visual foundation | streamlit-ux-designer | - | 1–2 | - |
-| M7.9-2 copy + empty/ready states | streamlit-ux-designer | docs-writer (tone) | 1 | after M7.9-1 |
-| M7.9-3 sidebar IA | streamlit-ux-designer | - | 1 | after M7.9-2 |
-| M7.9-4 chat + Sources readability | streamlit-ux-designer | streamlit-engineer (edge) | 1–2 | after M7.9-3 |
+| #70 M7.9-1 visual foundation | streamlit-ux-designer | - | 1–2 | - |
+| #71 M7.9-2 copy + empty/ready states | streamlit-ux-designer | docs-writer (tone) | 1 | after #70 |
+| #72 M7.9-3 sidebar IA | streamlit-ux-designer | - | 1 | after #71 |
+| #73 M7.9-4 chat + Sources readability | streamlit-ux-designer | streamlit-engineer (edge) | 1–2 | after #72 |
 
 ### M8: Thin FastAPI contract (after video + packaging)
 

--- a/docs/operators/ROADMAP.md
+++ b/docs/operators/ROADMAP.md
@@ -132,14 +132,16 @@ GitHub milestone: [M7.8](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/
 
 Calm, elegant client UI for confidential document Q&A. Progressive polish only; preserve Generator status, ready-state, Sources, Cloud dummy banner, and developer diagnostics.
 
-| Issue | Outcome |
-|-------|---------|
-| M7.9-1 | Calm visual foundation (hero + light theme) |
-| M7.9-2 | Client copy and empty / ready states |
-| M7.9-3 | Sidebar information architecture |
-| M7.9-4 | Chat and Sources readability |
+| Issue | Outcome | GitHub |
+|-------|---------|--------|
+| M7.9-1 | Calm visual foundation (hero + light theme) | [#70](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/70) |
+| M7.9-2 | Client copy and empty / ready states | [#71](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/71) |
+| M7.9-3 | Sidebar information architecture | [#72](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/72) |
+| M7.9-4 | Chat and Sources readability | [#73](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/73) |
 
-**Serial order:** M7.9-1 → 2 → 3 → 4. Nice-to-have before demo recording (#57); does not block thin M8.
+**Serial order:** #70 → #71 → #72 → #73. Nice-to-have before demo recording (#57); does not block thin M8.
+
+GitHub milestone: [M7.9 Interface polish](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/8)
 
 **Out of scope:** Docker, FastAPI, RAG accuracy, inventing brand logos.
 


### PR DESCRIPTION
## Main contribution

Points the operator roadmap and agent playbook at the new M7.9 interface-polish issues so the UX train has clear GitHub anchors.

## Summary
- ROADMAP + AGENTS link #70–#73 and milestone M7.9

## Test plan
- [ ] Links resolve to open issues under milestone M7.9


Made with [Cursor](https://cursor.com)