### PR TITLE
docs: M7.96 Repo clarity milestone (#89–#93)

### DIFF
--- a/.cursor/agents/deploy-engineer.md
+++ b/.cursor/agents/deploy-engineer.md
@@ -1,19 +1,24 @@
 ---
 name: deploy-engineer
 description: >-
-  Deploy specialist for Docker, docker-compose, Ollama sidecar, Caddy HTTPS, VPS pilot.
-  Use for M7 and M11 infra. Triggers: Dockerfile, docker-compose, Ollama, Caddy, deploy/.
-  Must not edit src/app.py or src/rag.py.
+  Deploy specialist for Docker, Compose, Ollama sidecar, Caddy HTTPS, VPS pilot.
+  Owns everything under deploy/ (Dockerfile, compose, Caddy, scripts). Use for M7,
+  M7.96 repo layout, and M11. Must not edit src/app.py or src/rag.py. Prefer real
+  path updates over shim stubs when moving files.
 ---
 
 You are the **deploy-engineer** for ai-doc-to-chat-pipeline.
 
 ## Owns
 
-- `Dockerfile`, `.dockerignore`
-- `docker-compose*.yml`
-- `Caddyfile`, `deploy/**`
+- `deploy/**` (Dockerfile, `docker-compose*.yml`, Caddyfiles, TLS/auth scripts)
+- `.dockerignore` (repo root or under `deploy/` as layout requires)
 - Infra sections of `DEPLOYMENT.md` (when assigned)
+
+## Layout (M7.96+)
+
+- Consolidate deploy assets under `deploy/`. **No root shim stubs.**
+- Update Compose build contexts and docs to match; do not leave “Moved to …” files.
 
 ## Must NOT touch
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,9 @@ How this repo uses Cursor **rules**, **subagents**, and **slash commands** to de
 | **M7** | Reference deployment (Docker, Compose, Caddy, live pilot) | ✅ Shipped |
 | **M7.8** | Demo-ready tier: swappable LLM, Anthropic path, streaming | ✅ Shipped (#53–#56; #57 video open) |
 | **M7.9** | Interface polish | ✅ Shipped (#70–#73) |
-| **M7.95** | Sources trust | 🚧 Next (#80–#83) |
-| **Video / packaging** | Walkthrough linked from README; calm product framing | After M7.95 (#57) |
+| **M7.95** | Sources trust | ✅ Shipped (#80–#83) |
+| **M7.96** | Repo clarity (deploy/ consolidation, no shims) | 🚧 Next (#89–#93) · **main only** |
+| **Video / packaging** | Walkthrough linked from README; calm product framing | #57 (stable pin unchanged by M7.96) |
 | **M8** | Thin FastAPI `/health`, `/chat`, OpenAPI | After packaging (#58–#60) |
 | **M8.5** | Eval report export | Optional (#61) |
 | **M9–M11** | Persist, access control, ops runbook | Client-triggered |
@@ -32,25 +33,27 @@ Full detail: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
 
 ## 🎯 Current focus
 
-- **Ship next:** M7.95 Sources trust (#80–#83) → demo video (#57) → packaging → thin M8 (#58–#60).
+- **Ship next:** M7.96 Repo clarity (#89–#93) on **main only** (optional before video) → demo video (#57) → packaging → thin M8 (#58–#60).
+- **Do not** bump `deploy/stable` for M7.96 unless the operator asks (VPS/Cloud stay on v0.8.0).
 - **Then pause** this repo for the Support MVP sibling unless a paid engagement needs more depth here.
 - **Later / on demand:** M8.5, M9–M11.
 
 ### Delivery train (default queue)
 
 ```text
-M7.8 ✅ → M7.9 ✅ → (#80 ∥ #83) → #81 → #82 → #57 → packaging → #58 → #59 → #60 → [pause]
+M7.95 ✅ → (#89 ∥ #91) → #90 → #92 → #93 → #57 → packaging → #58 → #59 → #60 → [pause]
 ```
 
 | Wave | Work | Agents | Human? |
 |------|------|--------|--------|
-| — | M7.8 + M7.9 | shipped | — |
-| 1a ∥ 1b | **#80** Sources cap · **#83** header chunking | config + streamlit ∥ rag-core → verifier | None |
-| 2 | **#81** sort Sources | rag-core → streamlit → verifier | None |
-| 3 | **#82** answer-overlap filter | rag-core → streamlit → verifier | None |
-| 4 | **#57** demo video + README | docs-writer prepares; **human records** | **Hard gate:** video URL |
-| 5 | **Packaging** | docs-writer | Soft: thumbnail / links OK |
-| 6–8 | **#58 → #59 → #60** thin M8 | rag-core → config → streamlit → verifier | Rare |
+| — | M7.8–M7.95 | shipped | — |
+| 1a ∥ 1b | **#89** REPO-STRUCTURE · **#91** agentic tidy | docs-writer | None |
+| 2 | **#90** move Docker/Compose/Caddy → `deploy/` (no shims) | deploy-engineer → docs → verifier | Compose path change on `main` only |
+| 3 | **#92** README + docs index | docs-writer | None |
+| 4 | **#93** issue templates + pre-commit | config-guardian → docs-writer | None |
+| 5 | **#57** demo video + README | docs-writer prepares; **human records** | **Hard gate:** video URL |
+| 6 | **Packaging** | docs-writer | Soft: thumbnail / links OK |
+| 7–9 | **#58 → #59 → #60** thin M8 | rag-core → config → streamlit → verifier | Rare |
 | — | **Pause** | orchestrator “phase complete” pulse | Support MVP elsewhere |
 
 ---
@@ -60,7 +63,7 @@ M7.8 ✅ → M7.9 ✅ → (#80 ∥ #83) → #81 → #82 → #57 → packaging �
 | Role (`name`) | Milestones | Owns | Must NOT touch |
 |---------------|------------|------|----------------|
 | `milestone-orchestrator` | All | Queue, branches, commits, PRs, **merges**, pulses | Direct app code edits |
-| `deploy-engineer` | M7, M11 | `Dockerfile`, `docker-compose*.yml`, `Caddyfile`, `deploy/` | `src/app.py`, `src/rag.py` |
+| `deploy-engineer` | M7, M7.96, M11 | `deploy/**` (Dockerfile, Compose, Caddy, scripts) | `src/app.py`, `src/rag.py` |
 | `config-guardian` | M7–M12 | `configs/**`, `.env.example` | Application logic |
 | `rag-core-engineer` | M7.8, M7.95, M8, M9, M12 | `src/rag.py`, `src/sectioning.py`, `src/retrieval_quality.py`, `src/rag/**`, `src/api/**` | Streamlit layout polish, Docker |
 | `streamlit-engineer` | Feature UI wiring | `src/app.py` session/chat/upload/Sources payload wiring | Docker, FastAPI internals, visual redesigns |
@@ -71,7 +74,7 @@ M7.8 ✅ → M7.9 ✅ → (#80 ∥ #83) → #81 → #82 → #57 → packaging �
 
 Invoke by role name. Files live in `.cursor/agents/`.
 
-**Train roster:** orchestrator always on; **rag-core + config + streamlit on M7.95 (#80–#83)**; streamlit-ux only if Sources captions need polish; docs-writer on #57/packaging + pulses; verifier every issue; deploy-engineer idle unless compose/env deploy notes change.
+**Train roster:** orchestrator always on; **docs-writer + deploy-engineer on M7.96 (#89–#93)**; config-guardian on #93; verifier when compose/Docker moves (#90); docs-writer on #57/packaging + pulses.
 
 ---
 
@@ -110,6 +113,18 @@ Invoke by role name. Files live in `.cursor/agents/`.
 | #81 M7.95-2 sort on-section → score | rag-core-engineer | streamlit-engineer | 1–2 | after #80; prefer after #83 |
 | #82 M7.95-3 answer-overlap filter | rag-core-engineer | streamlit-engineer | 2 | after #81 |
 | #83 M7.95-4 tighter header chunking | rag-core-engineer | config-guardian | 1–2 | ∥ #80 |
+
+### M7.96: Repo clarity (chore · main only · no shims)
+
+| Issue | Primary | Secondary | Est. commits | Serial |
+|-------|---------|-----------|--------------|--------|
+| #89 M7.96-1 REPO-STRUCTURE | docs-writer | - | 1 | ∥ #91 |
+| #90 M7.96-2 consolidate under `deploy/` | deploy-engineer | docs-writer | 2 | after #89 |
+| #91 M7.96-3 agentic surface tidy | docs-writer | orchestrator | 1 | ∥ #89 |
+| #92 M7.96-4 README + docs index | docs-writer | - | 1 | after #90 |
+| #93 M7.96-5 templates + pre-commit | config-guardian | docs-writer | 1 | after #92 |
+
+**Rule:** no root stub files (“Moved to deploy/…”). Update real paths. Do not ff `deploy/stable` in this milestone.
 
 ### M8: Thin FastAPI contract (after video + packaging)
 

--- a/docs/operators/PROJECT-DIRECTION.md
+++ b/docs/operators/PROJECT-DIRECTION.md
@@ -119,28 +119,31 @@ After each issue, you should answer **without opening Cursor**:
 
 ### Phase 1: Demo, video & packaging 🚧 START HERE
 
-**Milestones:** M7.8 ✅ → M7.9 ✅ → **M7.95 Sources trust** ([#80–#83](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/9)) → video (#57) → packaging checklist in [ROADMAP.md](ROADMAP.md)
+**Milestones:** M7.8–M7.95 ✅ → **M7.96 Repo clarity** ([#89–#93](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/10), main only) → video (#57) → packaging checklist in [ROADMAP.md](ROADMAP.md)
 
 | # | Issue | Agent map | You learn |
 |---|-------|-----------|-----------|
-| 53–56 | M7.8 demo tier | (shipped) | Provider switch; streaming; pitch |
-| 70–73 | M7.9 UI polish | (shipped) | Calm client UI |
-| 80 | Sources display cap | config-guardian, streamlit-engineer | Display vs retrieval `top_k` |
-| 81 | Sort Sources | rag-core-engineer, streamlit-engineer | On-section + score ordering |
-| 82 | Answer-overlap filter | rag-core-engineer, streamlit-engineer | Honest citations with fallback |
-| 83 | Header-aware chunking | rag-core-engineer, config-guardian | TOC bleed vs section bodies |
+| 53–56, 70–73, 80–83 | M7.8–M7.95 | (shipped) | Demo tier, UI, Sources trust |
+| 89 | REPO-STRUCTURE | docs-writer | Target tree, no shims |
+| 90 | Consolidate under `deploy/` | deploy-engineer, docs-writer | Compose contexts, real path moves |
+| 91 | Agentic surface tidy | docs-writer | `.cursor/` + AGENTS intentional |
+| 92 | README + docs index | docs-writer | Client first paint |
+| 93 | Templates + pre-commit | config-guardian, docs-writer | Contributor hygiene |
 | 57 | Record video + README link | docs-writer (you record) | Walkthrough asset |
 
 ```mermaid
 flowchart LR
-  A["M7.8 + M7.9"] --> B["#80 ∥ #83"]
-  B --> C["#81"]
-  C --> D["#82"]
-  D --> E["#57 record"]
-  E --> F[Packaging]
-  F --> G[Thin M8]
-  G --> H[Phase pause]
+  A["M7.95 done"] --> B["#89 ∥ #91"]
+  B --> C["#90 deploy/"]
+  C --> D["#92 README"]
+  D --> E["#93 tooling"]
+  E --> F["#57 record"]
+  F --> G[Packaging]
+  G --> H[Thin M8]
+  H --> I[Phase pause]
 ```
+
+**M7.96 note:** merge to `main` only; leave `deploy/stable` on v0.8.0 until you intentionally advance it.
 
 After packaging + thin M8: **pause** for Support MVP unless a paid engagement needs more here.
 

--- a/docs/operators/ROADMAP.md
+++ b/docs/operators/ROADMAP.md
@@ -19,8 +19,9 @@ For contributors and operators. Moves the pipeline from a **reference deployment
 | **M7** | Reference deployment | Live HTTPS pilot + `DEPLOYMENT.md` | ✅ Done |
 | **M7.8** | Demo-ready tier | Swappable LLM, streaming, recordable walkthrough | ✅ Done |
 | **M7.9** | Interface polish | Calm client UI | ✅ Done |
-| **M7.95** | Sources trust | Fewer, ranked, answer-overlapping citations | **Ship next** |
-| **Video (#57)** | Published walkthrough | Link in README | Prefer after M7.95 |
+| **M7.95** | Sources trust | Fewer, ranked, answer-overlapping citations | ✅ Done |
+| **M7.96** | Repo clarity | Professional layout; deploy assets under `deploy/` (no shims) | **Ship next** (main only) |
+| **Video (#57)** | Published walkthrough | Link in README | Soft: can film before or after M7.96 |
 | **Packaging** | Calm product framing | Clear pilot + Cloud + video links | After video |
 | **M8** | Thin FastAPI contract | OpenAPI `/health`, `/chat` | After packaging |
 | **M8.5** | Eval harness export | Before/after retrieval report | Optional |
@@ -181,11 +182,48 @@ Cited answers only help when Sources feels like an audit trail: short, ranked, a
 
 **Out of scope:** New LLM providers, FastAPI, full UI redesign.
 
-GitHub milestone: [M7.95 Sources trust](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/9)
+GitHub milestone: [M7.95 Sources trust](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/9) ✅ closed
 
 ---
 
-## Demo video (after M7.8 / prefer after M7.95)
+## M7.96: Repo clarity (chore · main only)
+
+**Background**
+
+Clients who open the GitHub repo should see a calm, professional layout. Deploy assets consolidate under `deploy/` with **no root shims**. Agentic tooling (`.cursor/`, `AGENTS.md`) stays visible and intentional. Merge to **`main` only** — do **not** bump `deploy/stable` as part of this milestone (VPS/Cloud stay on v0.8.0 until you choose).
+
+> **Takeaway:** One obvious tree: product in `src/` + `docs/product/`, ops in `deploy/` + `DEPLOYMENT.md`, agents in `.cursor/` + `AGENTS.md`.
+
+**Target:** part-time · **5 issues** · primary `docs-writer` + `deploy-engineer`
+
+| Issue | Outcome | GitHub |
+|-------|---------|--------|
+| M7.96-1 | Target layout in `REPO-STRUCTURE.md` | [#89](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/89) |
+| M7.96-2 | Move Docker/Compose/Caddy into `deploy/` (no shims) | [#90](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/90) |
+| M7.96-3 | Tidy agentic surface (`.cursor` + `AGENTS`) | [#91](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/91) |
+| M7.96-4 | README + docs index first paint | [#92](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/92) |
+| M7.96-5 | Issue templates + pre-commit hygiene | [#93](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/93) |
+
+**Delivery train**
+
+```text
+(#89 ∥ #91) → #90 → #92 → #93
+```
+
+| Wave | Work | Agents | Parallel notes |
+|------|------|--------|----------------|
+| 1a ∥ 1b | **#89** structure doc · **#91** agentic tidy | docs-writer ∥ docs-writer (split files) | No `deploy/` moves yet |
+| 2 | **#90** consolidate under `deploy/` | deploy-engineer → docs-writer → verifier | **No shims**; update compose contexts + DEPLOYMENT |
+| 3 | **#92** README + docs index | docs-writer | After paths final |
+| 4 | **#93** GitHub templates + pre-commit | config-guardian → docs-writer | Keep pre-commit |
+
+**Out of scope:** RAG/UI features, bumping `deploy/stable`, inventing new product scope.
+
+GitHub milestone: [M7.96 Repo clarity](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/10)
+
+---
+
+## Demo video (after M7.95; M7.96 optional before record)
 
 Storyboard: [`docs/product/demo-script.md`](../product/demo-script.md). Record using **Anthropic demo tier**; show architecture slide for **Ollama self-host**. Tracked as [#57](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/57).
 


### PR DESCRIPTION
## Main contribution

Defines **M7.96 · Repo clarity**: a chore train to make the public GitHub tree look professional. Deploy assets move under `deploy/` with **no shim stubs**, agentic tooling stays intentional, and `deploy/stable` is left alone so the VPS/Cloud video pin stays on v0.8.0.

## Summary
- ROADMAP + PROJECT-DIRECTION + AGENTS: milestone, waves, issue map #89–#93
- deploy-engineer ownership updated for `deploy/**`
- Explicit no-shim / main-only policy

## Test plan
- [ ] Milestone [M7.96](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/10) lists #89–#93
- [ ] Train: (#89 ∥ #91) → #90 → #92 → #93


Made with [Cursor](https://cursor.com)