### PR TITLE
M7.96-4: README + docs index for professional first paint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ Everything runs on one VM. Your documents never leave your environment (self-hos
 
 ---
 
+## 🗂️ Repository layout
+
+| Path | Role |
+|------|------|
+| `src/` | Application code (Streamlit UI and RAG pipeline) |
+| `docs/` | Product and operator docs ([index](docs/README.md)) |
+| `deploy/` | Docker, Compose, and Caddy assets for self-host |
+| `.cursor/` | Agent rules, specialists, and slash commands |
+| [`AGENTS.md`](AGENTS.md) | Contributor playbook (issues, agents, delivery train) |
+
+To run your own instance, follow the [Deployment Guide](DEPLOYMENT.md). Full tree: [docs/operators/REPO-STRUCTURE.md](docs/operators/REPO-STRUCTURE.md).
+
+---
+
 ## ✨ What it does well
 
 - **Policies, SOPs, reports, contracts, handbooks:** find rules, obligations, dates, and definitions in the PDF you uploaded

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,8 +16,8 @@ Start here when you want to understand the product, deploy it, or contribute. Do
 | **Deploying on a VPS** | [DEPLOYMENT.md](../DEPLOYMENT.md) | [Architecture](product/architecture.md) |
 | **Browsing as a buyer** | [README](../README.md) | Live pilot + [sample NDA](product/sample-nda.pdf) / [sample policy](product/sample-policy.md) |
 | **Shipping milestones** | [PROJECT-DIRECTION](operators/PROJECT-DIRECTION.md) | [ROADMAP](operators/ROADMAP.md), [AGENTS.md](../AGENTS.md) |
-| **Finding files in the repo** | [REPO-STRUCTURE](operators/REPO-STRUCTURE.md) | Target layout after M7.96 |
-| **Testing OCR** | [Testing OCR](operators/testing-ocr.md) | Local Docker steps |
+| **Finding files in the repo** | [REPO-STRUCTURE](operators/REPO-STRUCTURE.md) | Current layout (`src/`, `docs/`, `deploy/`, `.cursor/`) |
+| **Testing OCR** | [Testing OCR](operators/testing-ocr.md) | Local Docker steps under `deploy/` |
 
 ```mermaid
 flowchart LR
@@ -33,12 +33,21 @@ flowchart LR
 
 ## 🗂️ Folder map
 
+Docs sit inside a calm top-level tree. Product code in `src/`, self-host assets in `deploy/`, agentic tooling in `.cursor/` + [AGENTS.md](../AGENTS.md). Detail: [REPO-STRUCTURE](operators/REPO-STRUCTURE.md).
+
 ```text
-docs/
-  README.md          ← you are here
-  product/           ← how it works, demo, evaluation, sample docs
-  operators/         ← roadmap, direction, repo structure, OCR testing
-  archive/           ← older eval rounds (not primary reading)
+.
+├── README.md            ← client-facing overview
+├── AGENTS.md            ← contributor / agent playbook
+├── DEPLOYMENT.md        ← self-host & pilot ops
+├── src/                 ← Streamlit + RAG
+├── deploy/              ← Dockerfile, Compose, Caddy, scripts
+├── .cursor/             ← rules, agents, slash commands
+└── docs/                ← you are here
+      README.md
+      product/           ← architecture, demo, evaluation, sample docs
+      operators/         ← roadmap, direction, repo structure, OCR testing
+      archive/           ← older eval rounds (not primary reading)
 ```
 
 | Folder | Role |
@@ -46,7 +55,7 @@ docs/
 | [`product/`](product/) | Client-readable: architecture, demo script, evaluation, sample NDA + policy |
 | [`operators/`](operators/) | Roadmap, project direction, [repo structure](operators/REPO-STRUCTURE.md), contributor how-tos |
 | [`archive/`](archive/) | Historical eval rounds; keep for reference, not day-one reading |
-
+| [`deploy/`](../deploy/) (repo root) | Docker, Compose, and Caddy only (no root shims); start from [DEPLOYMENT.md](../DEPLOYMENT.md) |
 
 ---
 
@@ -55,4 +64,5 @@ docs/
 - **Live pilot:** [ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev)
 - **Public UI demo:** [Streamlit Cloud](https://ai-doc-to-chat-demo.streamlit.app)
 - **Self-host:** [DEPLOYMENT.md](../DEPLOYMENT.md)
+- **Repo layout:** [REPO-STRUCTURE](operators/REPO-STRUCTURE.md) · [AGENTS.md](../AGENTS.md)
 - **Sample uploads:** [product/sample-nda.pdf](product/sample-nda.pdf) · [product/sample-policy.md](product/sample-policy.md) (export to PDF)


### PR DESCRIPTION
## Main contribution

The README now shows a calm repository layout (src, docs, deploy, agentic tooling) so a client opening GitHub understands the tree in seconds. The docs index matches the consolidated `deploy/` layout.

## Summary
- README Repository layout + AGENTS pointer
- docs/README folder map synced
- Compose details stay in DEPLOYMENT.md

## Test plan
- [ ] README layout matches repo root
- [ ] Links to DEPLOYMENT, REPO-STRUCTURE, AGENTS work

Closes #92

Made with [Cursor](https://cursor.com)