### PR TITLE
feat(api): thin FastAPI /health and /chat (M8-2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,7 @@ USE_DUMMY_GENERATOR=
 LLM_PROVIDER=
 
 # Optional Anthropic model override when LLM_PROVIDER=anthropic.
-# Empty = claude-haiku-4-5-20251001 (code default in src/rag.py).
+# Empty = claude-haiku-4-5-20251001 (code default in src/rag/).
 ANTHROPIC_MODEL=
 
 # Optional Ollama generation overrides (empty = configs/config.yaml rag.generation)
@@ -56,6 +56,12 @@ OLLAMA_DO_SAMPLE=
 OLLAMA_FALLBACK_TO_DUMMY=
 OLLAMA_NUM_CTX=
 OLLAMA_TIMEOUT_SECONDS=
+
+# Thin FastAPI (optional; M8)
+# Local: PYTHONPATH=src uvicorn api.app:app --reload --port 8000
+# Compose: docker compose -f deploy/docker-compose.yml up api
+# API_HOST=
+# API_PORT=8000
 
 # UI presentation (Streamlit sidebar)
 # Default: client-facing pilot (no dev toggle, no retrieval debug).

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -177,6 +177,19 @@ docker compose -f deploy/docker-compose.yml up --build -d
 
 Open [http://localhost:8501](http://localhost:8501). Port 8501 binds to the host in the default (non-Caddy) Compose config.
 
+### Thin API (optional)
+
+Same Docker image; OpenAPI at `/docs`. Pass retrieved `context` with each `POST /chat` (no document store yet).
+
+```bash
+# Local (repo root, venv active)
+PYTHONPATH=src uvicorn api.app:app --host 127.0.0.1 --port 8000
+
+# Compose profile
+docker compose -f deploy/docker-compose.yml --profile api up --build -d api
+curl -s http://localhost:8000/health
+```
+
 For Caddy locally: same `--env-file .env -p ai-doc-to-chat-pipeline -f deploy/…` flow with `CADDYFILE=./Caddyfile.ip` and a self-signed cert.
 
 ---

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -36,5 +36,37 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # Thin M8 API (optional). Same image as app; OpenAPI at http://localhost:8000/docs
+  api:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+    env_file:
+      - path: ../.env
+        required: false
+    ports:
+      - "${API_PORT:-8000}:8000"
+    environment:
+      PYTHONPATH: /app/src
+      OLLAMA_HOST: http://ollama:11434
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-llama3.1:8b}
+      USE_DUMMY_GENERATOR: "false"
+      LLM_PROVIDER: ${LLM_PROVIDER:-}
+    command:
+      [
+        "uvicorn",
+        "api.app:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8000",
+      ]
+    depends_on:
+      ollama:
+        condition: service_healthy
+    restart: unless-stopped
+    profiles:
+      - api
+
 volumes:
   ollama_models:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,11 @@
 # Core framework & UI
 streamlit>=1.54.0,<1.55.0                  # Modern file uploader, fragments, stable UI
 
+# Thin integration API (M8)
+fastapi>=0.115.0,<1.0.0                    # GET /health, POST /chat, OpenAPI
+uvicorn[standard]>=0.32.0,<1.0.0           # ASGI server for src/api
+httpx>=0.27.0,<1.0.0                       # FastAPI TestClient + optional Streamlit client
+
 # Document processing & OCR
 pymupdf>=1.27.1                            # Fast PDF text + metadata extraction
 pytesseract>=0.3.13                        # Tesseract OCR wrapper (requires Tesseract binary installed)

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,1 @@
+"""Thin FastAPI integration surface (`/health`, `/chat`)."""

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,0 +1,40 @@
+"""Thin FastAPI app: GET /health, POST /chat, OpenAPI at /docs."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from api.schemas import ChatRequest, ChatResponse, HealthResponse
+from rag import generate_answer, resolve_llm_provider_name
+
+app = FastAPI(
+    title="AI Doc Chat API",
+    description=(
+        "Thin integration surface for private document Q&A. "
+        "Pass retrieved context with each chat request; persistence is optional later."
+    ),
+    version="0.1.0",
+)
+
+
+@app.get("/health", response_model=HealthResponse, tags=["ops"])
+def health() -> HealthResponse:
+    """Liveness check for probes and proposal demos."""
+    return HealthResponse()
+
+
+@app.post("/chat", response_model=ChatResponse, tags=["chat"])
+def chat(body: ChatRequest) -> ChatResponse:
+    """Return a grounded answer using the same LLM providers as the Streamlit app."""
+    dummy_mode = True if body.dummy_mode is None else body.dummy_mode
+    provider = resolve_llm_provider_name(dummy_mode=dummy_mode)
+    answer = generate_answer(
+        context=body.context,
+        query=body.query,
+        dummy_mode=dummy_mode,
+    )
+    return ChatResponse(
+        answer=answer,
+        provider=provider,
+        session_id=body.session_id,
+    )

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -1,0 +1,46 @@
+"""Request/response models for the thin chat API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class HealthResponse(BaseModel):
+    """Liveness payload for `GET /health`."""
+
+    status: str = "ok"
+    service: str = "ai-doc-api"
+
+
+class ChatRequest(BaseModel):
+    """Grounded chat request.
+
+    Pass retrieved ``context`` with the ``query``. Session/document persistence
+    is out of scope for thin M8 (see M9); optional ``session_id`` is reserved.
+    """
+
+    query: str = Field(..., min_length=1, description="User question")
+    context: str = Field(
+        ...,
+        min_length=1,
+        description="Retrieved document context used to ground the answer",
+    )
+    session_id: str | None = Field(
+        default=None,
+        description="Optional client correlation id (not persisted in thin M8)",
+    )
+    dummy_mode: bool | None = Field(
+        default=None,
+        description=(
+            "When set, maps to dummy vs ollama if LLM_PROVIDER is unset. "
+            "Omit to follow LLM_PROVIDER / server defaults (dummy_mode=True)."
+        ),
+    )
+
+
+class ChatResponse(BaseModel):
+    """Grounded answer JSON for `POST /chat`."""
+
+    answer: str
+    provider: str
+    session_id: str | None = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,93 @@
+"""Thin FastAPI /health and /chat contract tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from api.app import app  # noqa: E402
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_llm_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+
+def test_health_ok(client: TestClient) -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "service": "ai-doc-api"}
+
+
+def test_chat_dummy_returns_placeholder(client: TestClient) -> None:
+    response = client.post(
+        "/chat",
+        json={
+            "query": "What is the notice period?",
+            "context": "Section A says notice period is 30 days.",
+            "dummy_mode": True,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["provider"] == "dummy"
+    assert "no AI model is running here" in payload["answer"]
+    assert payload["session_id"] is None
+
+
+def test_chat_echoes_session_id(client: TestClient) -> None:
+    response = client.post(
+        "/chat",
+        json={
+            "query": "Hello?",
+            "context": "Some context for grounding.",
+            "session_id": "sess-1",
+            "dummy_mode": True,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["session_id"] == "sess-1"
+
+
+def test_chat_rejects_empty_query(client: TestClient) -> None:
+    response = client.post(
+        "/chat",
+        json={"query": "", "context": "Some context", "dummy_mode": True},
+    )
+    assert response.status_code == 422
+
+
+def test_chat_llm_provider_env_wins(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "dummy")
+    response = client.post(
+        "/chat",
+        json={
+            "query": "What applies?",
+            "context": "Clause text",
+            "dummy_mode": False,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["provider"] == "dummy"
+
+
+def test_openapi_available(client: TestClient) -> None:
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    paths = response.json()["paths"]
+    assert "/health" in paths
+    assert "/chat" in paths


### PR DESCRIPTION
## Main contribution

Adds a thin FastAPI surface (`GET /health`, `POST /chat`, OpenAPI at `/docs`) that reuses the `src/rag/` generation stack. Callers pass retrieved context with each request — enough for integrations and proposals without waiting on persistence.

## Summary
- `src/api/` app + Pydantic schemas
- Contract tests with FastAPI TestClient
- `fastapi` / `uvicorn` / `httpx` in requirements
- Optional Compose service behind `--profile api`
- DEPLOYMENT + `.env.example` notes

## Test plan
- [x] `pytest tests/ -q` (all green)
- [x] `ruff check src/api`
- [ ] `PYTHONPATH=src uvicorn api.app:app --port 8000` then `curl /health` and `POST /chat` with dummy context

Closes #59

Made with [Cursor](https://cursor.com)