### PR TITLE
M7.95-3: Answer-overlap filter for Sources (with fallback)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -30,6 +30,7 @@ from retrieval_quality import (
     INSUFFICIENT_CONTEXT_ANSWER,
     context_sufficient_for_query,
     dedupe_similar_chunks,
+    filter_docs_overlapping_answer,
     sort_source_docs,
 )
 from sectioning import (
@@ -300,10 +301,13 @@ def _build_sources_payload(
     retrieved_docs: list[Document],
     *,
     query: str | None = None,
+    answer: str | None = None,
 ) -> list[dict]:
     """Create a compact serializable source payload per assistant answer."""
     target_section = extract_target_section(query) if query else None
     ordered = sort_source_docs(retrieved_docs, target_section=target_section)
+    if answer:
+        ordered = filter_docs_overlapping_answer(ordered, answer)
     payload = []
     for chunk in ordered[:SOURCES_DISPLAY_MAX]:
         similarity = chunk.metadata.get("similarity")
@@ -1928,7 +1932,11 @@ if query and query.strip() and chat_ready:
             or "I could not generate an answer at this time. Please try again."
         )
         target_section = extract_target_section(query)
-        source_payload = _build_sources_payload(retrieved_docs, query=query)
+        source_payload = _build_sources_payload(
+            retrieved_docs,
+            query=query,
+            answer=assistant_message,
+        )
         _remember_response_timing(timing_payload if total_elapsed_ms > 0 else None)
         _append_chat_message(
             "assistant",

--- a/src/retrieval_quality.py
+++ b/src/retrieval_quality.py
@@ -10,6 +10,39 @@ INSUFFICIENT_CONTEXT_ANSWER = (
     "I could not find enough information in the document to answer."
 )
 
+# Light English stopwords for answer↔chunk overlap (keep the set tiny).
+_OVERLAP_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "in",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "that",
+        "the",
+        "to",
+        "was",
+        "were",
+        "with",
+    }
+)
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+# Default Jaccard floor for Sources answer-overlap (#82). Modest because
+# answers are short relative to chunks; tune upward if citations stay noisy.
+DEFAULT_ANSWER_OVERLAP_MIN_SCORE = 0.08
+
 OBLIGATION_QUERY_RE = re.compile(
     r"(?i)\b("
     r"must not|must agree|agree not|obligat|prohibit|prohibition|"
@@ -137,3 +170,51 @@ def sort_source_docs(
         key=lambda doc: (chunk_on_section(doc, target_section), _similarity_score(doc)),
         reverse=True,
     )
+
+
+def _content_tokens(text: str) -> set[str]:
+    """Lowercase alnum tokens minus a light stopword list."""
+    return {
+        tok
+        for tok in _TOKEN_RE.findall((text or "").lower())
+        if tok not in _OVERLAP_STOPWORDS
+    }
+
+
+def token_overlap_score(answer: str, chunk_text: str) -> float:
+    """
+    Deterministic token Jaccard between answer and chunk (0.0–1.0).
+
+    Empty answer or empty chunk → 0.0. No LLM calls.
+    """
+    answer_tokens = _content_tokens(answer)
+    chunk_tokens = _content_tokens(chunk_text)
+    if not answer_tokens or not chunk_tokens:
+        return 0.0
+
+    intersection = answer_tokens & chunk_tokens
+    union = answer_tokens | chunk_tokens
+    return len(intersection) / len(union)
+
+
+def filter_docs_overlapping_answer(
+    docs: list[Document],
+    answer: str,
+    *,
+    min_score: float = DEFAULT_ANSWER_OVERLAP_MIN_SCORE,
+) -> list[Document]:
+    """
+    Keep Sources chunks whose token overlap with ``answer`` is >= ``min_score``.
+
+    Safe fallback: if the answer is blank, or no doc clears the threshold,
+    return the original ``docs`` list unchanged (same order / identity).
+    """
+    if not docs or not (answer or "").strip():
+        return docs
+
+    kept = [
+        doc
+        for doc in docs
+        if token_overlap_score(answer, doc.page_content or "") >= min_score
+    ]
+    return kept if kept else docs

--- a/tests/test_retrieval_quality.py
+++ b/tests/test_retrieval_quality.py
@@ -9,11 +9,14 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 from retrieval_quality import (  # noqa: E402
+    DEFAULT_ANSWER_OVERLAP_MIN_SCORE,
     context_has_obligation_markers,
     context_sufficient_for_query,
     dedupe_similar_chunks,
+    filter_docs_overlapping_answer,
     query_expects_obligations,
     sort_source_docs,
+    token_overlap_score,
 )
 
 
@@ -125,3 +128,58 @@ def test_sort_source_docs_missing_similarity_sorts_last() -> None:
 
 def test_sort_source_docs_empty_input() -> None:
     assert sort_source_docs([], target_section="1") == []
+
+
+def test_token_overlap_score_jaccard_on_content_tokens() -> None:
+    answer = "The Receiving Party must hold Confidential Information in confidence."
+    match = "3. Obligations\nHold Confidential Information in strict confidence."
+    unrelated = "7. Miscellaneous — governing law of Spain and venue."
+    assert token_overlap_score(answer, match) > token_overlap_score(answer, unrelated)
+    assert token_overlap_score(answer, match) >= DEFAULT_ANSWER_OVERLAP_MIN_SCORE
+    assert token_overlap_score("", match) == 0.0
+    assert token_overlap_score(answer, "") == 0.0
+
+
+def test_filter_docs_overlapping_answer_keeps_matching_chunks() -> None:
+    answer = (
+        "The Receiving Party must hold Confidential Information in strict confidence "
+        "and not disclose trade secrets."
+    )
+    matching = Document(
+        page_content=(
+            "3. Obligations of the Receiving Party\n"
+            "Hold Confidential Information in strict confidence and protect trade secrets."
+        ),
+        metadata={"page": 2, "similarity": 0.9},
+    )
+    unrelated = Document(
+        page_content="7. Miscellaneous — governing law of Spain and exclusive venue.",
+        metadata={"page": 4, "similarity": 0.85},
+    )
+    filtered = filter_docs_overlapping_answer([matching, unrelated], answer)
+    assert filtered == [matching]
+
+
+def test_filter_docs_overlapping_answer_empty_filter_falls_back() -> None:
+    answer = "Liquidated damages equal ten thousand euros upon breach."
+    ranked = [
+        Document(
+            page_content="1. Definition of Confidential Information\nTrade secrets.",
+            metadata={"page": 1, "similarity": 0.9},
+        ),
+        Document(
+            page_content="4. Duration of Confidentiality\nFive years from disclosure.",
+            metadata={"page": 3, "similarity": 0.7},
+        ),
+    ]
+    filtered = filter_docs_overlapping_answer(ranked, answer)
+    assert filtered is ranked
+    assert filtered == ranked
+
+
+def test_filter_docs_overlapping_answer_empty_answer_returns_original() -> None:
+    docs = [
+        Document(page_content="3. Obligations\nHold in confidence.", metadata={"page": 2}),
+    ]
+    assert filter_docs_overlapping_answer(docs, "") is docs
+    assert filter_docs_overlapping_answer(docs, "   ") is docs


### PR DESCRIPTION
## Main contribution

Sources now prefer excerpts that overlap the generated answer, so the panel tracks what the model actually used. If overlap filtering would remove every candidate, the previous ranked list is kept (still capped at `sources_display_max`).

## Summary
- Token Jaccard overlap helper + filter with safe fallback
- Wired after sort, before display cap in `_build_sources_payload`
- Unit tests for keep / empty-filter fallback / blank answer

## Test plan
- [x] pytest passes
- [ ] Grounded question: Sources align with answer text
- [ ] If overlap would empty the list, capped fallback still shows
- [ ] Re-upload PDF after #83 so chunking + Sources stack together

Closes #82

Made with [Cursor](https://cursor.com)