### PR TITLE
feat: time-limited invite codes for pilot /app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,3 +90,8 @@ SITE_ADDRESS=
 # if you add `email {$ACME_EMAIL}` to the Caddyfile. Never use a placeholder
 # default that contains "@" (breaks Caddy env expansion).
 ACME_EMAIL=
+
+# Time-limited pilot invites (deploy/invite/). Required when using the Caddy overlay.
+# Generate: openssl rand -hex 32
+# Mint codes: python deploy/invite/mint.py --ttl 72h --label client-acme
+INVITE_SECRET=

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -130,6 +130,16 @@ Set `COMPOSE_PROJECT_NAME=ai-doc-to-chat-pipeline` in `.env` (see `.env.example`
 
 ### 6. Verify
 
+### Time-limited invites
+
+Set `INVITE_SECRET` in `.env` (required for the Caddy overlay). Mint out-of-band codes:
+
+```bash
+python deploy/invite/mint.py --ttl 72h --label client-acme
+```
+
+Invitees redeem via the gate (**Have invite**) or the signed URL (`/invite/redeem?token=…`). Valid cookie bypasses basic auth on `/app`; operators still use basic auth as fallback. Details: [deploy/invite/README.md](deploy/invite/README.md).
+
 With the hybrid Caddyfile (public gate + app under `/app`):
 
 ```bash

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,6 +1,7 @@
 # Production: Let's Encrypt HTTPS + pilot hybrid gate + apex static landing.
 # Set SITE_ADDRESS (e.g. ai-doc-pilot.roxanatapia.dev) and ACME_EMAIL in .env.
 # Generate auth: ./deploy/generate-caddy-auth.sh demo 'your-password'
+# Invites: INVITE_SECRET in .env; mint with python deploy/invite/mint.py
 # See DEPLOYMENT.md § HTTPS (Caddy).
 #
 # Static sites live in roxanatapia-web (mounted from /srv/roxanatapia-web/sites/…).
@@ -10,14 +11,36 @@
 # Do not use {$ACME_EMAIL:you@example.com} — a default containing "@" breaks Caddy's
 # placeholder parser. ACME contact is optional; existing certs in caddy_data keep working.
 
-# Pilot host: public gate at /; Streamlit behind basic_auth under /app.
+# Pilot host: public gate at /; Streamlit under /app via invite cookie or basic_auth.
 {$SITE_ADDRESS} {
-	handle /app* {
-		import /etc/caddy/caddy-basicauth.conf
+	handle /invite* {
+		reverse_proxy invite:8090
+	}
 
-		reverse_proxy app:8501 {
-			header_up Host {host}
-			header_up X-Real-IP {remote_host}
+	handle /app* {
+		@hasInviteCookie {
+			header Cookie *pilot_invite=*
+		}
+
+		handle @hasInviteCookie {
+			forward_auth invite:8090 {
+				uri /verify
+				copy_headers X-Invite-Ok
+			}
+
+			reverse_proxy app:8501 {
+				header_up Host {host}
+				header_up X-Real-IP {remote_host}
+			}
+		}
+
+		handle {
+			import /etc/caddy/caddy-basicauth.conf
+
+			reverse_proxy app:8501 {
+				header_up Host {host}
+				header_up X-Real-IP {remote_host}
+			}
 		}
 	}
 

--- a/deploy/docker-compose.caddy.yml
+++ b/deploy/docker-compose.caddy.yml
@@ -4,7 +4,7 @@
 #     -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up -d
 #
 # Why these flags (learned in M4 cutover):
-# - `--env-file .env` loads SITE_ADDRESS / ACME_EMAIL from the repo-root .env
+# - `--env-file .env` loads SITE_ADDRESS / ACME_EMAIL / INVITE_SECRET from the repo-root .env
 #   (Compose does not auto-load root .env when the first -f file is under deploy/).
 # - `-p ai-doc-to-chat-pipeline` keeps volume names stable (avoid project name "deploy").
 # - Volume paths below are relative to this file's directory (deploy/).
@@ -13,10 +13,21 @@
 #
 # Streamlit stays on the internal Compose network; only Caddy publishes 80/443.
 # Generate auth first: ./deploy/generate-caddy-auth.sh demo 'your-password'
+# Invites: set INVITE_SECRET in .env; mint with python deploy/invite/mint.py
 
 services:
   app:
     ports: !override []
+
+  invite:
+    build: ./invite
+    restart: unless-stopped
+    environment:
+      INVITE_SECRET: ${INVITE_SECRET:?Set INVITE_SECRET in repo-root .env}
+      INVITE_BIND: 0.0.0.0
+      INVITE_PORT: "8090"
+    expose:
+      - "8090"
 
   caddy:
     image: caddy:2.9.1-alpine
@@ -38,6 +49,7 @@ services:
       - caddy_config:/config
     depends_on:
       - app
+      - invite
 
 volumes:
   caddy_data:

--- a/deploy/invite/Dockerfile
+++ b/deploy/invite/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-alpine
+WORKDIR /app
+COPY tokens.py server.py ./
+ENV INVITE_BIND=0.0.0.0
+ENV INVITE_PORT=8090
+EXPOSE 8090
+CMD ["python", "server.py"]

--- a/deploy/invite/README.md
+++ b/deploy/invite/README.md
@@ -1,0 +1,37 @@
+# Time-limited pilot invites
+
+HMAC-signed tokens for `ai-doc-pilot` `/app`, validated by a tiny stdlib service and Caddy `forward_auth`. Caddy basic auth remains the operator fallback.
+
+## Setup
+
+1. Add a long random secret to repo-root `.env` (never commit it):
+
+```bash
+INVITE_SECRET=$(openssl rand -hex 32)
+```
+
+2. Recreate the stack (repo root):
+
+```bash
+docker compose --env-file .env -p ai-doc-to-chat-pipeline \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up -d --build
+```
+
+## Mint
+
+```bash
+python deploy/invite/mint.py --ttl 72h --label client-acme
+```
+
+Share `code=` or `url=` out of band. Default TTL is 72h.
+
+## Invitee flow
+
+1. Open the public gate.
+2. **Have invite** → paste code (POST `/invite/redeem`) or open the signed URL.
+3. Cookie `pilot_invite` is set; continue to `/app`.
+4. Operators can still use basic auth on `/app` without an invite cookie.
+
+## Revoke
+
+Rotate `INVITE_SECRET` and recreate the `invite` service (invalidates all outstanding tokens). Prefer short TTLs for one-off demos.

--- a/deploy/invite/mint.py
+++ b/deploy/invite/mint.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Mint a time-limited pilot invite code / signed URL.
+
+Usage (repo root, INVITE_SECRET in env or .env):
+  python deploy/invite/mint.py --ttl 72h --label client-acme
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Allow running as `python deploy/invite/mint.py`
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tokens import mint, parse_ttl  # noqa: E402
+
+
+def _load_dotenv() -> None:
+    root = Path(__file__).resolve().parents[2]
+    env_path = root / ".env"
+    if not env_path.is_file():
+        return
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip("'").strip('"')
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Mint a time-limited pilot invite")
+    parser.add_argument("--ttl", default="72h", help="TTL like 24h, 72h, 7d (default 72h)")
+    parser.add_argument("--label", default="", help="Optional label stored in the token")
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("INVITE_BASE_URL", "https://ai-doc-pilot.roxanatapia.dev"),
+        help="Public pilot host for the redeem URL",
+    )
+    args = parser.parse_args()
+    _load_dotenv()
+
+    try:
+        ttl = parse_ttl(args.ttl)
+        token = mint(ttl, label=args.label)
+    except (RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    base = args.base_url.rstrip("/")
+    print(f"ttl_seconds={ttl}")
+    if args.label:
+        print(f"label={args.label}")
+    print(f"code={token}")
+    print(f"url={base}/invite/redeem?token={token}")
+    print("Deliver out of band. Do not commit this output.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/invite/server.py
+++ b/deploy/invite/server.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Tiny invite redeem + forward_auth verify service (stdlib only)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from http.cookies import SimpleCookie
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tokens import COOKIE_NAME, verify  # noqa: E402
+
+HOST = os.environ.get("INVITE_BIND", "0.0.0.0")
+PORT = int(os.environ.get("INVITE_PORT", "8090"))
+COOKIE_MAX_AGE = int(os.environ.get("INVITE_COOKIE_MAX_AGE", str(7 * 86400)))
+APP_PATH = os.environ.get("INVITE_APP_PATH", "/app")
+
+
+def _html_page(title: str, body: str, status: int = 200) -> tuple[int, bytes, str]:
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{title}</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; background: #0c1218; color: #e8eef0;
+           max-width: 28rem; margin: 4rem auto; padding: 0 1.25rem; line-height: 1.5; }}
+    a {{ color: #7eb8c0; }}
+    .err {{ color: #f0a8a8; }}
+  </style>
+</head>
+<body>
+  <h1>{title}</h1>
+  {body}
+  <p><a href="/">Back to gate</a></p>
+</body>
+</html>
+"""
+    return status, html.encode("utf-8"), "text/html; charset=utf-8"
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "InviteAuth/1.0"
+
+    def log_message(self, fmt: str, *args) -> None:
+        sys.stderr.write("%s - %s\n" % (self.address_string(), fmt % args))
+
+    def _send(self, status: int, body: bytes, content_type: str, headers: dict[str, str] | None = None) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        if headers:
+            for key, value in headers.items():
+                self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _cookie_header(self, token: str) -> str:
+        return (
+            f"{COOKIE_NAME}={token}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age={COOKIE_MAX_AGE}"
+        )
+
+    def _token_from_cookie(self) -> str | None:
+        raw = self.headers.get("Cookie", "")
+        if not raw:
+            return None
+        cookie = SimpleCookie()
+        cookie.load(raw)
+        morsel = cookie.get(COOKIE_NAME)
+        return morsel.value if morsel else None
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+
+        if path == "/healthz":
+            self._send(200, b"ok\n", "text/plain; charset=utf-8")
+            return
+
+        if path == "/verify":
+            # Caddy forward_auth
+            token = self._token_from_cookie()
+            if not token:
+                self._send(401, b"missing invite\n", "text/plain; charset=utf-8")
+                return
+            try:
+                verify(token)
+            except (RuntimeError, ValueError):
+                self._send(401, b"invalid invite\n", "text/plain; charset=utf-8")
+                return
+            self._send(200, b"ok\n", "text/plain; charset=utf-8", {"X-Invite-Ok": "1"})
+            return
+
+        if path == "/invite/redeem":
+            qs = parse_qs(parsed.query)
+            token = (qs.get("token") or [""])[0]
+            self._redeem(token)
+            return
+
+        status, body, ctype = _html_page(
+            "Invite",
+            "<p>Use the gate’s <strong>Have invite</strong> form, or open a signed redeem URL.</p>",
+        )
+        self._send(status, body, ctype)
+
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        if path != "/invite/redeem":
+            self._send(404, b"not found\n", "text/plain; charset=utf-8")
+            return
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        raw = self.rfile.read(length).decode("utf-8", errors="replace") if length else ""
+        content_type = self.headers.get("Content-Type", "")
+        token = ""
+        if "application/json" in content_type:
+            import json
+
+            try:
+                data = json.loads(raw) if raw else {}
+                token = str(data.get("token") or data.get("code") or "")
+            except json.JSONDecodeError:
+                token = ""
+        else:
+            form = parse_qs(raw)
+            token = (form.get("token") or form.get("code") or [""])[0]
+        self._redeem(token)
+
+    def _redeem(self, token: str) -> None:
+        token = (token or "").strip()
+        if not token:
+            status, body, ctype = _html_page(
+                "Invite needed",
+                '<p class="err">Paste an invite code, or open the signed link from your email.</p>',
+                400,
+            )
+            self._send(status, body, ctype)
+            return
+        try:
+            verify(token)
+        except RuntimeError as exc:
+            status, body, ctype = _html_page("Invite unavailable", f'<p class="err">{exc}</p>', 503)
+            self._send(status, body, ctype)
+            return
+        except ValueError as exc:
+            status, body, ctype = _html_page("Invite invalid", f'<p class="err">{exc}</p>', 401)
+            self._send(status, body, ctype)
+            return
+
+        # 303 so refresh does not re-POST
+        self.send_response(303)
+        self.send_header("Location", APP_PATH)
+        self.send_header("Set-Cookie", self._cookie_header(token))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+
+
+def main() -> int:
+    try:
+        # Fail fast if secret missing
+        from tokens import get_secret
+
+        get_secret()
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    server = ThreadingHTTPServer((HOST, PORT), Handler)
+    print(f"invite auth listening on {HOST}:{PORT}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("shutting down", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/invite/tokens.py
+++ b/deploy/invite/tokens.py
@@ -1,0 +1,77 @@
+"""HMAC-signed, time-limited invite tokens (stdlib only)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import time
+from typing import Any
+
+
+COOKIE_NAME = "pilot_invite"
+TOKEN_PREFIX = "v1"
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(text: str) -> bytes:
+    pad = "=" * (-len(text) % 4)
+    return base64.urlsafe_b64decode(text + pad)
+
+
+def get_secret() -> bytes:
+    secret = os.environ.get("INVITE_SECRET", "").strip()
+    if not secret:
+        raise RuntimeError("INVITE_SECRET is not set")
+    return secret.encode("utf-8")
+
+
+def mint(ttl_seconds: int, label: str = "") -> str:
+    if ttl_seconds < 60:
+        raise ValueError("ttl_seconds must be at least 60")
+    payload: dict[str, Any] = {
+        "exp": int(time.time()) + ttl_seconds,
+        "jti": secrets.token_urlsafe(12),
+    }
+    if label:
+        payload["label"] = label
+    body = _b64url(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode())
+    sig = _b64url(hmac.new(get_secret(), body.encode("ascii"), hashlib.sha256).digest())
+    return f"{TOKEN_PREFIX}.{body}.{sig}"
+
+
+def verify(token: str) -> dict[str, Any]:
+    token = (token or "").strip()
+    parts = token.split(".")
+    if len(parts) != 3 or parts[0] != TOKEN_PREFIX:
+        raise ValueError("invalid token format")
+    body, sig = parts[1], parts[2]
+    expected = _b64url(hmac.new(get_secret(), body.encode("ascii"), hashlib.sha256).digest())
+    if not hmac.compare_digest(sig, expected):
+        raise ValueError("invalid signature")
+    try:
+        payload = json.loads(_b64url_decode(body))
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ValueError("invalid payload") from exc
+    exp = int(payload.get("exp", 0))
+    if exp < int(time.time()):
+        raise ValueError("token expired")
+    return payload
+
+
+def parse_ttl(text: str) -> int:
+    """Parse 24h, 72h, 7d, or bare seconds."""
+    text = text.strip().lower()
+    if text.endswith("d"):
+        return int(float(text[:-1]) * 86400)
+    if text.endswith("h"):
+        return int(float(text[:-1]) * 3600)
+    if text.endswith("m"):
+        return int(float(text[:-1]) * 60)
+    return int(text)


### PR DESCRIPTION
## Main contribution
Adds HMAC-signed, time-limited invite tokens for the AI Doc pilot `/app`, validated by a small invite service and Caddy `forward_auth`, while keeping basic auth as the operator fallback.

## Summary
- `deploy/invite/`: tokens, mint.py, server.py, Dockerfile
- Caddy: `/invite*` redeem; `/app*` invite cookie or basic auth
- Compose overlay builds `invite` service; requires `INVITE_SECRET`
- Docs in DEPLOYMENT.md and deploy/invite/README.md

## Test plan
- [ ] `INVITE_SECRET=… python3 deploy/invite/mint.py --ttl 1h`
- [ ] Redeem URL sets cookie and reaches `/app` without basic auth
- [ ] Expired/forged token → 401
- [ ] Operator basic auth still works without cookie
- [ ] Stack starts with `INVITE_SECRET` in `.env`


Made with [Cursor](https://cursor.com)