### PR TITLE
deploy: apex static landing + hybrid pilot gate

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,6 +2,8 @@
 # Docker has no hot-reload; disable watcher to avoid probing transformers submodules
 # that optionally import torchvision (not installed — not needed for embeddings).
 fileWatcherType = "none"
+# Served under /app behind Caddy (public gate owns /). See deploy/Caddyfile.
+baseUrlPath = "app"
 
 [client]
 # Private pilot: no "Ask ChatGPT" / Google links on errors; keep messages user-safe.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -124,13 +124,22 @@ Expect: `ollama` **healthy** · `app` **Up** · `caddy` **Up**. Port 8501 is not
 
 ### 6. Verify
 
+With the hybrid Caddyfile (public gate + app under `/app`):
+
 ```bash
-# 401 without credentials, 200 with
+# Public gate (no credentials): expect 200 HTML from roxanatapia-web sites/pilot-gate
 curl -sk -o /dev/null -w "%{http_code}\n" https://YOUR_DOMAIN/
-curl -sk -o /dev/null -w "%{http_code}\n" -u demo:YOUR_PASSWORD https://YOUR_DOMAIN/
+
+# App path: 401 without credentials, 200 with
+curl -sk -o /dev/null -w "%{http_code}\n" https://YOUR_DOMAIN/app
+curl -sk -o /dev/null -w "%{http_code}\n" -u demo:YOUR_PASSWORD https://YOUR_DOMAIN/app
 ```
 
-Open `https://YOUR_DOMAIN` in a browser. Sign in, upload a PDF, ask a question.
+Open `https://YOUR_DOMAIN/` for the gate, then **Sign in** → `/app`. Upload a PDF, ask a question.
+
+**Apex landing** (`roxanatapia.dev`) is served from the same Caddy process via static files under `/srv/roxanatapia-web/sites/apex`. Marketing sites and cutover steps: [roxanatapia-web deploy/CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md). Deploy those files on the VPS before reloading Caddy.
+
+**IP-only mode** (`Caddyfile.ip`) still puts basic auth on the whole listener (no static gate). Use domain mode for the hybrid front door.
 
 **Later, switch from IP to domain:** set `SITE_ADDRESS=your.domain.com` + `ACME_EMAIL`, remove `CADDYFILE=./Caddyfile.ip`, recreate Caddy. Let's Encrypt issues the cert automatically.
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,23 +1,37 @@
-# Production pilot: automatic HTTPS via Let's Encrypt.
-# Set SITE_ADDRESS to your subdomain (e.g. demo.example.com) and ACME_EMAIL in .env.
+# Production: Let's Encrypt HTTPS + pilot hybrid gate + apex static landing.
+# Set SITE_ADDRESS (e.g. ai-doc-pilot.roxanatapia.dev) and ACME_EMAIL in .env.
 # Generate auth: ./deploy/generate-caddy-auth.sh demo 'your-password'
 # See DEPLOYMENT.md § HTTPS (Caddy).
+#
+# Static sites live in roxanatapia-web (mounted from /srv/roxanatapia-web/sites/…).
+# Cutover checklist: https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md
+# Apply only after those directories exist on the VPS (otherwise apex/gate 404).
 
 {
 	email {$ACME_EMAIL:you@example.com}
 }
 
+# Pilot host: public gate at /; Streamlit behind basic_auth under /app.
 {$SITE_ADDRESS} {
-	import /etc/caddy/caddy-basicauth.conf
+	handle /app* {
+		import /etc/caddy/caddy-basicauth.conf
 
-	reverse_proxy app:8501 {
-		header_up Host {host}
-		header_up X-Real-IP {remote_host}
+		reverse_proxy app:8501 {
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+		}
+	}
+
+	handle {
+		root * /srv/roxanatapia-web/sites/pilot-gate
+		file_server
 	}
 }
 
-# Root domain marketing redirects (optional; set A/AAAA for apex to VPS).
+# Apex marketing site (no redirect to pilot).
 roxanatapia.dev, www.roxanatapia.dev {
 	redir /upwork https://www.upwork.com/freelancers/roxanadev 301
-	redir / https://ai-doc-pilot.roxanatapia.dev 302
+
+	root * /srv/roxanatapia-web/sites/apex
+	file_server
 }

--- a/deploy/docker-compose.caddy.yml
+++ b/deploy/docker-compose.caddy.yml
@@ -22,6 +22,9 @@ services:
       - ${CADDYFILE:-./Caddyfile}:/etc/caddy/Caddyfile:ro
       - ./caddy-basicauth.conf:/etc/caddy/caddy-basicauth.conf:ro
       - ./certs:/etc/caddy/certs:ro
+      # Static front doors from roxanatapia-web (clone/rsync to host paths first).
+      - /srv/roxanatapia-web/sites/apex:/srv/roxanatapia-web/sites/apex:ro
+      - /srv/roxanatapia-web/sites/pilot-gate:/srv/roxanatapia-web/sites/pilot-gate:ro
       - caddy_data:/data
       - caddy_config:/config
     depends_on:


### PR DESCRIPTION
## Main contribution
Updates production Caddy so `roxanatapia.dev` serves the static apex landing from [roxanatapia-web](https://github.com/RoxanaTapia/roxanatapia-web), and `ai-doc-pilot` shows a public gate at `/` with Streamlit behind basic auth under `/app`.

## Summary
- Replace apex → pilot `redir` with `file_server` for `/srv/roxanatapia-web/sites/apex`
- Pilot host: public `sites/pilot-gate` at `/`; `basic_auth` + `reverse_proxy` only under `/app*`
- Compose bind-mounts for both static roots
- Streamlit `server.baseUrlPath = "app"`
- DEPLOYMENT verify steps updated for hybrid paths

## Do not merge/apply until
1. Static files exist on the VPS at `/srv/roxanatapia-web/sites/{apex,pilot-gate}` (from roxanatapia-web)
2. Operator is ready for cutover ([CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md))

Coordinates with roxanatapia-web issues **#11** (live apply) and **#12** (redirect retirement).

## Test plan
- [ ] Static roots present on VPS before reload
- [ ] `https://roxanatapia.dev/` → apex landing (not pilot auth)
- [ ] `https://roxanatapia.dev/upwork` → 301 Upwork
- [ ] Pilot `/` → public gate (no auth dialog)
- [ ] Pilot `/app` → basic auth, then Streamlit (assets/WS OK)
- [ ] Wrong password on `/app` does not affect public `/`


Made with [Cursor](https://cursor.com)