### PR TITLE
M7.95-1: Cap Sources panel (sources_display_max=3)

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -12,7 +12,8 @@ rag:
   fetch_k: 75                # candidate pool size before MMR reranking
   early_page_max: 20         # prefer chunks from pages <= this value
   ui:
-    sources_display_max: 5   # sources shown in chat UI (can be <= top_k)
+    # Cap Sources panel length. Sensible range: 2–3 (keeps UI scannable; can be <= top_k).
+    sources_display_max: 3
     source_preview_chars: 280
   retrieval:
     strategy: "hybrid"       # Round 2 default: semantic + BM25 for section/term lookup

--- a/src/app.py
+++ b/src/app.py
@@ -258,7 +258,7 @@ try:
     CONTEXT_SUFFICIENCY_GUARD = bool(retrieval_cfg.get("context_sufficiency_guard", True))
 
     ui_cfg = rag_cfg.get("ui", {}) or {}
-    SOURCES_DISPLAY_MAX = int(ui_cfg.get("sources_display_max", 5))
+    SOURCES_DISPLAY_MAX = int(ui_cfg.get("sources_display_max", 3))
     SOURCE_PREVIEW_CHARS = int(ui_cfg.get("source_preview_chars", 280))
 except (FileNotFoundError, OSError, yaml.YAMLError, KeyError, TypeError, ValueError) as exc:
     st.error(f"Configuration error in {CONFIG_PATH}: {exc}")


### PR DESCRIPTION
## Main contribution

The Sources panel now defaults to three excerpts so the audit trail stays short and scannable. Operators can still set `sources_display_max` to 2–3 in config without changing LLM `top_k`.

## Summary
- `rag.ui.sources_display_max` default 5 → 3
- App fallback aligned to 3
- Display-only; retrieval `top_k` unchanged

## Test plan
- [x] pytest passes
- [ ] Sources panel shows ≤ 3 items with default config
- [ ] Setting `sources_display_max: 2` caps at 2 after restart

Closes #80

Made with [Cursor](https://cursor.com)