### PR TITLE
docs: video last + packaging soft pass before thin M8

### DIFF
--- a/.cursor/agents/milestone-orchestrator.md
+++ b/.cursor/agents/milestone-orchestrator.md
@@ -13,7 +13,7 @@ You are the **milestone-orchestrator** for ai-doc-to-chat-pipeline.
 ## Role
 
 - Read GitHub issue (`gh issue view`) and `docs/operators/ROADMAP.md` + `AGENTS.md`.
-- Prefer **train mode** for the delivery queue (#53→#60); still **one issue = one branch = one PR**.
+- Prefer **train mode** for the delivery queue (packaging → #58→#60 → #57); still **one issue = one branch = one PR**.
 - Create branch `feat/m7-8-<name>` or `feat/m8-<name>` from latest `main`.
 - Dispatch specialists by file ownership; never parallelize same-file edits.
 - Collect specialist reports; **you alone** run `git commit` (1–2 granular commits per ROADMAP).
@@ -33,9 +33,9 @@ You are the **milestone-orchestrator** for ai-doc-to-chat-pipeline.
 
 ## Hard human gates (stop)
 
-1. **#57 video URL** — human records and supplies the public link.
-2. **Secrets** — never commit API keys or real hostnames.
-3. **CI still red** after one focused fix attempt.
+1. **Secrets** — never commit API keys or real hostnames.
+2. **CI still red** after one focused fix attempt.
+3. **#57 video URL** — only when shipping #57 (after thin M8). Human records and supplies the public link. Do not block packaging or M8 on this.
 
 ## Status pulse (required after each merge / wave)
 
@@ -50,7 +50,7 @@ You are the **milestone-orchestrator** for ai-doc-to-chat-pipeline.
 ## Delivery train order
 
 ```text
-#53 → #54 → (#55 ∥ #56) → #57 → packaging → #58 → #59 → #60
+packaging (minus video) → #58 → #59 → #60 → #57
 ```
 
 Then pause; Support MVP is a sibling project, not this repo’s next milestone.

--- a/.cursor/commands/ship-issue.md
+++ b/.cursor/commands/ship-issue.md
@@ -55,7 +55,7 @@ Closes #NN
 
 Invoke **blocker-reporter**, ask **docs-writer** to polish the Blocker card, use AGENTS.md Human decisions log, then **STOP**.
 
-Hard gates: #57 video URL, secrets, CI still red after one fix attempt.
+Hard gates: secrets, CI still red after one fix attempt. #57 video URL only when shipping #57 (after thin M8).
 
 ## Issue number
 

--- a/.cursor/commands/ship-milestone.md
+++ b/.cursor/commands/ship-milestone.md
@@ -18,24 +18,25 @@ Follow **train mode** in `AGENTS.md` unless the operator said `hold merges`. Kee
 - Still **one issue = one branch = one PR**.
 - Use the `/ship-issue #NN` loop for each issue: specialists → verifier → commit → PR → merge when green → **status pulse**.
 - Respect parallel windows (e.g. #55 ∥ #56) and serial deps (#53→#54→#55; #58→#59→#60).
-- On hard gates (#57 video URL, secrets, CI still red): Blocker card (`docs-writer` polish) and **STOP**.
+- On hard gates (secrets, CI still red): Blocker card (`docs-writer` polish) and **STOP**.
+- #57 video is **last**: stop for a video URL only when the train reaches recording.
 - Do not start Support MVP / n8n CRM as this repo’s next work.
 
 ### Default delivery train
 
 ```text
-#53 → #54 → (#55 ∥ #56) → #57 → packaging → #58 → #59 → #60
+packaging (minus video) → #58 → #59 → #60 → #57
 ```
 
-End with a phase-complete pulse after packaging + thin M8 (or after packaging if M8 is deferred).
+End with a phase-complete pulse after thin M8 + video.
 
 ## Milestone definitions of done
 
 - **M7:** ✅ HTTPS pilot, DEPLOYMENT.md, Compose (shipped)
 - **M7.8:** Swappable LLM, Anthropic demo tier, streaming, recordable walkthrough
-- **Video (#57):** Link in README after M7.8
-- **Portfolio packaging:** Calm README hero, pilot + Cloud links, 16:9 thumbnail story (after video)
+- **Portfolio packaging:** Calm README hero, pilot + Cloud links, 16:9 thumbnail story (video URL deferred)
 - **M8 (thin):** `/health`, `/chat`, OpenAPI; modest `src/rag/` extract (not a large rewrite gate)
+- **Video (#57):** Link in README **after** thin M8
 - **M8.5:** Eval export (optional / secondary after thin M8)
 - **M9–M11:** Client-triggered (persist, SSO, runbook); not default portfolio path
 - **M12:** Light services/tiers one-pager (providers ship in M7.8)

--- a/.cursor/rules/milestone-workflow.mdc
+++ b/.cursor/rules/milestone-workflow.mdc
@@ -7,7 +7,7 @@ alwaysApply: true
 
 ## Background
 
-Delivery order: M7.8 → video → packaging → thin M8 → optional M8.5; M9–M11 client-triggered.
+Delivery order: M7.8 → packaging → thin M8 → video last (#57) → optional M8.5; M9–M11 client-triggered.
 See `docs/operators/ROADMAP.md`. Do not treat Support MVP / n8n CRM as this repo’s core path.
 Keep operator and GitHub prose calm and confident; avoid “hire-me” / salesy framing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,13 @@ Operator direction and sequencing live in [docs/operators/PROJECT-DIRECTION.md](
 | Milestone | Goal | Status |
 |-----------|------|--------|
 | **M7** | Reference deployment (Docker, Compose, Caddy, live pilot) | ✅ Shipped |
-| **M7.8** | Demo-ready tier: swappable LLM, Anthropic path, streaming | ✅ Shipped (#53–#56; #57 video open) |
+| **M7.8** | Demo-ready tier: swappable LLM, Anthropic path, streaming | ✅ Shipped (#53–#56; #57 video open, last) |
 | **M7.9** | Interface polish | ✅ Shipped (#70–#73) |
 | **M7.95** | Sources trust | ✅ Shipped (#80–#83) |
-| **M7.96** | Repo clarity (deploy/ consolidation, no shims) | 🚧 Next (#89–#93) · **main only** |
-| **Video / packaging** | Walkthrough linked from README; calm product framing | #57 (stable pin unchanged by M7.96) |
-| **M8** | Thin FastAPI `/health`, `/chat`, OpenAPI | After packaging (#58–#60) |
+| **M7.96** | Repo clarity (deploy/ consolidation, no shims) | ✅ Shipped (#89–#93) · **main only** |
+| **Packaging** | Calm product framing (pilot + Cloud links; video URL later) | Soft pass after M7.96 |
+| **M8** | Thin FastAPI `/health`, `/chat`, OpenAPI | Next (#58–#60) |
+| **Video (#57)** | Walkthrough linked from README | **Last** after thin M8 |
 | **M8.5** | Eval report export | Optional (#61) |
 | **M9–M11** | Persist, access control, ops runbook | Client-triggered |
 | **M12** | Light services / tiers one-pager | Light |
@@ -48,27 +49,23 @@ Full detail: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
 
 ## 🎯 Current focus
 
-- **Ship next:** M7.96 Repo clarity (#89–#93) on **main only** (optional before video) → demo video (#57) → packaging → thin M8 (#58–#60).
-- **Do not** bump `deploy/stable` for M7.96 unless the operator asks (VPS/Cloud stay on v0.8.0).
+- **Ship next:** packaging soft pass (no video URL required) → thin M8 (#58–#60) → demo video (#57) last.
+- **Do not** bump `deploy/stable` unless the operator asks (VPS/Cloud stay on v0.8.0).
 - **Then pause** this repo for the Support MVP sibling unless a paid engagement needs more depth here.
 - **Later / on demand:** M8.5, M9–M11.
 
 ### Delivery train (default queue)
 
 ```text
-M7.95 ✅ → (#89 ∥ #91) → #90 → #92 → #93 → #57 → packaging → #58 → #59 → #60 → [pause]
+M7.96 ✅ → packaging (minus video) → #58 → #59 → #60 → #57 → [pause]
 ```
 
 | Wave | Work | Agents | Human? |
 |------|------|--------|--------|
-| — | M7.8–M7.95 | shipped | — |
-| 1a ∥ 1b | **#89** REPO-STRUCTURE · **#91** agentic tidy | docs-writer | None |
-| 2 | **#90** move Docker/Compose/Caddy → `deploy/` (no shims) | deploy-engineer → docs → verifier | Compose path change on `main` only |
-| 3 | **#92** README + docs index | docs-writer | None |
-| 4 | **#93** issue templates + pre-commit | config-guardian → docs-writer | None |
-| 5 | **#57** demo video + README | docs-writer prepares; **human records** | **Hard gate:** video URL |
-| 6 | **Packaging** | docs-writer | Soft: thumbnail / links OK |
-| 7–9 | **#58 → #59 → #60** thin M8 | rag-core → config → streamlit → verifier | Rare |
+| — | M7.8–M7.96 | shipped | — |
+| 1 | **Packaging** (README framing, tiers, thumbnail; skip video URL) | docs-writer | Soft |
+| 2–4 | **#58 → #59 → #60** thin M8 | rag-core → config → streamlit → verifier | Rare |
+| 5 | **#57** demo video + README link | docs-writer prepares; **human records** | Closing gate: video URL |
 | — | **Pause** | orchestrator “phase complete” pulse | Support MVP elsewhere |
 
 ---
@@ -89,7 +86,7 @@ M7.95 ✅ → (#89 ∥ #91) → #90 → #92 → #93 → #57 → packaging → #5
 
 Invoke by role name. Files live in `.cursor/agents/`.
 
-**Train roster:** orchestrator always on; **docs-writer + deploy-engineer on M7.96 (#89–#93)**; config-guardian on #93; verifier when compose/Docker moves (#90); docs-writer on #57/packaging + pulses.
+**Train roster:** orchestrator always on; **docs-writer on packaging**; rag-core + config + streamlit on thin M8 (#58–#60); docs-writer on #57 (video last) + pulses.
 
 ---
 
@@ -109,7 +106,7 @@ Invoke by role name. Files live in `.cursor/agents/`.
 | #54 M7.8-2 Anthropic adapter | rag-core-engineer | config-guardian | 2 | after #53 |
 | #55 M7.8-3 Streamlit streaming | streamlit-engineer | rag-core-engineer (review) | 1–2 | after #54 |
 | #56 M7.8-4 docs + sample doc | docs-writer | - | 1–2 | parallel #55 |
-| #57 M7.8-5 demo video + README | docs-writer | human records | 1 | after #54–#56 |
+| #57 M7.8-5 demo video + README | docs-writer | human records | 1 | **last** after #58–#60 |
 
 ### M7.9: Interface polish (short UX pass)
 
@@ -141,7 +138,7 @@ Invoke by role name. Files live in `.cursor/agents/`.
 
 **Rule:** no root stub files (“Moved to deploy/…”). Update real paths. Do not ff `deploy/stable` in this milestone.
 
-### M8: Thin FastAPI contract (after video + packaging)
+### M8: Thin FastAPI contract (after packaging; before video)
 
 | Issue | Primary | Secondary | Est. commits | Serial |
 |-------|---------|-----------|--------------|--------|
@@ -229,9 +226,9 @@ Keep it short. Operator supervises via these, not via “say commit.”
 
 ### Hard human gates (stop the train)
 
-1. **#57 recording** — agents prepare script/README; only the human can film/upload and supply the public URL.
-2. **Secrets** — API keys and real hostnames stay in `.env` / VPS only; never in git.
-3. **CI still red** after one focused fix attempt — emit a Blocker card; do not loop forever.
+1. **Secrets** — API keys and real hostnames stay in `.env` / VPS only; never in git.
+2. **CI still red** after one focused fix attempt — emit a Blocker card; do not loop forever.
+3. **#57 recording** — only when the train reaches #57 (after thin M8). Agents prepare script/README; only the human can film/upload and supply the public URL. Do **not** stop packaging or M8 waiting for a video link.
 
 Soft gate: packaging thumbnail / README emphasis (default: calm product framing; human can tweak later).
 
@@ -259,7 +256,7 @@ flowchart LR
 6. PR: **`## Main contribution`** first, `Closes #NN`. Push and merge when green (train mode).
 7. Optional learning pass later (see PROJECT-DIRECTION).
 
-For the full queue, prefer `/ship-milestone M7.8` then continue into packaging + thin M8 rather than a fresh chat per issue (unless context is huge).
+For the full queue, prefer `/ship-milestone M8` (packaging → #58–#60 → #57) rather than a fresh chat per issue (unless context is huge).
 
 ---
 
@@ -289,7 +286,8 @@ Command files live in [`.cursor/commands/`](.cursor/commands/). Stale M7-only al
 | OpenAI provider | After Anthropic (#54) | Optional third backend |
 | Support MVP / n8n CRM bot | Separate later project | Not this repo’s M8+ north star |
 | M9–M11 depth | Client-triggered | Not required for demo-ready pause |
-| Thin M8 in delivery train | **Include** (#58–#60 after packaging) | Then pause for Support MVP |
+| Thin M8 in delivery train | **Include** (#58–#60 after packaging) | Then #57 video last; pause for Support MVP |
+| Demo video order | **Last** after thin M8 (#57) | Not a blocker for packaging or M8 |
 
 ---
 
@@ -336,12 +334,13 @@ After each phase slice: dispatch `docs-writer` to sync README + ROADMAP. Before 
 
 ```text
 Act as milestone-orchestrator. Run the delivery train:
-#53 → #54 → (#55 ∥ #56) → #57 → packaging → #58 → #59 → #60.
+packaging (minus video) → #58 → #59 → #60 → #57.
 
 - Follow docs/operators/PROJECT-DIRECTION.md, docs/operators/ROADMAP.md, and AGENTS.md
 - Specialists must NOT commit; you commit, push, and merge when verifier + CI are green
 - After each merge, send a short Status pulse
-- On hard gates (#57 video URL, secrets, CI still red): Blocker card (docs-writer polish) and STOP
+- On hard gates (secrets, CI still red): Blocker card (docs-writer polish) and STOP
+- #57 video is last: stop only when the train reaches recording (need public URL)
 - Do not start Support MVP in this repo; end with a phase-complete pulse
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Upload a confidential PDF (policies, SOPs, reports, contracts, or internal handb
 The live pilot is password-protected. Credentials are not published here.
 [Request access on Upwork](https://www.upwork.com/freelancers/roxanadev) for a walkthrough, or once you have access use the [sample NDA](docs/product/sample-nda.pdf) or the [sample retention policy](docs/product/sample-policy.md) (export the markdown to PDF).
 
-**Demo video:** Coming after the demo-ready recording pass. Storyboard: [docs/product/demo-script.md](docs/product/demo-script.md).
+**Demo video:** Coming after the thin API pass. Storyboard: [docs/product/demo-script.md](docs/product/demo-script.md).
 
 > **Privacy note:** Uploaded files are processed in memory and never stored. Each session starts fresh. Use only sample or non-confidential documents on the shared pilot. For sensitive documents, [deploy your own instance](DEPLOYMENT.md).
 
@@ -87,7 +87,7 @@ Follow the [Deployment Guide](DEPLOYMENT.md). It covers VPS sizing, HTTPS with C
 
 Eval corpus: [sample NDA](docs/product/sample-nda.pdf) · [sample retention policy](docs/product/sample-policy.md) · [pilot evaluation](docs/product/pilot-evaluation.md).
 
-**What's next on this product:** demo-ready recording and a calm walkthrough video. Deeper production (persistence, SSO, ops) lands when a pilot needs it. Full sequencing for contributors: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
+**What's next on this product:** a thin `/health` + `/chat` API, then a calm walkthrough video. Deeper production (persistence, SSO, ops) lands when a pilot needs it. Full sequencing for contributors: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
 
 ---
 

--- a/docs/operators/PROJECT-DIRECTION.md
+++ b/docs/operators/PROJECT-DIRECTION.md
@@ -6,7 +6,7 @@ How to finish this pipeline with Cursor discipline, code you understand, and a p
 
 Full milestone detail: [ROADMAP.md](ROADMAP.md) · Agent playbook: [AGENTS.md](../../AGENTS.md) · Docs index: [docs/README.md](../README.md)
 
-> **Takeaway:** Start Phase 1 at #53. Deep production waits for a real client.
+> **Takeaway:** Start thin M8 at #58 (video is last). Deep production waits for a real client.
 
 ---
 
@@ -15,9 +15,10 @@ Full milestone detail: [ROADMAP.md](ROADMAP.md) · Agent playbook: [AGENTS.md](.
 | Milestone | Goal | Status |
 |-----------|------|--------|
 | **M7** | Reference deployment | ✅ Shipped |
-| **M7.8** | Demo-ready LLM tier + streaming | 🚧 Next (#53–#57) |
-| **Video + packaging** | Walkthrough + calm README framing | After M7.8 |
-| **M8** | Thin `/health` + `/chat` API | After packaging (#58–#60) |
+| **M7.8–M7.96** | Demo tier, UI, Sources trust, repo clarity | ✅ Shipped |
+| **Packaging** | Calm README framing (video URL later) | Soft pass |
+| **M8** | Thin `/health` + `/chat` API | **Next** (#58–#60) |
+| **Video (#57)** | Walkthrough linked from README | **Last** after thin M8 |
 | **M8.5 / M9–M12** | Eval export; persist; SSO; ops; light pack | Optional / client-triggered |
 
 ---
@@ -38,7 +39,7 @@ This repo’s north star is **not** a website support assistant. Escalate/CRM be
 
 > Upload a confidential PDF, ask a question, get a **fast** answer with **page citations** on **your** infrastructure. Optionally expose a **thin** `/health` + `/chat` API for integrations; keep eval export and persistence for when a buyer asks.
 
-If that sentence feels true after **demo + video + packaging + thin M8**, this phase of the repo is complete. Then pause here and start the Support MVP sibling unless a paid client needs more depth.
+If that sentence feels true after **demo + packaging + thin M8 + video**, this phase of the repo is complete. Then pause here and start the Support MVP sibling unless a paid client needs more depth.
 
 ---
 
@@ -95,9 +96,10 @@ After each issue, you should answer **without opening Cursor**:
 | Phase | Milestones | “I’d use it / I’d show it” test |
 |-------|------------|----------------------------------|
 | **0** | M7 ✅ | You trust deploy; you don’t trust speed on VPS Ollama |
-| **1** | M7.8 → video → packaging | You’d show a colleague the video; README looks calm |
+| **1** | M7.8 → packaging | README looks calm; pilot + Cloud links clear |
 | **2** | Thin M8 | You’d call `/chat` from curl in a proposal |
-| **2b** | M8.5 (optional) | You’d send an eval report for a retrieval audit |
+| **2b** | Video (#57) | You’d show a colleague the walkthrough |
+| **2c** | M8.5 (optional) | You’d send an eval report for a retrieval audit |
 | **3** | M9–M11 | Client-triggered |
 | **4** | M12 light | Short tiers/services one-pager |
 
@@ -117,35 +119,47 @@ After each issue, you should answer **without opening Cursor**:
 
 ---
 
-### Phase 1: Demo, video & packaging 🚧 START HERE
+### Phase 1: Demo & packaging ✅ (M7.8–M7.96 shipped)
 
-**Milestones:** M7.8–M7.95 ✅ → **M7.96 Repo clarity** ([#89–#93](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/10), main only) → video (#57) → packaging checklist in [ROADMAP.md](ROADMAP.md)
+**Milestones:** M7.8–M7.96 ✅ → packaging soft pass (video URL deferred) → see Phase 2.
 
 | # | Issue | Agent map | You learn |
 |---|-------|-----------|-----------|
-| 53–56, 70–73, 80–83 | M7.8–M7.95 | (shipped) | Demo tier, UI, Sources trust |
-| 89 | REPO-STRUCTURE | docs-writer | Target tree, no shims |
-| 90 | Consolidate under `deploy/` | deploy-engineer, docs-writer | Compose contexts, real path moves |
-| 91 | Agentic surface tidy | docs-writer | `.cursor/` + AGENTS intentional |
-| 92 | README + docs index | docs-writer | Client first paint |
-| 93 | Templates + pre-commit | config-guardian, docs-writer | Contributor hygiene |
-| 57 | Record video + README link | docs-writer (you record) | Walkthrough asset |
+| 53–56, 70–73, 80–83, 89–93 | M7.8–M7.96 | (shipped) | Demo tier, UI, Sources trust, repo clarity |
+
+**M7.96 note:** left `deploy/stable` on v0.8.0; advance only when you intentionally choose to.
+
+---
+
+### Phase 1b: Packaging soft pass 🚧
+
+Calm README framing, honest tiers, thumbnail story. **Do not wait** on a video URL (that is #57 after M8). Checklist: [ROADMAP.md](ROADMAP.md).
+
+---
+
+### Phase 2: Thin API contract 🚧 START HERE
+
+**Milestones:** M8 ([#58–#60](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/2))
+
+Serial #58 → #59 → #60. Default delivery train after packaging soft pass. Does **not** wait on #57.
 
 ```mermaid
 flowchart LR
-  A["M7.95 done"] --> B["#89 ∥ #91"]
-  B --> C["#90 deploy/"]
-  C --> D["#92 README"]
-  D --> E["#93 tooling"]
+  A["M7.96 done"] --> B[Packaging]
+  B --> C["#58"]
+  C --> D["#59"]
+  D --> E["#60"]
   E --> F["#57 record"]
-  F --> G[Packaging]
-  G --> H[Thin M8]
-  H --> I[Phase pause]
+  F --> G[Phase pause]
 ```
 
-**M7.96 note:** merge to `main` only; leave `deploy/stable` on v0.8.0 until you intentionally advance it.
+After thin M8 + video: **pause** for Support MVP unless a paid engagement needs more here.
 
-After packaging + thin M8: **pause** for Support MVP unless a paid engagement needs more here.
+---
+
+### Phase 2b: Demo video (last)
+
+**Issue:** [#57](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/57) — record walkthrough; link from README. Human films; agents prepare storyboard/README line.
 
 **Env for recording (local, never commit)**
 
@@ -157,15 +171,7 @@ ANTHROPIC_API_KEY=sk-...
 
 ---
 
-### Phase 2: Thin API contract
-
-**Milestones:** M8 ([#58–#60](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/2))
-
-Serial #58 → #59 → #60. Included in the default delivery train after packaging.
-
----
-
-### Phase 2b: Eval export (optional / next)
+### Phase 2c: Eval export (optional / next)
 
 **Milestone:** M8.5 ([#61](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/61))
 
@@ -202,9 +208,9 @@ Not required for the demo-ready pause.
 
 Columns: `Backlog` | `Ready` | `In progress` | `In review` | `Done`
 
-**Ready now:** [#53](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/53)
+**Ready now:** packaging soft pass, then [#58](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/58)
 
-**Do not start:** [#57](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/57) (video) until #54–#56 done.
+**Do not start:** [#57](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/57) (video) until thin M8 (#58–#60) is done.
 
 ---
 
@@ -229,6 +235,7 @@ Columns: `Backlog` | `Ready` | `In progress` | `In review` | `Done`
 | Pitch vertical | Confidential **documents**, not legal-only |
 | Support MVP / n8n CRM bot | Separate later project |
 | Commit / merge | Train mode in AGENTS.md (orchestrator merges when green) |
+| Demo video order | **Last** after thin M8 (#57) | Not a blocker for packaging or M8 |
 
 ---
 

--- a/docs/operators/ROADMAP.md
+++ b/docs/operators/ROADMAP.md
@@ -4,7 +4,7 @@
 
 For contributors and operators. Moves the pipeline from a **reference deployment** to a **demo-ready** private document Q&A product: fast cited answers on a walkthrough, then a thin API for integrations. Deeper production work (persist / SSO / ops) is client-triggered, not the default climb after M7.
 
-> **Takeaway:** Ship M7.8 → video → packaging → thin M8. Support MVP / n8n CRM is a separate later project.
+> **Takeaway:** Ship M7.8 → packaging → thin M8 → video last. Support MVP / n8n CRM is a separate later project.
 
 **Positioning:** private **document Q&A** for confidential PDFs (contracts, policies, SOPs, reports, internal KB exports), not legal-only. LLM backend is swappable: local Ollama (air-gap) or Anthropic/OpenAI (speed for demos and pilots).
 
@@ -20,10 +20,10 @@ For contributors and operators. Moves the pipeline from a **reference deployment
 | **M7.8** | Demo-ready tier | Swappable LLM, streaming, recordable walkthrough | ✅ Done |
 | **M7.9** | Interface polish | Calm client UI | ✅ Done |
 | **M7.95** | Sources trust | Fewer, ranked, answer-overlapping citations | ✅ Done |
-| **M7.96** | Repo clarity | Professional layout; deploy assets under `deploy/` (no shims) | **Ship next** (main only) |
-| **Video (#57)** | Published walkthrough | Link in README | Soft: can film before or after M7.96 |
-| **Packaging** | Calm product framing | Clear pilot + Cloud + video links | After video |
-| **M8** | Thin FastAPI contract | OpenAPI `/health`, `/chat` | After packaging |
+| **M7.96** | Repo clarity | Professional layout; deploy assets under `deploy/` (no shims) | ✅ Done (main only) |
+| **Packaging** | Calm product framing | Clear pilot + Cloud links; video URL later | Soft pass after M7.96 |
+| **M8** | Thin FastAPI contract | OpenAPI `/health`, `/chat` | **Ship next** |
+| **Video (#57)** | Published walkthrough | Link in README | **Last** after thin M8 |
 | **M8.5** | Eval harness export | Before/after retrieval report | Optional |
 | **M9** | Persistent ingestion | PDFs + vectors survive restart | Client-triggered |
 | **M10** | Access control | SSO / auth proxy + `SECURITY.md` | Client-triggered |
@@ -55,25 +55,26 @@ For contributors and operators. Moves the pipeline from a **reference deployment
 | Phase | Milestones | Outcome you can stand behind |
 |-------|------------|------------------------------|
 | **0. Shipped** | M7 ✅ | Reproducible private pilot on one VM; live URL; deployment guide |
-| **1. Demo & trust** | **M7.8** → video → **packaging** | Fast, cited answers on a walkthrough; calm README; clear pilot + Cloud links |
+| **1. Demo & trust** | **M7.8** → **packaging** | Fast, cited answers; calm README; clear pilot + Cloud links |
 | **2. Thin API** | **M8** | Not Streamlit-only: `/health`, `/chat`, OpenAPI |
-| **2b. Optional** | **M8.5** eval | Reproducible retrieval report for audits |
+| **2b. Walkthrough** | **Video (#57)** | Published demo linked from README (last) |
+| **2c. Optional** | **M8.5** eval | Reproducible retrieval report for audits |
 | **3. Client-triggered** | M9 → M11 | Docs survive restart; SSO; runbooks when a pilot/RFP needs them |
 | **4. Light pack** | M12 | Pilot tiers / services one-pager |
 
 ```mermaid
 flowchart TD
   M7[M7 shipped] --> M78[M7.8 demo tier]
-  M78 --> V[Demo video]
-  V --> P[Packaging]
+  M78 --> P[Packaging]
   P --> M8[Thin M8 API]
-  M8 --> Pause[Phase pause]
+  M8 --> V[Demo video]
+  V --> Pause[Phase pause]
   Pause --> Support[Support MVP sibling project]
   M8 -.-> M85[M8.5 eval optional]
   Pause -.->|client-triggered| M9[M9–M11]
 ```
 
-**Phase pause** after packaging + thin M8: this repo is demo-ready and integration-ready. Then focus the Support MVP sibling unless a paid client needs more depth here. M8.5 and M9–M12 do not unlock Support MVP.
+**Phase pause** after thin M8 + video: this repo is demo-ready and integration-ready. Then focus the Support MVP sibling unless a paid client needs more depth here. M8.5 and M9–M12 do not unlock Support MVP.
 
 ---
 
@@ -99,7 +100,7 @@ flowchart TD
 
 ---
 
-## M7.8: Demo-ready tier 🚧 next
+## M7.8: Demo-ready tier ✅ shipped (#53–#56; #57 video last)
 
 **Target:** part-time · **5 issues** · `priority-ship-first`
 
@@ -123,7 +124,7 @@ flowchart TD
 | M7.8-4 | Product narrative ≠ code; eval corpus (NDA) ≠ market vertical |
 | M7.8-5 | Walkthrough asset; no new Python required |
 
-**Serial order:** #53 → #54 → #55; #56 parallel with #55; #57 after #54–#56.
+**Serial order:** #53 → #54 → #55; #56 parallel with #55; #57 last after thin M8 (#58–#60).
 
 GitHub milestone: [M7.8](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/7)
 
@@ -223,33 +224,22 @@ GitHub milestone: [M7.96 Repo clarity](https://github.com/RoxanaTapia/ai-doc-to-
 
 ---
 
-## Demo video (after M7.95; M7.96 optional before record)
-
-Storyboard: [`docs/product/demo-script.md`](../product/demo-script.md). Record using **Anthropic demo tier**; show architecture slide for **Ollama self-host**. Tracked as [#57](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/57).
-
-### Learnings
-
-- The video should show **retrieval + citations + deploy path**, not raw local inference speed.
-- Pre-warm the model; run storyboard questions once before Record.
-
----
-
-## Packaging (after video)
+## Packaging (after M7.96; before thin M8)
 
 | Item | Outcome |
 |------|---------|
 | Thumbnail story | Calm 16:9 still (upload → cited answer) |
 | README framing | Private document Q&A; pilot + Cloud links obvious |
-| Video link | README Demo video line points at published walkthrough |
 | Honest tiers | Demo (API LLM) vs self-host (Ollama) stated once |
+| Video link | Deferred to [#57](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/57) (after thin M8) |
 
-**Definition of done:** A first-time reader understands the product and where to go next in under a minute.
+**Definition of done:** A first-time reader understands the product and where to go next in under a minute (walkthrough URL can still say “coming soon”).
 
 ---
 
 ## M8: Thin FastAPI contract
 
-Thin integration surface after video + packaging. Enough for proposals and integrations. Not a large API rewrite gate.
+Thin integration surface after packaging. Enough for proposals and integrations. Not a large API rewrite gate. Does **not** wait on the demo video.
 
 | Issue | Outcome | GitHub |
 |-------|---------|--------|
@@ -262,6 +252,19 @@ Thin integration surface after video + packaging. Enough for proposals and integ
 **Serial:** #58 before #59–#60.
 
 GitHub milestone: [M8](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/2)
+
+---
+
+## Demo video (last; after thin M8)
+
+Storyboard: [`docs/product/demo-script.md`](../product/demo-script.md). Record using **Anthropic demo tier**; show architecture slide for **Ollama self-host**. Tracked as [#57](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/57).
+
+Film after packaging + thin M8 so the walkthrough can mention the live pilot and (optionally) `/health` + `/chat`. Then set the README **Demo video** line to the published URL.
+
+### Learnings
+
+- The video should show **retrieval + citations + deploy path**, not raw local inference speed.
+- Pre-warm the model; run storyboard questions once before Record.
 
 ---
 
@@ -318,8 +321,9 @@ GitHub milestone: [M8](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/mi
 | Stage | You can confidently offer |
 |-------|---------------------------|
 | **Now (M7)** | RAG retrieval review; private pilot deploy; live URL |
-| **After M7.8 + video + packaging** | Walkthrough with cited answers; clear demo vs self-host story |
+| **After M7.8 + packaging** | Clear demo vs self-host story; calm README |
 | **After thin M8** | Integrations via `/health` + `/chat` / OpenAPI |
+| **After video (#57)** | Walkthrough with cited answers linked from README |
 | **After M8.5** | Reproducible retrieval reports for audits |
 | **After M9–M11 (client-scoped)** | Deeper production contracts |
 
@@ -335,7 +339,7 @@ Browser → HTTPS (Caddy) → Streamlit and/or FastAPI
                               └── LLM (Ollama | Anthropic | OpenAI)
 ```
 
-**Today:** M7 shipped (Streamlit + Ollama + FAISS per session). **Next:** M7.8 swappable LLM + streaming → video → packaging → thin M8.
+**Today:** M7–M7.96 shipped (Streamlit + swappable LLM + FAISS per session; deploy under `deploy/`). **Next:** packaging → thin M8 → video last.
 
 Client-readable diagram: [product/architecture.md](../product/architecture.md).
 


### PR DESCRIPTION
## Main contribution

Reorders the delivery train so calm product packaging and the thin FastAPI slice ship before the walkthrough video. The demo recording stays a closing human step, not a gate that blocks integrations.

## Summary
- Train order: packaging → #58–#60 → #57 (video last)
- Sync AGENTS, ROADMAP, PROJECT-DIRECTION, and Cursor train helpers
- README: thin API next; video after that (link still deferred)

## Test plan
- [ ] Skim AGENTS delivery train table matches ROADMAP mermaid
- [ ] README first paint still clear without a video URL

Closes packaging soft pass (no dedicated issue). Unblocks #58.

Made with [Cursor](https://cursor.com)