### PR TITLE
docs: M7.95 Sources trust milestone and train plan

### DIFF
--- a/.cursor/agents/rag-core-engineer.md
+++ b/.cursor/agents/rag-core-engineer.md
@@ -1,22 +1,23 @@
 ---
 name: rag-core-engineer
 description: >-
-  RAG core and FastAPI engineer. Owns src/rag.py, src/rag/ package, src/api/, LLM
-  provider interfaces, generation backends. Use for M7.8, M8, M9. Triggers: FastAPI,
-  LLMProvider, Anthropic, Ollama generation refactor. Must not edit Streamlit or Docker.
+  RAG core and FastAPI engineer. Owns src/rag.py, src/sectioning.py,
+  src/retrieval_quality.py, src/rag/ package, src/api/, LLM providers, chunking and
+  Sources-ranking helpers. Use for M7.8, M7.95, M8, M9. Must not edit Streamlit
+  layout or Docker.
 ---
 
 You are the **rag-core-engineer** for ai-doc-to-chat-pipeline.
 
 ## Owns
 
-- `src/rag.py`, future `src/rag/**`
+- `src/rag.py`, `src/sectioning.py`, `src/retrieval_quality.py`, future `src/rag/**`
 - `src/api/**` (M8+)
-- Tests for RAG generation and API routes
+- Tests for RAG generation, sectioning, retrieval-quality helpers, and API routes
 
 ## Must NOT touch
 
-- `src/app.py` (streamlit-engineer)
+- `src/app.py` layout / session UX (streamlit-engineer / streamlit-ux-designer)
 - `Dockerfile`, `docker-compose*.yml` (deploy-engineer)
 
 ## Standards

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,10 @@ How this repo uses Cursor **rules**, **subagents**, and **slash commands** to de
 | Milestone | Goal | Status |
 |-----------|------|--------|
 | **M7** | Reference deployment (Docker, Compose, Caddy, live pilot) | ✅ Shipped |
-| **M7.8** | Demo-ready tier: swappable LLM, Anthropic path, streaming | 🚧 Next (#53–#57) |
-| **Video / packaging** | Walkthrough linked from README; calm product framing | After M7.8 |
+| **M7.8** | Demo-ready tier: swappable LLM, Anthropic path, streaming | ✅ Shipped (#53–#56; #57 video open) |
+| **M7.9** | Interface polish | ✅ Shipped (#70–#73) |
+| **M7.95** | Sources trust | 🚧 Next (#80–#83) |
+| **Video / packaging** | Walkthrough linked from README; calm product framing | After M7.95 (#57) |
 | **M8** | Thin FastAPI `/health`, `/chat`, OpenAPI | After packaging (#58–#60) |
 | **M8.5** | Eval report export | Optional (#61) |
 | **M9–M11** | Persist, access control, ops runbook | Client-triggered |
@@ -30,21 +32,22 @@ Full detail: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
 
 ## 🎯 Current focus
 
-- **Ship next:** M7.8 (#53–#57) → demo video → packaging → thin M8 (#58–#60).
+- **Ship next:** M7.95 Sources trust (#80–#83) → demo video (#57) → packaging → thin M8 (#58–#60).
 - **Then pause** this repo for the Support MVP sibling unless a paid engagement needs more depth here.
 - **Later / on demand:** M8.5, M9–M11.
 
 ### Delivery train (default queue)
 
 ```text
-#53 → #54 → (#55 ∥ #56) → #57 → packaging → #58 → #59 → #60 → [pause]
+M7.8 ✅ → M7.9 ✅ → (#80 ∥ #83) → #81 → #82 → #57 → packaging → #58 → #59 → #60 → [pause]
 ```
 
 | Wave | Work | Agents | Human? |
 |------|------|--------|--------|
-| 1 | **#53** LLMProvider + env | rag-core → config-guardian → verifier | Only if design ambiguous |
-| 2 | **#54** Anthropic adapter | rag-core → config-guardian → verifier | Secrets on VPS/local only |
-| 3a ∥ 3b | **#55** streaming · **#56** docs | streamlit (+ rag review) ∥ docs-writer | None if files stay split |
+| — | M7.8 + M7.9 | shipped | — |
+| 1a ∥ 1b | **#80** Sources cap · **#83** header chunking | config + streamlit ∥ rag-core → verifier | None |
+| 2 | **#81** sort Sources | rag-core → streamlit → verifier | None |
+| 3 | **#82** answer-overlap filter | rag-core → streamlit → verifier | None |
 | 4 | **#57** demo video + README | docs-writer prepares; **human records** | **Hard gate:** video URL |
 | 5 | **Packaging** | docs-writer | Soft: thumbnail / links OK |
 | 6–8 | **#58 → #59 → #60** thin M8 | rag-core → config → streamlit → verifier | Rare |
@@ -59,8 +62,8 @@ Full detail: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
 | `milestone-orchestrator` | All | Queue, branches, commits, PRs, **merges**, pulses | Direct app code edits |
 | `deploy-engineer` | M7, M11 | `Dockerfile`, `docker-compose*.yml`, `Caddyfile`, `deploy/` | `src/app.py`, `src/rag.py` |
 | `config-guardian` | M7–M12 | `configs/**`, `.env.example` | Application logic |
-| `rag-core-engineer` | M7.8, M8, M9, M12 | `src/rag.py`, `src/rag/**`, `src/api/**` | Streamlit UI, Docker |
-| `streamlit-engineer` | Feature UI wiring | `src/app.py` session/chat/upload wiring | Docker, FastAPI internals, visual redesigns |
+| `rag-core-engineer` | M7.8, M7.95, M8, M9, M12 | `src/rag.py`, `src/sectioning.py`, `src/retrieval_quality.py`, `src/rag/**`, `src/api/**` | Streamlit layout polish, Docker |
+| `streamlit-engineer` | Feature UI wiring | `src/app.py` session/chat/upload/Sources payload wiring | Docker, FastAPI internals, visual redesigns |
 | `streamlit-ux-designer` | M7.9 UI polish | Layout, IA, microcopy, chat/sources readability | Docker, FastAPI, RAG providers |
 | `docs-writer` | M7, M7.8, M10–M12 | `docs/**`, `DEPLOYMENT*.md`, **README**, PR/issue prose, **blocker card polish** | Python except docstrings |
 | `verifier` | All | Runs pytest/ruff; `tests/**` fixes only | Feature implementation |
@@ -68,7 +71,7 @@ Full detail: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
 
 Invoke by role name. Files live in `.cursor/agents/`.
 
-**Train roster:** orchestrator always on; rag-core on #53/#54/#58/#59; config on #53/#54/#59; streamlit on #55/#60; **streamlit-ux-designer on M7.9**; docs-writer on #56/#57/packaging + pulses/blockers; verifier every issue; deploy-engineer idle unless compose/env deploy notes change.
+**Train roster:** orchestrator always on; **rag-core + config + streamlit on M7.95 (#80–#83)**; streamlit-ux only if Sources captions need polish; docs-writer on #57/packaging + pulses; verifier every issue; deploy-engineer idle unless compose/env deploy notes change.
 
 ---
 
@@ -98,6 +101,15 @@ Invoke by role name. Files live in `.cursor/agents/`.
 | #71 M7.9-2 copy + empty/ready states | streamlit-ux-designer | docs-writer (tone) | 1 | after #70 |
 | #72 M7.9-3 sidebar IA | streamlit-ux-designer | - | 1 | after #71 |
 | #73 M7.9-4 chat + Sources readability | streamlit-ux-designer | streamlit-engineer (edge) | 1–2 | after #72 |
+
+### M7.95: Sources trust (before video)
+
+| Issue | Primary | Secondary | Est. commits | Serial |
+|-------|---------|-----------|--------------|--------|
+| #80 M7.95-1 Sources display cap | config-guardian | streamlit-engineer | 1 | ∥ #83 |
+| #81 M7.95-2 sort on-section → score | rag-core-engineer | streamlit-engineer | 1–2 | after #80; prefer after #83 |
+| #82 M7.95-3 answer-overlap filter | rag-core-engineer | streamlit-engineer | 2 | after #81 |
+| #83 M7.95-4 tighter header chunking | rag-core-engineer | config-guardian | 1–2 | ∥ #80 |
 
 ### M8: Thin FastAPI contract (after video + packaging)
 

--- a/docs/operators/PROJECT-DIRECTION.md
+++ b/docs/operators/PROJECT-DIRECTION.md
@@ -119,23 +119,24 @@ After each issue, you should answer **without opening Cursor**:
 
 ### Phase 1: Demo, video & packaging 🚧 START HERE
 
-**Milestones:** M7.8 ([#53–#57](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/7)) → video (#57) → packaging checklist in [ROADMAP.md](ROADMAP.md)
+**Milestones:** M7.8 ✅ → M7.9 ✅ → **M7.95 Sources trust** ([#80–#83](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/9)) → video (#57) → packaging checklist in [ROADMAP.md](ROADMAP.md)
 
 | # | Issue | Agent map | You learn |
 |---|-------|-----------|-----------|
-| 53 | LLMProvider + env switch | rag-core-engineer, config-guardian | Protocol pattern; config-driven backends |
-| 54 | Anthropic adapter | rag-core-engineer, config-guardian | API keys, Haiku vs Sonnet |
-| 55 | Streamlit streaming | streamlit-engineer | UX; generators |
-| 56 | Docs + non-legal sample | docs-writer | Positioning; eval ≠ vertical |
+| 53–56 | M7.8 demo tier | (shipped) | Provider switch; streaming; pitch |
+| 70–73 | M7.9 UI polish | (shipped) | Calm client UI |
+| 80 | Sources display cap | config-guardian, streamlit-engineer | Display vs retrieval `top_k` |
+| 81 | Sort Sources | rag-core-engineer, streamlit-engineer | On-section + score ordering |
+| 82 | Answer-overlap filter | rag-core-engineer, streamlit-engineer | Honest citations with fallback |
+| 83 | Header-aware chunking | rag-core-engineer, config-guardian | TOC bleed vs section bodies |
 | 57 | Record video + README link | docs-writer (you record) | Walkthrough asset |
 
 ```mermaid
 flowchart LR
-  A["/ship-issue #53"] --> B["#54"]
-  B --> C["#55"]
-  B --> D["#56 parallel"]
-  C --> E["#57 record"]
-  D --> E
+  A["M7.8 + M7.9"] --> B["#80 ∥ #83"]
+  B --> C["#81"]
+  C --> D["#82"]
+  D --> E["#57 record"]
   E --> F[Packaging]
   F --> G[Thin M8]
   G --> H[Phase pause]

--- a/docs/operators/ROADMAP.md
+++ b/docs/operators/ROADMAP.md
@@ -17,8 +17,10 @@ For contributors and operators. Moves the pipeline from a **reference deployment
 | Milestone | Goal | Proof of done | Priority |
 |-----------|------|---------------|----------|
 | **M7** | Reference deployment | Live HTTPS pilot + `DEPLOYMENT.md` | ✅ Done |
-| **M7.8** | Demo-ready tier | Swappable LLM, streaming, recordable walkthrough | **Ship next** |
-| **Video (#57)** | Published walkthrough | Link in README | After M7.8 |
+| **M7.8** | Demo-ready tier | Swappable LLM, streaming, recordable walkthrough | ✅ Done |
+| **M7.9** | Interface polish | Calm client UI | ✅ Done |
+| **M7.95** | Sources trust | Fewer, ranked, answer-overlapping citations | **Ship next** |
+| **Video (#57)** | Published walkthrough | Link in README | Prefer after M7.95 |
 | **Packaging** | Calm product framing | Clear pilot + Cloud + video links | After video |
 | **M8** | Thin FastAPI contract | OpenAPI `/health`, `/chat` | After packaging |
 | **M8.5** | Eval harness export | Before/after retrieval report | Optional |
@@ -141,13 +143,49 @@ Calm, elegant client UI for confidential document Q&A. Progressive polish only; 
 
 **Serial order:** #70 → #71 → #72 → #73. Nice-to-have before demo recording (#57); does not block thin M8.
 
-GitHub milestone: [M7.9 Interface polish](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/8)
+**Out of scope:** Docker, FastAPI, inventing brand logos.
 
-**Out of scope:** Docker, FastAPI, RAG accuracy, inventing brand logos.
+GitHub milestone: [M7.9 Interface polish](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/8) ✅ closed
 
 ---
 
-## Demo video (after M7.8)
+## M7.95: Sources trust
+
+**Background**
+
+Cited answers only help when Sources feels like an audit trail: short, ranked, and tied to what the model said. This slice tightens display ranking and chunk boundaries. It is not a model swap.
+
+> **Takeaway:** Fewer, better-ranked Sources that overlap the answer. Prefer shipping before the walkthrough video (#57).
+
+**Target:** part-time · **4 issues** · primary `rag-core-engineer` + `streamlit-engineer` · knobs via `config-guardian`
+
+| Issue | Outcome | GitHub |
+|-------|---------|--------|
+| M7.95-1 | Cap panel with `sources_display_max` (default 3) | [#80](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/80) |
+| M7.95-2 | Sort: on-section first, then similarity | [#81](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/81) |
+| M7.95-3 | Answer-overlap filter with safe fallback | [#82](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/82) |
+| M7.95-4 | Tighter chunking around section headers | [#83](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/83) |
+
+**Delivery train**
+
+```text
+(#80 ∥ #83) → #81 → #82 → [docs sync if needed]
+```
+
+| Wave | Work | Agents | Parallel notes |
+|------|------|--------|----------------|
+| 1a ∥ 1b | **#80** display cap · **#83** section chunking | config + streamlit ∥ rag-core | YAML/UI vs `sectioning.py` |
+| 2 | **#81** sort on-section → score | rag-core → streamlit | After #83 preferred |
+| 3 | **#82** answer-overlap + fallback | rag-core → streamlit | After #80 + #81 |
+| * | verifier | every issue | pytest green before PR |
+
+**Out of scope:** New LLM providers, FastAPI, full UI redesign.
+
+GitHub milestone: [M7.95 Sources trust](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/9)
+
+---
+
+## Demo video (after M7.8 / prefer after M7.95)
 
 Storyboard: [`docs/product/demo-script.md`](../product/demo-script.md). Record using **Anthropic demo tier**; show architecture slide for **Ollama self-host**. Tracked as [#57](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/57).
 


### PR DESCRIPTION
## Main contribution

Adds **M7.95 · Sources trust** to the operator roadmap and agent playbook: a short train to make Sources a reliable audit trail (fewer items, better ranking, answer overlap, less TOC bleed) before recording the walkthrough. No new specialist roles — existing rag-core, streamlit-engineer, and config-guardian own the work.

## Summary
- ROADMAP + PROJECT-DIRECTION: milestone, issues #80–#83, delivery waves
- AGENTS.md: train queue and issue→agent map
- rag-core-engineer ownership extended to `sectioning.py` / `retrieval_quality.py`

## Test plan
- [ ] Milestone [M7.95](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/9) lists #80–#83
- [ ] Train order matches: (#80 ∥ #83) → #81 → #82 → #57


Made with [Cursor](https://cursor.com)