### PR TITLE
chore(deploy): harden Compose env + Caddyfile after cutover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,11 +70,15 @@ APP_ALLOW_DEV_TOGGLE=false
 # HTTPS reverse proxy (deploy/docker-compose.caddy.yml + Caddy)
 # =============================================================================
 # Canonical start (from repo root):
-#   docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up --build -d
+#   docker compose --env-file .env -p ai-doc-to-chat-pipeline \
+#     -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up --build -d
 # Basic auth credentials live in deploy/caddy-basicauth.conf (not in .env).
 # Generate with: ./deploy/generate-caddy-auth.sh demo 'YOUR_PASSWORD'
 
-# Production subdomain (Let's Encrypt). Example: demo.example.com
+# Keep named volumes on the historical project (do not omit -p / this var).
+COMPOSE_PROJECT_NAME=ai-doc-to-chat-pipeline
+
+# Production subdomain (Let's Encrypt). Example: ai-doc-pilot.roxanatapia.dev
 SITE_ADDRESS=
 
 # Interim IP demo without a domain — self-signed TLS on :443 (browser warning).
@@ -82,5 +86,7 @@ SITE_ADDRESS=
 # CADDYFILE=./Caddyfile.ip
 # (or CADDYFILE=Caddyfile.ip)
 
-# ACME registration email (production subdomain only; ignored for Caddyfile.ip)
+# Optional ACME contact email (not required for existing certs). Must be non-empty
+# if you add `email {$ACME_EMAIL}` to the Caddyfile. Never use a placeholder
+# default that contains "@" (breaks Caddy env expansion).
 ACME_EMAIL=

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -115,12 +115,18 @@ docker compose -f deploy/docker-compose.yml exec ollama ollama pull phi3:mini
 
 ### 5. Start the full stack with HTTPS
 
+From the **repo root** (so `.env` is found and volume names stay stable):
+
 ```bash
-docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up --build -d
-docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml ps
+docker compose --env-file .env -p ai-doc-to-chat-pipeline \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up --build -d
+docker compose --env-file .env -p ai-doc-to-chat-pipeline \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml ps
 ```
 
 Expect: `ollama` **healthy** · `app` **Up** · `caddy` **Up**. Port 8501 is not exposed publicly.
+
+Set `COMPOSE_PROJECT_NAME=ai-doc-to-chat-pipeline` in `.env` (see `.env.example`) so you can omit `-p` later. Always pass `--env-file .env` when the first compose file lives under `deploy/`.
 
 ### 6. Verify
 
@@ -161,7 +167,7 @@ docker compose -f deploy/docker-compose.yml up --build -d
 
 Open [http://localhost:8501](http://localhost:8501). Port 8501 binds to the host in the default (non-Caddy) Compose config.
 
-For Caddy locally: same `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml` flow with `CADDYFILE=./Caddyfile.ip` and a self-signed cert.
+For Caddy locally: same `--env-file .env -p ai-doc-to-chat-pipeline -f deploy/…` flow with `CADDYFILE=./Caddyfile.ip` and a self-signed cert.
 
 ---
 
@@ -178,8 +184,9 @@ Settings cascade: `.env` overrides → `configs/config.yaml` → built-in defaul
 | `APP_PRESENTATION_MODE` | `client` | `client` hides dev debug panels |
 | `APP_ALLOW_DEV_TOGGLE` | `false` | `true` only for local retrieval tuning |
 | `SITE_ADDRESS` | *(empty)* | Subdomain for Let's Encrypt (e.g. `demo.example.com`) |
-| `ACME_EMAIL` | *(empty)* | Let's Encrypt registration email |
-| `CADDYFILE` | `./Caddyfile` | Set to `./Caddyfile.ip` (or `Caddyfile.ip`) for bare-IP mode; relative to `deploy/` |
+| `COMPOSE_PROJECT_NAME` | `ai-doc-to-chat-pipeline` | Keeps Docker volume names stable after the `deploy/` layout move |
+| `ACME_EMAIL` | *(empty)* | Optional ACME contact; not required for existing certs |
+| `CADDYFILE` | `./Caddyfile` | Set to `./Caddyfile.ip` for bare-IP mode; relative to `deploy/` |
 | `LLM_PROVIDER` | *(empty → ollama)* | Set to `anthropic` for the fast demo tier |
 | `ANTHROPIC_API_KEY` | *(empty)* | Required when `LLM_PROVIDER=anthropic`; `.env` only, never git |
 | `ANTHROPIC_MODEL` | `claude-haiku-4-5-20251001` | Optional Haiku override |
@@ -222,6 +229,11 @@ Restart the app container after changing provider or key. Leave `LLM_PROVIDER` u
 | Connection refused on Ollama | Wrong host or app started too early | Use Compose; `OLLAMA_HOST` must be `http://ollama:11434`, not `localhost` |
 | `YOUR_VPS_IP:8501` accessible from internet | Caddy overlay not active | Use `-f deploy/docker-compose.caddy.yml`; confirm `caddy` is Up |
 | **401** with correct password | Wrong hash in conf file | Re-run `./deploy/generate-caddy-auth.sh`, restart Caddy |
+| **401** on `/app` without password | Expected | Public gate is `/`; only `/app` requires basic auth |
+| Caddy restart loop: `email` parse error | Empty `ACME_EMAIL` inside container, or `{$VAR:you@…}` default | Pass `--env-file .env`; do not use an `@` in Caddy env defaults |
+| Caddy: `caddy-basicauth.conf: is a directory` | Docker created an empty host dir after a bad bind path | `rm -rf` that directory; mount `deploy/caddy-basicauth.conf` (a file); recreate Caddy |
+| New volumes named `deploy_*` | Project name became `deploy` | Use `-p ai-doc-to-chat-pipeline` or `COMPOSE_PROJECT_NAME` |
+| `SITE_ADDRESS` / `ACME_EMAIL` empty in `docker inspect` | Root `.env` not loaded | Always `docker compose --env-file .env …` from repo root |
 | **ERR_SSL_PROTOCOL_ERROR** / TLS error | Stale or mismatched cert/key | Re-run `./deploy/generate-ip-tls.sh YOUR_IP`, wipe Caddy volumes, recreate |
 | **Model not found** in chat | Model not pulled or name mismatch | `docker compose -f deploy/docker-compose.yml exec ollama ollama pull phi3:mini`; set `OLLAMA_MODEL` to same tag |
 | OOM / very slow on CPU | Model too large for RAM | Use `phi3:mini`; set `OLLAMA_NUM_CTX=1024` in `.env` |
@@ -231,7 +243,8 @@ Restart the app container after changing provider or key. Leave `LLM_PROVIDER` u
 Quick diagnostics:
 
 ```bash
-docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml ps
+docker compose --env-file .env -p ai-doc-to-chat-pipeline \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml ps
 docker compose -f deploy/docker-compose.yml logs --tail=50 app
 docker compose -f deploy/docker-compose.yml logs --tail=50 ollama
 docker compose -f deploy/docker-compose.yml exec ollama ollama list

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -6,10 +6,9 @@
 # Static sites live in roxanatapia-web (mounted from /srv/roxanatapia-web/sites/…).
 # Cutover checklist: https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md
 # Apply only after those directories exist on the VPS (otherwise apex/gate 404).
-
-{
-	email {$ACME_EMAIL:you@example.com}
-}
+#
+# Do not use {$ACME_EMAIL:you@example.com} — a default containing "@" breaks Caddy's
+# placeholder parser. ACME contact is optional; existing certs in caddy_data keep working.
 
 # Pilot host: public gate at /; Streamlit behind basic_auth under /app.
 {$SITE_ADDRESS} {

--- a/deploy/docker-compose.caddy.yml
+++ b/deploy/docker-compose.caddy.yml
@@ -1,8 +1,17 @@
-# HTTPS reverse proxy overlay — use with the base stack (from repo root):
-#   docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up -d
+# HTTPS reverse proxy overlay — run from the **repo root**:
+#
+#   docker compose --env-file .env -p ai-doc-to-chat-pipeline \
+#     -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up -d
+#
+# Why these flags (learned in M4 cutover):
+# - `--env-file .env` loads SITE_ADDRESS / ACME_EMAIL from the repo-root .env
+#   (Compose does not auto-load root .env when the first -f file is under deploy/).
+# - `-p ai-doc-to-chat-pipeline` keeps volume names stable (avoid project name "deploy").
+# - Volume paths below are relative to this file's directory (deploy/).
+#   Do NOT use `--project-directory` at repo root with these relative paths, or
+#   Docker may create empty host directories named Caddyfile / caddy-basicauth.conf.
 #
 # Streamlit stays on the internal Compose network; only Caddy publishes 80/443.
-# Copy .env.example → .env and set SITE_ADDRESS (or CADDYFILE=./Caddyfile.ip).
 # Generate auth first: ./deploy/generate-caddy-auth.sh demo 'your-password'
 
 services:


### PR DESCRIPTION
## Main contribution
Hardens the post-`deploy/` Compose + Caddy workflow so the next VPS reload does not repeat the M4 cutover footguns (empty env, wrong project name, crash-looping Caddy).

## Summary
- Remove broken `{$ACME_EMAIL:you@example.com}` placeholder from `deploy/Caddyfile` (optional ACME email; `@` in defaults breaks Caddy parsing)
- Document canonical flags: `--env-file .env -p ai-doc-to-chat-pipeline`
- Add `COMPOSE_PROJECT_NAME` to `.env.example`
- DEPLOYMENT troubleshooting: empty env, fake bind-mount directories, `deploy_*` volumes, expected `/app` 401

## Test plan
- [ ] From repo root, `docker compose --env-file .env -p ai-doc-to-chat-pipeline -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml config` succeeds
- [ ] `docker inspect …caddy-1` shows non-empty `SITE_ADDRESS` when `.env` is set
- [ ] No `email {$…:…@…}` default remains in `deploy/Caddyfile`


Made with [Cursor](https://cursor.com)