### PR TITLE
M7.95-4: Tighter chunking around section headers

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -2,6 +2,7 @@
 chunking:
   chunk_size: 1000          # characters per chunk – tune for your documents
   chunk_overlap: 200        # R4-D: smaller overlap to reduce cross-section bleed
+  # M7.95-4: header split ignores TOC/FAQ false headers; re-index after changing this
   split_on_legal_headers: true  # tuning #2: split at numbered / title-style clause headers
 
 embeddings:

--- a/src/sectioning.py
+++ b/src/sectioning.py
@@ -13,7 +13,8 @@ TITLE_LINE_HEADER_RE = re.compile(
 )
 SECTION_IN_QUERY_RE = re.compile(r"section\s+(\d+)", re.IGNORECASE)
 SECTION_SYMBOL_RE = re.compile(r"§\s*(\d+)")
-SECTION_LABEL_RE = re.compile(r"(?i)\bsection\s+(\d+)\b")
+# Line-anchored: mid-sentence "defined in Section 1" must not become a header.
+SECTION_LABEL_RE = re.compile(r"(?im)^\s*section\s+(\d+)\b")
 
 _SKIP_TITLE_PREFIXES = (
     "Note to",
@@ -24,6 +25,15 @@ _SKIP_TITLE_PREFIXES = (
     "Place and",
     "Signature",
 )
+
+# TOC leaders ("Title ........ 3") and FAQ-style numbered questions are not clause headers.
+_TOC_LEADER_RE = re.compile(r"\.{2,}\s*\d+\s*$")
+_INTERROGATIVE_START_RE = re.compile(
+    r"(?i)^(?:how|what|why|when|where|who|whom|whose|which|"
+    r"does|do|did|is|are|was|were|can|could|should|will|would|may)\b"
+)
+_NOTE_FOR_RE = re.compile(r"(?i)^note for\b")
+_NUMBERED_LINE_RE = re.compile(r"^\s*\d+\.\s+")
 
 
 def extract_target_section(query: str) -> str | None:
@@ -60,17 +70,95 @@ def _valid_title_header(title: str) -> bool:
     return True
 
 
+def _looks_like_toc_entry(text: str) -> bool:
+    """True for TOC rows with leader dots and a trailing page number."""
+    return bool(_TOC_LEADER_RE.search((text or "").strip()))
+
+
+def _looks_like_faq_question(text: str) -> bool:
+    """True for eval/FAQ lines like 'How is X defined…?' or numbered questions."""
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return False
+    body = _NUMBERED_LINE_RE.sub("", cleaned, count=1).strip()
+    if not body:
+        return False
+    if body.endswith("?"):
+        return True
+    return bool(_INTERROGATIVE_START_RE.match(body))
+
+
+def _valid_numbered_header(title: str) -> bool:
+    """Reject TOC leaders and FAQ-style fragments as numbered clause headers."""
+    cleaned = (title or "").strip()
+    if not cleaned:
+        return False
+    if _looks_like_toc_entry(cleaned):
+        return False
+    if _looks_like_faq_question(cleaned):
+        return False
+    return True
+
+
+def _is_bleed_line(line: str) -> bool:
+    """Lines that should not stick to a section body (TOC rows, FAQ prompts, note banners)."""
+    stripped = (line or "").strip()
+    if not stripped:
+        return False
+    if _NOTE_FOR_RE.match(stripped):
+        return True
+    if _looks_like_toc_entry(stripped):
+        return True
+    if _NUMBERED_LINE_RE.match(stripped) and _looks_like_faq_question(stripped):
+        return True
+    return False
+
+
+def _peel_trailing_bleed(text: str) -> tuple[str, str]:
+    """
+    Peel trailing TOC/FAQ/note lines from a section body.
+
+    Returns (clean_body, bleed_text). Bleed is empty when nothing was peeled.
+    """
+    lines = (text or "").splitlines()
+    if not lines:
+        return "", ""
+
+    bleed_start = len(lines)
+    index = len(lines) - 1
+    while index >= 0:
+        stripped = lines[index].strip()
+        if not stripped:
+            index -= 1
+            continue
+        if _is_bleed_line(lines[index]):
+            bleed_start = index
+            index -= 1
+            continue
+        break
+
+    while bleed_start > 0 and not lines[bleed_start - 1].strip():
+        bleed_start -= 1
+
+    body = "\n".join(lines[:bleed_start]).strip()
+    bleed = "\n".join(lines[bleed_start:]).strip()
+    return body, bleed
+
+
 def find_legal_headers(text: str) -> list[tuple[int, str, str]]:
     """Return sorted (char_offset, section_id, title) for numbered and title-style headers."""
     headers: list[tuple[int, str, str]] = []
     seen_at: set[int] = set()
 
     for match in NUMBERED_CLAUSE_RE.finditer(text or ""):
+        title = match.group(2).strip()
+        if not _valid_numbered_header(title):
+            continue
         pos = match.start()
         if pos in seen_at:
             continue
         seen_at.add(pos)
-        headers.append((pos, match.group(1), match.group(2).strip()[:80]))
+        headers.append((pos, match.group(1), title[:80]))
 
     for match in SECTION_LABEL_RE.finditer(text or ""):
         pos = match.start()
@@ -103,12 +191,14 @@ def split_documents_by_legal_headers(page_docs: list[Document]) -> list[Document
     Split each page into header-bounded sections before character chunking (tuning #2).
 
     Keeps preamble (text before the first header) as its own document when non-empty.
+    Peels trailing TOC/FAQ bleed from section bodies into a separate notes document.
     """
     section_docs: list[Document] = []
     for page_doc in page_docs:
         text = page_doc.page_content or ""
         base_metadata = dict(page_doc.metadata)
         headers = find_legal_headers(text)
+        page_bleed: list[str] = []
 
         if not headers:
             section_docs.append(page_doc)
@@ -129,9 +219,14 @@ def split_documents_by_legal_headers(page_docs: list[Document]) -> list[Document
             section_text = text[pos:end].strip()
             if not section_text:
                 continue
+            body, bleed = _peel_trailing_bleed(section_text)
+            if bleed:
+                page_bleed.append(bleed)
+            if not body:
+                continue
             section_docs.append(
                 Document(
-                    page_content=section_text,
+                    page_content=body,
                     metadata={
                         **base_metadata,
                         "section": section_id,
@@ -139,6 +234,16 @@ def split_documents_by_legal_headers(page_docs: list[Document]) -> list[Document
                     },
                 )
             )
+
+        if page_bleed:
+            notes = "\n\n".join(page_bleed).strip()
+            if notes:
+                section_docs.append(
+                    Document(
+                        page_content=notes,
+                        metadata={**base_metadata, "section_title": "notes"},
+                    )
+                )
 
     return section_docs if section_docs else page_docs
 
@@ -162,11 +267,14 @@ def section_spans_in_chunk(text: str) -> list[tuple[str, int, int, str | None]]:
     seen_at: set[int] = set()
 
     for match in NUMBERED_CLAUSE_RE.finditer(text or ""):
+        title = match.group(2).strip()
+        if not _valid_numbered_header(title):
+            continue
         pos = match.start()
         if pos in seen_at:
             continue
         seen_at.add(pos)
-        headers.append((pos, match.group(1), match.group(2).strip()[:80]))
+        headers.append((pos, match.group(1), title[:80]))
 
     for match in TITLE_LINE_HEADER_RE.finditer(text or ""):
         title = match.group(1).strip()

--- a/tests/test_section_parsing.py
+++ b/tests/test_section_parsing.py
@@ -75,6 +75,30 @@ No Further Rights.
 Nothing herein shall grant any ownership of the Confidential Information.
 """
 
+TOC_BLEED_PAGE = """\
+CONFIDENTIALITY AND NON-DISCLOSURE AGREEMENT
+
+TABLE OF CONTENTS
+1. Definition of Confidential Information ............. 1
+2. Exclusions from Confidential Information ........... 2
+3. Obligations of the Receiving Party ................. 3
+
+WHEREAS, the parties wish to share information.
+
+1. Definition of Confidential Information
+Confidential Information means any information with commercial value.
+
+2. Exclusions from Confidential Information
+Confidential Information does not include public information.
+
+3. Obligations of the Receiving Party
+The Receiving Party shall hold all Confidential Information in strict confidence.
+
+Note for pilot testers:
+1. How is Confidential Information defined in Section 1?
+2. What obligations does Section 3 impose on the Receiving Party?
+"""
+
 
 def test_extract_target_section_parses_common_patterns() -> None:
     assert extract_target_section("What does Section 3 require?") == "3"
@@ -324,4 +348,69 @@ def test_chunk_contains_section_matches_title_slug() -> None:
     )
     assert chunk_contains_section(doc.page_content, "confidentiality")
     assert doc.metadata.get("section") == "confidentiality"
+
+
+def test_find_legal_headers_skips_toc_and_faq_lines() -> None:
+    headers = find_legal_headers(TOC_BLEED_PAGE)
+    ids = [item[1] for item in headers]
+    titles = [item[2] for item in headers]
+    assert ids == ["1", "2", "3"]
+    assert all("...." not in title for title in titles)
+    assert all("How is" not in title for title in titles)
+    assert all(title for title in titles)  # real clauses keep titles
+
+
+def test_split_documents_keeps_toc_out_of_section_bodies() -> None:
+    sections = split_documents_by_legal_headers(
+        [Document(page_content=TOC_BLEED_PAGE, metadata={"page": 1})]
+    )
+    by_section = {
+        doc.metadata.get("section"): doc
+        for doc in sections
+        if doc.metadata.get("section")
+    }
+    preamble = next(
+        doc for doc in sections if doc.metadata.get("section_title") == "preamble"
+    )
+    notes = next(
+        (doc for doc in sections if doc.metadata.get("section_title") == "notes"),
+        None,
+    )
+
+    assert "TABLE OF CONTENTS" in preamble.page_content
+    assert "............." in preamble.page_content
+    assert "WHEREAS" in preamble.page_content
+    assert "means any information" not in preamble.page_content
+
+    section_one = by_section["1"]
+    assert section_one.page_content.startswith("1. Definition")
+    assert "means any information" in section_one.page_content
+    assert "............." not in section_one.page_content
+    assert "WHEREAS" not in section_one.page_content
+    assert "How is" not in section_one.page_content
+
+    section_three = by_section["3"]
+    assert "strict confidence" in section_three.page_content
+    assert "How is" not in section_three.page_content
+    assert "Note for pilot" not in section_three.page_content
+
+    assert notes is not None
+    assert "How is Confidential Information defined" in notes.page_content
+
+
+def test_split_documents_preamble_isolated_from_section_one() -> None:
+    page = """\
+Parties agree as follows.
+
+1. Definition of Confidential Information
+Confidential Information means trade secrets.
+"""
+    sections = split_documents_by_legal_headers(
+        [Document(page_content=page, metadata={"page": 1})]
+    )
+    assert sections[0].metadata.get("section_title") == "preamble"
+    assert "Parties agree" in sections[0].page_content
+    assert sections[1].metadata.get("section") == "1"
+    assert sections[1].page_content.startswith("1. Definition")
+    assert "Parties agree" not in sections[1].page_content
 


### PR DESCRIPTION
## Main contribution

Section-aware splitting no longer treats TOC rows and FAQ-style numbered questions as clause headers, so preamble and notes bleed less into body chunks. Re-index (re-upload) after deploy to refresh Sources.

## Summary
- TOC leader rows and FAQ questions excluded from legal-header detection
- Line-anchored `Section N` matching
- Trailing note/FAQ lines peeled into a notes doc
- Tests cover TOC bleed isolation

## Test plan
- [x] pytest passes (section + full suite)
- [ ] Re-upload sample NDA; Section 1 body chunks no longer open with TOC lines
- [ ] Real clause headers still split correctly

Closes #83

Made with [Cursor](https://cursor.com)