### PR TITLE
M7.9-1: Calm visual foundation (hero + light theme)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -40,6 +40,7 @@ from sectioning import (
     extract_target_section,
 )
 from streamlit.runtime.scriptrunner import add_script_run_ctx, get_script_run_ctx
+from ui_theme import inject_theme
 
 st.set_page_config(page_title="Ask your PDF · Private RAG", layout="wide")
 APP_ROOT = Path(__file__).resolve().parent.parent
@@ -49,9 +50,9 @@ TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
 # Stable for the lifetime of the Streamlit process (survives reruns, changes on container restart).
 _APP_BOOT_ID = str(os.getpid())
 
-# Client-demo microcopy — memorable pilot tone, serious for legal/ops buyers
+# Client-demo microcopy — calm confidential document Q&A
 _CLIENT_COPY = {
-    "hero_title": "🔒 Ask your PDF anything ✨",
+    "hero_title": "Ask your PDF anything",
     "hero_lead": (
         "Private, grounded answers with <strong>page-level sources</strong> — "
         "on infrastructure you control."
@@ -129,30 +130,12 @@ def _active_generator_label(dummy_mode: bool) -> str:
 
 
 def _inject_demo_styles() -> None:
-    """Light hero styling for client-facing demos (Streamlit-safe CSS)."""
-    st.markdown(
-        """
-        <style>
-        .app-hero { margin: -0.75rem 0 1.25rem 0; }
-        .app-hero__lead {
-            font-size: 1.15rem;
-            line-height: 1.55;
-            color: #4b5563;
-            margin: 0 0 0.45rem 0;
-        }
-        .app-hero__kicker {
-            font-size: 0.95rem;
-            color: #9ca3af;
-            margin: 0;
-        }
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
+    """Calm visual foundation for client-facing demos (Streamlit-safe CSS)."""
+    inject_theme()
 
 
 def _render_client_hero() -> None:
-    """Main headline — trustworthy, memorable, hire-me without being salesy."""
+    """Main headline — quiet title, clear lead/kicker hierarchy."""
     _inject_demo_styles()
     st.title(_CLIENT_COPY["hero_title"])
     st.markdown(

--- a/src/ui_theme.py
+++ b/src/ui_theme.py
@@ -1,0 +1,54 @@
+"""Minimal Streamlit-safe theme tokens for client-facing demos.
+
+Calm neutrals (ink / slate / soft paper). ``--app-accent`` is a future hook —
+leave unused until a brand accent is chosen; do not invent a logo here.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+
+# Cool neutrals — restrained, buyer-safe; not purple-gradient / glow chrome.
+_THEME_CSS = """
+:root {
+  --app-ink: #1c2430;
+  --app-slate: #5c6570;
+  --app-muted: #8a929c;
+  --app-paper: #f5f6f8;
+  --app-accent: #3d5a6c;
+}
+
+section.main h1 {
+  color: var(--app-ink);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  margin-bottom: 0.2rem;
+}
+
+.app-hero {
+  margin: 0 0 1.35rem 0;
+  padding: 0 0 1rem 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--app-ink) 10%, var(--app-paper));
+}
+
+.app-hero__lead {
+  font-size: 1.08rem;
+  line-height: 1.55;
+  color: var(--app-slate);
+  margin: 0.15rem 0 0.5rem 0;
+}
+
+.app-hero__kicker {
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: var(--app-muted);
+  margin: 0;
+  letter-spacing: 0.01em;
+}
+"""
+
+
+def inject_theme() -> None:
+    """Inject calm foundation CSS once per render (Streamlit-safe)."""
+    st.markdown(f"<style>{_THEME_CSS}</style>", unsafe_allow_html=True)


### PR DESCRIPTION
## Main contribution

Client-mode first paint is quieter and more intentional: the hero drops decorative emoji, and a small theme module sets calm ink/slate/paper tokens so the pilot reads as confidential document Q&A rather than a noisy demo skin.

## Summary
- Hero title: `Ask your PDF anything` (no decorative emoji)
- New `src/ui_theme.py` with CSS tokens + `--app-accent` hook (unused)
- Generator status, ready-state, Sources, Cloud banner, developer path preserved

## Test plan
- [x] pytest passes
- [ ] Client mode: calm hero hierarchy, no purple/glow chrome
- [ ] Generator caption still visible in sidebar
- [ ] Upload → ready → Sources still work; developer path intact

Closes #70

Made with [Cursor](https://cursor.com)