### PR TITLE
M7.96-1: Document target repo layout (REPO-STRUCTURE)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Start here when you want to understand the product, deploy it, or contribute. Do
 | **Deploying on a VPS** | [DEPLOYMENT.md](../DEPLOYMENT.md) | [Architecture](product/architecture.md) |
 | **Browsing as a buyer** | [README](../README.md) | Live pilot + [sample NDA](product/sample-nda.pdf) / [sample policy](product/sample-policy.md) |
 | **Shipping milestones** | [PROJECT-DIRECTION](operators/PROJECT-DIRECTION.md) | [ROADMAP](operators/ROADMAP.md), [AGENTS.md](../AGENTS.md) |
+| **Finding files in the repo** | [REPO-STRUCTURE](operators/REPO-STRUCTURE.md) | Target layout after M7.96 |
 | **Testing OCR** | [Testing OCR](operators/testing-ocr.md) | Local Docker steps |
 
 ```mermaid
@@ -36,14 +37,14 @@ flowchart LR
 docs/
   README.md          ← you are here
   product/           ← how it works, demo, evaluation, sample docs
-  operators/         ← roadmap, direction, OCR testing
+  operators/         ← roadmap, direction, repo structure, OCR testing
   archive/           ← older eval rounds (not primary reading)
 ```
 
 | Folder | Role |
 |--------|------|
 | [`product/`](product/) | Client-readable: architecture, demo script, evaluation, sample NDA + policy |
-| [`operators/`](operators/) | Roadmap, project direction, contributor how-tos |
+| [`operators/`](operators/) | Roadmap, project direction, [repo structure](operators/REPO-STRUCTURE.md), contributor how-tos |
 | [`archive/`](archive/) | Historical eval rounds; keep for reference, not day-one reading |
 
 

--- a/docs/operators/REPO-STRUCTURE.md
+++ b/docs/operators/REPO-STRUCTURE.md
@@ -1,0 +1,117 @@
+# Repository structure (target)
+
+## Background
+
+After **M7.96**, the repo should read as one calm tree: product code and docs in the obvious places, deploy assets under `deploy/`, and agentic tooling kept intentional rather than hidden. This page describes that **target** layout (post [#90](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/90)). Until that move lands, Docker/Compose/Caddy may still sit at the repo root.
+
+> **Takeaway:** Product in `src/` + `docs/product/`. Ops in `deploy/` + `DEPLOYMENT.md`. Agents in `AGENTS.md` + `.cursor/`. No root “Moved to deploy/…” stubs.
+
+**Milestone rule:** M7.96 merges to **`main` only**. Do **not** bump `deploy/stable` for this chore (VPS and Streamlit Cloud stay on the current pin until you choose otherwise).
+
+---
+
+## 🗺️ Top-level layout
+
+```text
+.
+├── README.md                 ← client-facing overview
+├── AGENTS.md                 ← contributor / agent playbook
+├── DEPLOYMENT.md             ← self-host & pilot ops
+├── LICENSE
+├── requirements.txt
+├── pyproject.toml
+├── .env.example
+├── .pre-commit-config.yaml
+├── .streamlit/               ← Streamlit theme / config
+├── .cursor/                  ← rules, agents, slash commands
+├── .github/                  ← issue templates, CI
+├── src/                      ← application code
+├── tests/
+├── configs/                  ← YAML (chunking, prompts, …)
+├── docs/                     ← product / operators / archive
+└── deploy/                   ← Docker, Compose, Caddy, scripts
+```
+
+| Area | Role |
+|------|------|
+| **Root prose** | README (buyers), DEPLOYMENT (IT), AGENTS (contributors) |
+| **`src/`** | Streamlit app, RAG, retrieval helpers |
+| **`tests/`** | pytest suite |
+| **`configs/`** | Tunables loaded at runtime |
+| **`docs/`** | Audience-split documentation (see below) |
+| **`deploy/`** | Everything needed to run the pilot container stack |
+| **`.cursor/` + `AGENTS.md`** | How humans and agents ship milestones |
+
+---
+
+## 🛠️ `deploy/` (no root shims)
+
+After [#90](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/90), deploy assets live **only** under `deploy/`:
+
+```text
+deploy/
+├── Dockerfile
+├── docker-compose.yml
+├── docker-compose.caddy.yml
+├── Caddyfile
+├── Caddyfile.ip
+├── caddy-basicauth.conf.example
+├── generate-caddy-auth.sh
+├── generate-ip-tls.sh
+└── …                             ← other deploy scripts as needed
+```
+
+**Rules**
+
+- No root copies of Dockerfile, `docker-compose*.yml`, or `Caddyfile*`.
+- No stub files at the root that say “Moved to `deploy/`…”. Update real paths in docs and CI instead.
+- Compose build contexts and `DEPLOYMENT.md` commands point at `deploy/`.
+
+Operators still start from [DEPLOYMENT.md](../../DEPLOYMENT.md); the folder above is where the files actually live.
+
+---
+
+## 📖 `docs/` map
+
+Unchanged by the Docker move; kept here so the full tree is one picture.
+
+```text
+docs/
+├── README.md          ← docs index (start here)
+├── product/           ← architecture, demo, evaluation, samples
+├── operators/         ← roadmap, direction, this file, OCR testing
+└── archive/           ← historical eval rounds
+```
+
+| Folder | Audience |
+|--------|----------|
+| [`docs/product/`](../product/) | Buyers and IT evaluating the product |
+| [`docs/operators/`](./) | Contributors shipping the delivery train |
+| [`docs/archive/`](../archive/) | Older eval notes; not day-one reading |
+
+Index: [docs/README.md](../README.md).
+
+---
+
+## 🎯 Agentic surface (intentional)
+
+Agentic files stay in the open tree on purpose:
+
+| Path | Purpose |
+|------|---------|
+| [`AGENTS.md`](../../AGENTS.md) | Issue → agent map, train mode, human gates |
+| [`.cursor/agents/`](../../.cursor/agents/) | Specialist role prompts |
+| [`.cursor/rules/`](../../.cursor/rules/) | Always-on coding and milestone rules |
+| [`.cursor/commands/`](../../.cursor/commands/) | Slash commands (`/ship-issue`, `/verify`, …) |
+
+Tidy and naming hygiene for this surface is [#91](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/91). Do not bury or delete the agentic layer for “cleaner GitHub cosmetics.”
+
+---
+
+## ✅ What this milestone does not change
+
+- **Pin / release:** `deploy/stable` is not fast-forwarded by M7.96.
+- **Product features:** No RAG or UI work in this chore.
+- **Docs audiences:** `product/` vs `operators/` vs `archive/` stay as they are; README polish is [#92](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/92).
+
+Related: [ROADMAP · M7.96](ROADMAP.md#m796-repo-clarity-chore--main-only).


### PR DESCRIPTION
## Main contribution

Adds a clear target repository map so clients and contributors can see where product, deploy, docs, and agentic tooling belong after the deploy/ consolidation — with an explicit no-shim rule and main-only merge policy.

## Summary
- New `docs/operators/REPO-STRUCTURE.md`
- Link from `docs/README.md`

## Test plan
- [ ] Docs index links to REPO-STRUCTURE
- [ ] Tree matches the planned post-#90 layout

Closes #89

Made with [Cursor](https://cursor.com)