### PR TITLE
M7.95-2: Sort Sources on-section first, then similarity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -30,6 +30,7 @@ from retrieval_quality import (
     INSUFFICIENT_CONTEXT_ANSWER,
     context_sufficient_for_query,
     dedupe_similar_chunks,
+    sort_source_docs,
 )
 from sectioning import (
     annotate_chunk_sections,
@@ -302,8 +303,9 @@ def _build_sources_payload(
 ) -> list[dict]:
     """Create a compact serializable source payload per assistant answer."""
     target_section = extract_target_section(query) if query else None
+    ordered = sort_source_docs(retrieved_docs, target_section=target_section)
     payload = []
-    for chunk in retrieved_docs[:SOURCES_DISPLAY_MAX]:
+    for chunk in ordered[:SOURCES_DISPLAY_MAX]:
         similarity = chunk.metadata.get("similarity")
         entry = {
             "page": chunk.metadata.get("page", "N/A"),

--- a/src/retrieval_quality.py
+++ b/src/retrieval_quality.py
@@ -101,3 +101,39 @@ def context_sufficient_for_query(query: str, context: str) -> tuple[bool, str | 
         return False, "obligation_markers_missing"
 
     return True, None
+
+
+def _similarity_score(doc: Document) -> float:
+    """UI similarity from metadata; missing/non-numeric → lowest."""
+    score = doc.metadata.get("similarity")
+    if isinstance(score, (int, float)):
+        return float(score)
+    return float("-inf")
+
+
+def sort_source_docs(
+    docs: list[Document],
+    *,
+    target_section: str | None,
+) -> list[Document]:
+    """
+    Order Sources for display: on-section first, then similarity descending.
+
+    When ``target_section`` is set, section-matched chunks rank above off-section
+    ones; within each group, higher ``metadata["similarity"]`` wins. With no
+    target section, order by similarity only. Missing scores sort last.
+    """
+    if not docs:
+        return []
+
+    if not target_section:
+        return sorted(docs, key=_similarity_score, reverse=True)
+
+    # Local import keeps retrieval_quality free of a hard sectioning cycle.
+    from sectioning import chunk_on_section
+
+    return sorted(
+        docs,
+        key=lambda doc: (chunk_on_section(doc, target_section), _similarity_score(doc)),
+        reverse=True,
+    )

--- a/tests/test_retrieval_quality.py
+++ b/tests/test_retrieval_quality.py
@@ -13,6 +13,7 @@ from retrieval_quality import (  # noqa: E402
     context_sufficient_for_query,
     dedupe_similar_chunks,
     query_expects_obligations,
+    sort_source_docs,
 )
 
 
@@ -75,3 +76,52 @@ def test_dedupe_drops_tiny_boilerplate_when_longer_chunk_on_page() -> None:
 def test_context_has_obligation_markers() -> None:
     assert context_has_obligation_markers("The party shall not disclose secrets.")
     assert not context_has_obligation_markers("7. Miscellaneous — laws of Spain.")
+
+
+def test_sort_source_docs_on_section_before_off_section() -> None:
+    off_high = Document(
+        page_content="1. Definition of Confidential Information\nTrade secrets.",
+        metadata={"page": 1, "similarity": 0.95},
+    )
+    on_low = Document(
+        page_content="3. Obligations of the Receiving Party\nHold in confidence.",
+        metadata={"page": 2, "similarity": 0.4},
+    )
+    on_high = Document(
+        page_content="3. Obligations\nReturn or destroy materials.",
+        metadata={"page": 2, "similarity": 0.8},
+    )
+    off_low = Document(
+        page_content="4. Duration of Confidentiality\nFive years.",
+        metadata={"page": 3, "similarity": 0.5},
+    )
+    ordered = sort_source_docs(
+        [off_high, on_low, off_low, on_high],
+        target_section="3",
+    )
+    assert ordered == [on_high, on_low, off_high, off_low]
+
+
+def test_sort_source_docs_similarity_only_without_target() -> None:
+    low = Document(page_content="a", metadata={"similarity": 0.2})
+    high = Document(page_content="b", metadata={"similarity": 0.9})
+    mid = Document(page_content="c", metadata={"similarity": 0.5})
+    ordered = sort_source_docs([low, high, mid], target_section=None)
+    assert ordered == [high, mid, low]
+
+
+def test_sort_source_docs_missing_similarity_sorts_last() -> None:
+    scored = Document(
+        page_content="3. Obligations\nDuty.",
+        metadata={"similarity": 0.3},
+    )
+    missing = Document(
+        page_content="3. Obligations\nAnother duty.",
+        metadata={},
+    )
+    ordered = sort_source_docs([missing, scored], target_section="3")
+    assert ordered == [scored, missing]
+
+
+def test_sort_source_docs_empty_input() -> None:
+    assert sort_source_docs([], target_section="1") == []


### PR DESCRIPTION
## Main contribution

Sources are ordered so section-matched excerpts appear before off-section neighbors, then by similarity. When the question does not name a section, ordering stays similarity-only. The display cap from #80 still applies after sort.

## Summary
- `sort_source_docs` helper in `retrieval_quality.py` + unit tests
- `_build_sources_payload` sorts before `sources_display_max` slice

## Test plan
- [x] pytest passes
- [ ] Section-scoped question: on-section Sources appear first
- [ ] Generic question: similarity order only
- [ ] Panel still respects sources_display_max (≤3)

Closes #81

Made with [Cursor](https://cursor.com)