### PR TITLE
feat(rag): extract src/rag/ package (M8-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Everything runs on one VM. Your documents never leave your environment (self-hos
 
 | Path | Role |
 |------|------|
-| `src/` | Application code (Streamlit UI and RAG pipeline) |
+| `src/` | Application code (Streamlit UI; RAG under `src/rag/`) |
 | `docs/` | Product and operator docs ([index](docs/README.md)) |
 | `deploy/` | Docker, Compose, and Caddy assets for self-host |
 | `.cursor/` | Agent rules, specialists, and slash commands |

--- a/docs/operators/PROJECT-DIRECTION.md
+++ b/docs/operators/PROJECT-DIRECTION.md
@@ -65,7 +65,7 @@ feat/m8-fastapi-chat       → closes #59
 
 **When stuck:** invoke `blocker-reporter` format in AGENTS.md; update Human decisions log; STOP.
 
-**Do not:** one mega-PR for multiple issues; parallel edits on `src/rag.py` + `src/app.py` across two issues.
+**Do not:** one mega-PR for multiple issues; parallel edits on `src/rag/` + `src/app.py` across two issues.
 
 ---
 
@@ -76,7 +76,7 @@ After each issue, you should answer **without opening Cursor**:
 | Layer | Files | Question to answer |
 |-------|-------|-------------------|
 | **UI** | `src/app.py` | What happens on upload → index → chat? |
-| **RAG** | `src/rag.py` → `src/rag/` (M8) | How does context get built before the LLM? |
+| **RAG** | `src/rag/` | How does context get built before the LLM? |
 | **Config** | `configs/config.yaml`, `.env` | What knob changes retrieval vs generation? |
 | **Deploy** | `docker-compose*.yml`, `DEPLOYMENT.md` | How does a request reach Ollama or API LLM? |
 

--- a/src/rag/__init__.py
+++ b/src/rag/__init__.py
@@ -1,0 +1,54 @@
+"""RAG generation package: config loaders, LLM providers, and answer entrypoints."""
+
+from rag.config import (
+    APP_ROOT,
+    CONFIG_PATH,
+    DEFAULT_ANTHROPIC_MODEL,
+    DEFAULT_PROMPT_TEMPLATE,
+    PROMPTS_PATH,
+    load_generation_config,
+    load_rag_prompt,
+)
+from rag.generation import generate_answer, generate_answer_stream
+from rag.providers import (
+    DUMMY_UI_RESPONSE,
+    SUPPORTED_LLM_PROVIDERS,
+    AnthropicLLMProvider,
+    ChatAnthropic,
+    ChatOllama,
+    DummyLLMProvider,
+    LLMProvider,
+    OllamaLLMProvider,
+    _generate_with_anthropic,
+    _generate_with_ollama,
+    _stream_with_anthropic,
+    _stream_with_ollama,
+    get_llm_provider,
+    resolve_llm_provider_name,
+)
+
+__all__ = [
+    "APP_ROOT",
+    "CONFIG_PATH",
+    "DEFAULT_ANTHROPIC_MODEL",
+    "DEFAULT_PROMPT_TEMPLATE",
+    "DUMMY_UI_RESPONSE",
+    "LLMProvider",
+    "PROMPTS_PATH",
+    "SUPPORTED_LLM_PROVIDERS",
+    "AnthropicLLMProvider",
+    "ChatAnthropic",
+    "ChatOllama",
+    "DummyLLMProvider",
+    "OllamaLLMProvider",
+    "generate_answer",
+    "generate_answer_stream",
+    "get_llm_provider",
+    "load_generation_config",
+    "load_rag_prompt",
+    "resolve_llm_provider_name",
+    "_generate_with_anthropic",
+    "_generate_with_ollama",
+    "_stream_with_anthropic",
+    "_stream_with_ollama",
+]

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -1,0 +1,124 @@
+"""Config and prompt loaders for the RAG generation stack."""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# src/rag/config.py → repo root
+APP_ROOT = Path(__file__).resolve().parents[2]
+PROMPTS_PATH = APP_ROOT / "configs" / "prompts.yaml"
+CONFIG_PATH = APP_ROOT / "configs" / "config.yaml"
+
+# Current Anthropic Haiku (fast demo/video). Override with ANTHROPIC_MODEL.
+DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
+DEFAULT_PROMPT_TEMPLATE = (
+    "You are a precise and concise legal assistant.\n"
+    "Answer ONLY using information from the provided context.\n"
+    "If there is no relevant information, say: "
+    '"I could not find enough information in the document to answer."\n\n'
+    "Extracted context:\n"
+    "{context}\n\n"
+    "User question:\n"
+    "{question}\n\n"
+    "Answer (keep it short, clear, and cite the source when possible):"
+)
+
+
+@lru_cache(maxsize=1)
+def load_rag_prompt() -> str:
+    """Load and cache the raw RAG prompt template from YAML config."""
+    if not PROMPTS_PATH.exists():
+        return DEFAULT_PROMPT_TEMPLATE
+    with PROMPTS_PATH.open(encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+    prompt_cfg = config.get("rag_prompt", {}) or {}
+    direct_template = prompt_cfg.get("template")
+    if direct_template:
+        return direct_template
+    system_template = (prompt_cfg.get("system_template") or "").strip()
+    user_template = (prompt_cfg.get("user_template") or "").strip()
+    if system_template and user_template:
+        return f"{system_template}\n\n{user_template}"
+    return DEFAULT_PROMPT_TEMPLATE
+
+
+@lru_cache(maxsize=1)
+def load_generation_config() -> dict[str, Any]:
+    """Load generation config with optional env overrides."""
+    config = {}
+    if CONFIG_PATH.exists():
+        with CONFIG_PATH.open(encoding="utf-8") as f:
+            config = yaml.safe_load(f) or {}
+
+    generation = (config.get("rag", {}) or {}).get("generation", {}) or {}
+
+    def _env_text(name: str) -> str | None:
+        """Return stripped env var text, treating empty values as unset."""
+        raw = os.getenv(name)
+        if raw is None:
+            return None
+        normalized = raw.strip()
+        return normalized if normalized else None
+
+    def _env_bool(name: str, default: bool) -> bool:
+        raw = _env_text(name)
+        if raw is None:
+            return default
+        return raw.lower() in {"1", "true", "yes", "on"}
+
+    def _env_float(name: str, default: float) -> float:
+        raw = _env_text(name)
+        if raw is None:
+            return float(default)
+        try:
+            return float(raw)
+        except ValueError:
+            logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+            return float(default)
+
+    def _env_int(name: str, default: int) -> int:
+        raw = _env_text(name)
+        if raw is None:
+            return int(default)
+        try:
+            return int(raw)
+        except ValueError:
+            logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+            return int(default)
+
+    default_model = str(generation.get("model", "llama3.1:8b"))
+    model_override = _env_text("OLLAMA_MODEL")
+    # Env wins when set; YAML `provider` is informational default for operators.
+    yaml_provider = str(generation.get("provider", "") or "").strip().lower()
+    env_provider = _env_text("LLM_PROVIDER")
+    anthropic_model = _env_text("ANTHROPIC_MODEL") or DEFAULT_ANTHROPIC_MODEL
+
+    return {
+        "provider": (env_provider or yaml_provider or "").lower() or None,
+        "model": model_override or default_model,
+        "anthropic_model": anthropic_model,
+        "temperature": _env_float("OLLAMA_TEMPERATURE", float(generation.get("temperature", 0.3))),
+        "top_p": _env_float("OLLAMA_TOP_P", float(generation.get("top_p", 0.9))),
+        "max_new_tokens": _env_int(
+            "OLLAMA_MAX_NEW_TOKENS",
+            int(generation.get("max_new_tokens", 256)),
+        ),
+        "do_sample": _env_bool("OLLAMA_DO_SAMPLE", bool(generation.get("do_sample", False))),
+        "fallback_to_dummy_on_error": _env_bool(
+            "OLLAMA_FALLBACK_TO_DUMMY",
+            bool(generation.get("fallback_to_dummy_on_error", False)),
+        ),
+        "num_ctx": _env_int("OLLAMA_NUM_CTX", int(generation.get("num_ctx", 4096))),
+        "timeout_seconds": _env_int(
+            "OLLAMA_TIMEOUT_SECONDS",
+            int(generation.get("timeout_seconds", 90)),
+        ),
+    }

--- a/src/rag/generation.py
+++ b/src/rag/generation.py
@@ -1,0 +1,76 @@
+"""Public generate / stream entrypoints for grounded answers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+from rag.providers import get_llm_provider, resolve_llm_provider_name
+
+CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0B-\x1F\x7F]")
+
+
+def _normalize_untrusted_text(text: str, max_chars: int) -> str:
+    """Trim and sanitize untrusted user/document text for prompting."""
+    cleaned = CONTROL_CHARS_RE.sub("", text or "").strip()
+    if len(cleaned) > max_chars:
+        return cleaned[:max_chars]
+    return cleaned
+
+
+def _prepare_generation_inputs(
+    context: str,
+    query: str,
+) -> tuple[str, str] | str:
+    """Validate/sanitize inputs. Return `(safe_context, safe_query)` or an error message."""
+    safe_query = _normalize_untrusted_text(query, max_chars=2000)
+    if not safe_query:
+        return "Please enter a non-empty question."
+    safe_context = _normalize_untrusted_text(context, max_chars=12000)
+    if not safe_context:
+        return "I could not find relevant information in the document to answer this question."
+    return safe_context, safe_query
+
+
+def generate_answer(context: str, query: str, dummy_mode: bool = True) -> str:
+    """Generate a response from retrieved context and user question.
+
+    Provider selection: explicit `LLM_PROVIDER` env wins; when unset, `dummy_mode`
+    (and thus Streamlit's `USE_DUMMY_GENERATOR`) maps to dummy vs ollama.
+    """
+    prepared = _prepare_generation_inputs(context, query)
+    if isinstance(prepared, str):
+        return prepared
+    safe_context, safe_query = prepared
+
+    provider_name = resolve_llm_provider_name(dummy_mode=dummy_mode)
+    provider = get_llm_provider(provider_name)
+    return provider.generate(safe_context, safe_query)
+
+
+def generate_answer_stream(
+    context: str,
+    query: str,
+    dummy_mode: bool = True,
+) -> Iterator[str]:
+    """Yield answer text chunks for progressive UI (`st.write_stream`).
+
+    Same provider selection and input validation as `generate_answer`. Providers
+    that support native streaming use `.stream()`; if streaming fails before any
+    chunk, the full `generate()` result is yielded as one chunk.
+    """
+    prepared = _prepare_generation_inputs(context, query)
+    if isinstance(prepared, str):
+        yield prepared
+        return
+    safe_context, safe_query = prepared
+
+    provider_name = resolve_llm_provider_name(dummy_mode=dummy_mode)
+    provider = get_llm_provider(provider_name)
+    stream_fn = getattr(provider, "stream", None)
+    if callable(stream_fn):
+        yield from stream_fn(safe_context, safe_query)
+        return
+    answer = provider.generate(safe_context, safe_query)
+    if answer:
+        yield answer

--- a/src/rag/providers.py
+++ b/src/rag/providers.py
@@ -1,34 +1,26 @@
+"""Swappable LLM backends for grounded answer generation."""
+
+from __future__ import annotations
+
 import logging
 import os
-import re
 from collections.abc import Iterator
-from functools import lru_cache
-from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
-import yaml
 from langchain_anthropic import ChatAnthropic
 from langchain_ollama import ChatOllama
 
-logger = logging.getLogger(__name__)
-CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0B-\x1F\x7F]")
-APP_ROOT = Path(__file__).resolve().parent.parent
-PROMPTS_PATH = APP_ROOT / "configs" / "prompts.yaml"
-CONFIG_PATH = APP_ROOT / "configs" / "config.yaml"
-SUPPORTED_LLM_PROVIDERS = frozenset({"ollama", "anthropic", "openai", "dummy"})
-# Current Anthropic Haiku (fast demo/video). Override with ANTHROPIC_MODEL.
-DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
-DEFAULT_PROMPT_TEMPLATE = (
-    "You are a precise and concise legal assistant.\n"
-    "Answer ONLY using information from the provided context.\n"
-    "If there is no relevant information, say: "
-    '"I could not find enough information in the document to answer."\n\n'
-    "Extracted context:\n"
-    "{context}\n\n"
-    "User question:\n"
-    "{question}\n\n"
-    "Answer (keep it short, clear, and cite the source when possible):"
+from rag.config import (
+    DEFAULT_ANTHROPIC_MODEL,
+    DEFAULT_PROMPT_TEMPLATE,
+    PROMPTS_PATH,
+    load_generation_config,
+    load_rag_prompt,
 )
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_LLM_PROVIDERS = frozenset({"ollama", "anthropic", "openai", "dummy"})
 DUMMY_UI_RESPONSE = (
     "This is a UI demo — no AI model is running here.\n\n"
     "Upload and search work, but answers are not generated on this host.\n\n"
@@ -48,106 +40,6 @@ class LLMProvider(Protocol):
     def stream(self, context: str, query: str) -> Iterator[str]:
         """Yield answer text chunks for progressive UI (e.g. `st.write_stream`)."""
         ...
-
-
-def _normalize_untrusted_text(text: str, max_chars: int) -> str:
-    """Trim and sanitize untrusted user/document text for prompting."""
-    cleaned = CONTROL_CHARS_RE.sub("", text or "").strip()
-    if len(cleaned) > max_chars:
-        return cleaned[:max_chars]
-    return cleaned
-
-
-@lru_cache(maxsize=1)
-def load_rag_prompt() -> str:
-    """Load and cache the raw RAG prompt template from YAML config."""
-    if not PROMPTS_PATH.exists():
-        return DEFAULT_PROMPT_TEMPLATE
-    with PROMPTS_PATH.open(encoding="utf-8") as f:
-        config = yaml.safe_load(f) or {}
-    prompt_cfg = config.get("rag_prompt", {}) or {}
-    direct_template = prompt_cfg.get("template")
-    if direct_template:
-        return direct_template
-    system_template = (prompt_cfg.get("system_template") or "").strip()
-    user_template = (prompt_cfg.get("user_template") or "").strip()
-    if system_template and user_template:
-        return f"{system_template}\n\n{user_template}"
-    return DEFAULT_PROMPT_TEMPLATE
-
-
-@lru_cache(maxsize=1)
-def load_generation_config() -> dict[str, Any]:
-    """Load generation config with optional env overrides."""
-    config = {}
-    if CONFIG_PATH.exists():
-        with CONFIG_PATH.open(encoding="utf-8") as f:
-            config = yaml.safe_load(f) or {}
-
-    generation = (config.get("rag", {}) or {}).get("generation", {}) or {}
-
-    def _env_text(name: str) -> str | None:
-        """Return stripped env var text, treating empty values as unset."""
-        raw = os.getenv(name)
-        if raw is None:
-            return None
-        normalized = raw.strip()
-        return normalized if normalized else None
-
-    def _env_bool(name: str, default: bool) -> bool:
-        raw = _env_text(name)
-        if raw is None:
-            return default
-        return raw.lower() in {"1", "true", "yes", "on"}
-
-    def _env_float(name: str, default: float) -> float:
-        raw = _env_text(name)
-        if raw is None:
-            return float(default)
-        try:
-            return float(raw)
-        except ValueError:
-            logger.warning("Invalid %s=%r; using default %s", name, raw, default)
-            return float(default)
-
-    def _env_int(name: str, default: int) -> int:
-        raw = _env_text(name)
-        if raw is None:
-            return int(default)
-        try:
-            return int(raw)
-        except ValueError:
-            logger.warning("Invalid %s=%r; using default %s", name, raw, default)
-            return int(default)
-
-    default_model = str(generation.get("model", "llama3.1:8b"))
-    model_override = _env_text("OLLAMA_MODEL")
-    # Env wins when set; YAML `provider` is informational default for operators.
-    yaml_provider = str(generation.get("provider", "") or "").strip().lower()
-    env_provider = _env_text("LLM_PROVIDER")
-    anthropic_model = _env_text("ANTHROPIC_MODEL") or DEFAULT_ANTHROPIC_MODEL
-
-    return {
-        "provider": (env_provider or yaml_provider or "").lower() or None,
-        "model": model_override or default_model,
-        "anthropic_model": anthropic_model,
-        "temperature": _env_float("OLLAMA_TEMPERATURE", float(generation.get("temperature", 0.3))),
-        "top_p": _env_float("OLLAMA_TOP_P", float(generation.get("top_p", 0.9))),
-        "max_new_tokens": _env_int(
-            "OLLAMA_MAX_NEW_TOKENS",
-            int(generation.get("max_new_tokens", 256)),
-        ),
-        "do_sample": _env_bool("OLLAMA_DO_SAMPLE", bool(generation.get("do_sample", False))),
-        "fallback_to_dummy_on_error": _env_bool(
-            "OLLAMA_FALLBACK_TO_DUMMY",
-            bool(generation.get("fallback_to_dummy_on_error", False)),
-        ),
-        "num_ctx": _env_int("OLLAMA_NUM_CTX", int(generation.get("num_ctx", 4096))),
-        "timeout_seconds": _env_int(
-            "OLLAMA_TIMEOUT_SECONDS",
-            int(generation.get("timeout_seconds", 90)),
-        ),
-    }
 
 
 def _format_prompt(template: str, context: str, query: str) -> str:
@@ -404,61 +296,3 @@ def get_llm_provider(
         f"Unknown LLM provider {normalized!r}. "
         f"Expected one of: {', '.join(sorted(SUPPORTED_LLM_PROVIDERS))}."
     )
-
-
-def _prepare_generation_inputs(
-    context: str,
-    query: str,
-) -> tuple[str, str] | str:
-    """Validate/sanitize inputs. Return `(safe_context, safe_query)` or an error message."""
-    safe_query = _normalize_untrusted_text(query, max_chars=2000)
-    if not safe_query:
-        return "Please enter a non-empty question."
-    safe_context = _normalize_untrusted_text(context, max_chars=12000)
-    if not safe_context:
-        return "I could not find relevant information in the document to answer this question."
-    return safe_context, safe_query
-
-
-def generate_answer(context: str, query: str, dummy_mode: bool = True) -> str:
-    """Generate a response from retrieved context and user question.
-
-    Provider selection: explicit `LLM_PROVIDER` env wins; when unset, `dummy_mode`
-    (and thus Streamlit's `USE_DUMMY_GENERATOR`) maps to dummy vs ollama.
-    """
-    prepared = _prepare_generation_inputs(context, query)
-    if isinstance(prepared, str):
-        return prepared
-    safe_context, safe_query = prepared
-
-    provider_name = resolve_llm_provider_name(dummy_mode=dummy_mode)
-    provider = get_llm_provider(provider_name)
-    return provider.generate(safe_context, safe_query)
-
-
-def generate_answer_stream(
-    context: str,
-    query: str,
-    dummy_mode: bool = True,
-) -> Iterator[str]:
-    """Yield answer text chunks for progressive UI (`st.write_stream`).
-
-    Same provider selection and input validation as `generate_answer`. Providers
-    that support native streaming use `.stream()`; if streaming fails before any
-    chunk, the full `generate()` result is yielded as one chunk.
-    """
-    prepared = _prepare_generation_inputs(context, query)
-    if isinstance(prepared, str):
-        yield prepared
-        return
-    safe_context, safe_query = prepared
-
-    provider_name = resolve_llm_provider_name(dummy_mode=dummy_mode)
-    provider = get_llm_provider(provider_name)
-    stream_fn = getattr(provider, "stream", None)
-    if callable(stream_fn):
-        yield from stream_fn(safe_context, safe_query)
-        return
-    answer = provider.generate(safe_context, safe_query)
-    if answer:
-        yield answer

--- a/tests/test_rag_generation.py
+++ b/tests/test_rag_generation.py
@@ -40,7 +40,7 @@ def test_generate_answer_real_mode_calls_ollama_wrapper(monkeypatch) -> None:
         captured["settings"] = settings
         return "final from ollama"
 
-    monkeypatch.setattr(rag, "_generate_with_ollama", _fake_generate)
+    monkeypatch.setattr(rag.providers, "_generate_with_ollama", _fake_generate)
 
     answer = rag.generate_answer(
         context="Clause 5: Non-compete applies for 3 years.",
@@ -61,9 +61,9 @@ def test_generate_answer_passes_settings_to_ollama_wrapper(monkeypatch) -> None:
         captured["settings"] = settings
         return "ok"
 
-    monkeypatch.setattr(rag, "_generate_with_ollama", _fake_generate)
+    monkeypatch.setattr(rag.providers, "_generate_with_ollama", _fake_generate)
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "load_generation_config",
         lambda: {
             "model": "phi3:mini",
@@ -99,9 +99,9 @@ def test_generate_with_ollama_respects_config_and_prompt(monkeypatch) -> None:
             created["prompt"] = prompt
             return SimpleNamespace(content=" Generated answer. ")
 
-    monkeypatch.setattr(rag, "ChatOllama", FakeChatOllama)
+    monkeypatch.setattr(rag.providers, "ChatOllama", FakeChatOllama)
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "load_generation_config",
         lambda: {
             "model": "phi3:mini",
@@ -115,7 +115,7 @@ def test_generate_with_ollama_respects_config_and_prompt(monkeypatch) -> None:
         },
     )
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "load_rag_prompt",
         lambda: "CTX={context}\nQ={question}\nA=",
     )
@@ -136,14 +136,14 @@ def test_generate_with_ollama_respects_config_and_prompt(monkeypatch) -> None:
 
 def test_generate_answer_falls_back_to_dummy_when_enabled(monkeypatch) -> None:
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "_generate_with_ollama",
         lambda context, query, settings=None: (_ for _ in ()).throw(
             ConnectionError("connection refused")
         ),
     )
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "load_generation_config",
         lambda: {"fallback_to_dummy_on_error": True},
     )
@@ -160,14 +160,14 @@ def test_generate_answer_falls_back_to_dummy_when_enabled(monkeypatch) -> None:
 
 def test_generate_answer_raises_structured_error_when_fallback_disabled(monkeypatch) -> None:
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "_generate_with_ollama",
         lambda context, query, settings=None: (_ for _ in ()).throw(
             RuntimeError("model not found")
         ),
     )
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "load_generation_config",
         lambda: {"fallback_to_dummy_on_error": False},
     )
@@ -187,12 +187,12 @@ def test_generate_answer_raises_structured_error_when_fallback_disabled(monkeypa
 
 def test_generate_answer_raises_structured_timeout_when_fallback_disabled(monkeypatch) -> None:
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "_generate_with_ollama",
         lambda context, query, settings=None: (_ for _ in ()).throw(TimeoutError("timed out")),
     )
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "load_generation_config",
         lambda: {"fallback_to_dummy_on_error": False},
     )
@@ -252,7 +252,7 @@ def test_generate_answer_llm_provider_dummy_env(monkeypatch) -> None:
 def test_generate_answer_llm_provider_ollama_env(monkeypatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "_generate_with_ollama",
         lambda context, query, settings=None: "via env",
     )
@@ -268,7 +268,7 @@ def test_generate_answer_llm_provider_anthropic_env(monkeypatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "anthropic")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "_generate_with_anthropic",
         lambda context, query, settings=None: "via anthropic",
     )
@@ -292,9 +292,9 @@ def test_generate_with_anthropic_respects_config_and_prompt(monkeypatch) -> None
             return SimpleNamespace(content=" Cited answer. ")
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-not-real")
-    monkeypatch.setattr(rag, "ChatAnthropic", FakeChatAnthropic)
+    monkeypatch.setattr(rag.providers, "ChatAnthropic", FakeChatAnthropic)
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "load_generation_config",
         lambda: {
             "anthropic_model": "claude-haiku-4-5-20251001",
@@ -306,7 +306,7 @@ def test_generate_with_anthropic_respects_config_and_prompt(monkeypatch) -> None
         },
     )
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "load_rag_prompt",
         lambda: "CTX={context}\nQ={question}\nA=",
     )
@@ -340,7 +340,7 @@ def test_anthropic_provider_generate_routes_and_invokes(monkeypatch) -> None:
         captured["settings"] = settings
         return "anthropic answer"
 
-    monkeypatch.setattr(rag, "_generate_with_anthropic", _fake_generate)
+    monkeypatch.setattr(rag.providers, "_generate_with_anthropic", _fake_generate)
     provider = rag.AnthropicLLMProvider(
         settings={
             "anthropic_model": "claude-haiku-4-5-20251001",
@@ -415,9 +415,9 @@ def test_stream_with_anthropic_uses_langchain_stream(monkeypatch) -> None:
             raise AssertionError("invoke should not be used for streaming path")
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-not-real")
-    monkeypatch.setattr(rag, "ChatAnthropic", FakeChatAnthropic)
+    monkeypatch.setattr(rag.providers, "ChatAnthropic", FakeChatAnthropic)
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "load_generation_config",
         lambda: {
             "anthropic_model": "claude-haiku-4-5-20251001",
@@ -428,7 +428,7 @@ def test_stream_with_anthropic_uses_langchain_stream(monkeypatch) -> None:
             "timeout_seconds": 30,
         },
     )
-    monkeypatch.setattr(rag, "load_rag_prompt", lambda: "CTX={context}\nQ={question}\nA=")
+    monkeypatch.setattr(rag.providers, "load_rag_prompt", lambda: "CTX={context}\nQ={question}\nA=")
 
     chunks = list(rag._stream_with_anthropic("Context text", "Question text"))
 
@@ -447,7 +447,7 @@ def test_generate_answer_stream_anthropic_env(monkeypatch) -> None:
         yield "chunk-a"
         yield "chunk-b"
 
-    monkeypatch.setattr(rag, "_stream_with_anthropic", _fake_stream)
+    monkeypatch.setattr(rag.providers, "_stream_with_anthropic", _fake_stream)
 
     chunks = list(
         rag.generate_answer_stream(
@@ -466,9 +466,9 @@ def test_anthropic_provider_stream_falls_back_to_generate(monkeypatch) -> None:
         raise ConnectionError("stream broken")
         yield  # pragma: no cover — make this a generator
 
-    monkeypatch.setattr(rag, "_stream_with_anthropic", _failing_stream)
+    monkeypatch.setattr(rag.providers, "_stream_with_anthropic", _failing_stream)
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "_generate_with_anthropic",
         lambda context, query, settings=None: "fallback full answer",
     )
@@ -502,9 +502,9 @@ def test_stream_with_ollama_uses_langchain_stream(monkeypatch) -> None:
         def invoke(self, prompt):
             raise AssertionError("invoke should not be used for streaming path")
 
-    monkeypatch.setattr(rag, "ChatOllama", FakeChatOllama)
+    monkeypatch.setattr(rag.providers, "ChatOllama", FakeChatOllama)
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "load_generation_config",
         lambda: {
             "model": "phi3:mini",
@@ -517,7 +517,7 @@ def test_stream_with_ollama_uses_langchain_stream(monkeypatch) -> None:
             "timeout_seconds": 30,
         },
     )
-    monkeypatch.setattr(rag, "load_rag_prompt", lambda: "CTX={context}\nQ={question}\nA=")
+    monkeypatch.setattr(rag.providers, "load_rag_prompt", lambda: "CTX={context}\nQ={question}\nA=")
 
     chunks = list(rag._stream_with_ollama("Context text", "Question text"))
 
@@ -534,9 +534,9 @@ def test_generate_answer_stream_ollama_falls_back_to_generate(monkeypatch) -> No
         raise TimeoutError("stream timed out")
         yield  # pragma: no cover
 
-    monkeypatch.setattr(rag, "_stream_with_ollama", _failing_stream)
+    monkeypatch.setattr(rag.providers, "_stream_with_ollama", _failing_stream)
     monkeypatch.setattr(
-        rag,
+        rag.providers,
         "_generate_with_ollama",
         lambda context, query, settings=None: "non-stream answer",
     )


### PR DESCRIPTION
## Main contribution

Moves the generation stack from a single `src/rag.py` into a small `src/rag/` package (config, providers, generate/stream). Streamlit and tests keep the same public imports, with no answer-behavior change — the first step toward a thin `/chat` API.

## Summary
- Add `src/rag/{config,providers,generation}.py` + package `__init__` re-exports
- Remove monolithic `src/rag.py`
- Retarget generation tests to patch `rag.providers` internals
- Light README / operator path updates

## Test plan
- [x] `pytest tests/ -v` (80 passed)
- [x] `ruff check src/rag`
- [ ] Spot-check: Streamlit still imports `from rag import generate_answer, ...`

Closes #58

Made with [Cursor](https://cursor.com)