### PR TITLE
fix: Anthropic Haiku temperature/top_p conflict + honest errors

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -888,13 +888,44 @@ def _ollama_recovery_expander(*, expanded: bool = False) -> None:
         st.caption(f"CPU smoke-test order: {recommended_order_text}.")
 
 
+def _active_provider_for_errors() -> str:
+    """Provider name used when mapping generation failures to user-facing copy."""
+    return resolve_llm_provider_name(dummy_mode=st.session_state.get("dummy_generator_only", True))
+
+
 def _generation_failure_reason(exc: BaseException) -> tuple[str, str]:
     """Return (short_user_reason, normalized_error_text)."""
+    error_text = str(exc).lower()
+    provider = _active_provider_for_errors()
+
+    if provider == "anthropic":
+        if "api_key" in error_text or "authentication" in error_text or "401" in error_text:
+            reason = "Anthropic rejected the API key. Check `ANTHROPIC_API_KEY` in `.env`."
+        elif "temperature" in error_text and "top_p" in error_text:
+            reason = (
+                "Anthropic rejected the request (sampling settings). "
+                "Restart the app after updating, then retry."
+            )
+        elif "rate" in error_text or "429" in error_text:
+            reason = "Anthropic rate limit reached. Wait a moment, then retry."
+        elif "timeout" in error_text or "timed out" in error_text:
+            reason = "Anthropic timed out. Retry with a shorter question."
+        else:
+            detail = str(exc).strip()
+            # Prefer the API message body when present; keep it short for chat.
+            if "message': '" in detail:
+                try:
+                    reason = "Anthropic error: " + detail.split("message': '", 1)[1].split("'", 1)[0]
+                except IndexError:
+                    reason = "Could not generate an Anthropic answer right now."
+            else:
+                reason = "Could not generate an Anthropic answer right now."
+        return reason, error_text
+
     try:
         model_name = load_generation_config().get("model", "llama3.1:8b")
     except (FileNotFoundError, OSError, yaml.YAMLError, TypeError, ValueError, KeyError):
         model_name = "llama3.1:8b"
-    error_text = str(exc).lower()
     if "connection" in error_text or "refused" in error_text:
         reason = "Could not connect to Ollama. Start the Ollama server first."
     elif "not found" in error_text or "model" in error_text:
@@ -918,7 +949,8 @@ def _render_persistent_generation_error() -> None:
         return
     reason = err.get("user_reason", "Generation failed.")
     st.error(reason)
-    _ollama_recovery_expander(expanded=False)
+    if _active_provider_for_errors() == "ollama":
+        _ollama_recovery_expander(expanded=False)
     detail = err.get("detail")
     if st.session_state.developer_mode and detail:
         with st.expander("Technical details", expanded=False):

--- a/src/rag.py
+++ b/src/rag.py
@@ -204,7 +204,11 @@ def _build_ollama_llm(settings: dict[str, Any]) -> ChatOllama:
 
 
 def _build_anthropic_llm(settings: dict[str, Any], api_key: str) -> ChatAnthropic:
-    """Construct a ChatAnthropic client from generation settings."""
+    """Construct a ChatAnthropic client from generation settings.
+
+    Haiku 4.5+ rejects requests that set both ``temperature`` and ``top_p``.
+    Prefer temperature only (deterministic 0.0 when ``do_sample`` is false).
+    """
     effective_temperature = settings["temperature"] if settings["do_sample"] else 0.0
     model = str(settings.get("anthropic_model") or DEFAULT_ANTHROPIC_MODEL)
     return ChatAnthropic(
@@ -212,7 +216,6 @@ def _build_anthropic_llm(settings: dict[str, Any], api_key: str) -> ChatAnthropi
         api_key=api_key,
         temperature=effective_temperature,
         max_tokens=int(settings["max_new_tokens"]),
-        top_p=settings["top_p"],
         timeout=float(settings["timeout_seconds"]),
     )
 

--- a/tests/test_rag_generation.py
+++ b/tests/test_rag_generation.py
@@ -318,7 +318,8 @@ def test_generate_with_anthropic_respects_config_and_prompt(monkeypatch) -> None
     assert created["kwargs"]["api_key"] == "test-key-not-real"
     assert created["kwargs"]["max_tokens"] == 128
     assert created["kwargs"]["timeout"] == 30.0
-    assert created["kwargs"]["top_p"] == 0.9
+    # Haiku 4.5 rejects temperature + top_p together; we send temperature only.
+    assert "top_p" not in created["kwargs"]
     assert created["kwargs"]["temperature"] == 0.0
     assert "CTX=Context text" in created["prompt"]
     assert "Q=Question text" in created["prompt"]


### PR DESCRIPTION
## Main contribution

Local Anthropic demo was actually calling Claude, but Haiku 4.5 rejected requests that set both `temperature` and `top_p`. The UI then misread that failure as a missing local `llama3.1:8b` Ollama model. This fix sends temperature only to Anthropic and shows provider-aware error copy (Ollama recovery expander only for Ollama).

## Summary
- `_build_anthropic_llm`: drop `top_p` (temperature only)
- `_generation_failure_reason`: Anthropic-specific messages
- Persistent error banner: Ollama help expander only when provider is ollama
- Unit test updated for Anthropic kwargs

## Test plan
- [x] pytest passes
- [ ] Local: `LLM_PROVIDER=anthropic` + key → ask a question → streaming answer (no llama error)
- [ ] Sidebar Generator still shows Anthropic · Haiku
- [ ] Force an Anthropic failure → error mentions Anthropic, not Ollama pull


Made with [Cursor](https://cursor.com)