### PR TITLE
feat(ui): Streamlit optional API backend (M8-3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,9 +59,13 @@ OLLAMA_TIMEOUT_SECONDS=
 
 # Thin FastAPI (optional; M8)
 # Local: PYTHONPATH=src uvicorn api.app:app --reload --port 8000
-# Compose: docker compose -f deploy/docker-compose.yml up api
+# Compose: docker compose -f deploy/docker-compose.yml --profile api up -d api
 # API_HOST=
 # API_PORT=8000
+# When set, Streamlit POSTs /chat here instead of in-process generation.
+# Compose example (app → api service): API_BASE_URL=http://api:8000
+# Local example: API_BASE_URL=http://127.0.0.1:8000
+API_BASE_URL=
 
 # UI presentation (Streamlit sidebar)
 # Default: client-facing pilot (no dev toggle, no retrieval debug).

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -190,6 +190,8 @@ docker compose -f deploy/docker-compose.yml --profile api up --build -d api
 curl -s http://localhost:8000/health
 ```
 
+Streamlit stays in-process by default. To route generation through the API, set `API_BASE_URL` (e.g. `http://127.0.0.1:8000` locally, or `http://api:8000` between Compose services).
+
 For Caddy locally: same `--env-file .env -p ai-doc-to-chat-pipeline -f deploy/…` flow with `CADDYFILE=./Caddyfile.ip` and a self-signed cert.
 
 ---

--- a/src/api_client.py
+++ b/src/api_client.py
@@ -1,0 +1,70 @@
+"""Optional HTTP client: Streamlit → thin FastAPI when API_BASE_URL is set."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Iterator
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+def api_base_url() -> str | None:
+    """Return stripped API base URL, or None when Streamlit should generate in-process."""
+    raw = (os.getenv("API_BASE_URL") or "").strip()
+    if not raw:
+        return None
+    return raw.rstrip("/")
+
+
+def chat_via_api(
+    *,
+    context: str,
+    query: str,
+    dummy_mode: bool = True,
+    session_id: str | None = None,
+    timeout_seconds: float = 120.0,
+) -> str:
+    """POST /chat and return the answer string. Raises on transport/HTTP errors."""
+    base = api_base_url()
+    if not base:
+        raise RuntimeError("API_BASE_URL is not set")
+
+    payload = {
+        "query": query,
+        "context": context,
+        "dummy_mode": dummy_mode,
+    }
+    if session_id:
+        payload["session_id"] = session_id
+
+    with httpx.Client(timeout=timeout_seconds) as client:
+        response = client.post(f"{base}/chat", json=payload)
+        response.raise_for_status()
+        data = response.json()
+    answer = data.get("answer")
+    if not isinstance(answer, str):
+        raise RuntimeError("API /chat response missing string 'answer'")
+    return answer
+
+
+def chat_via_api_stream(
+    *,
+    context: str,
+    query: str,
+    dummy_mode: bool = True,
+    session_id: str | None = None,
+    timeout_seconds: float = 120.0,
+) -> Iterator[str]:
+    """Yield the API answer as one chunk (thin /chat is non-streaming today)."""
+    answer = chat_via_api(
+        context=context,
+        query=query,
+        dummy_mode=dummy_mode,
+        session_id=session_id,
+        timeout_seconds=timeout_seconds,
+    )
+    if answer:
+        yield answer

--- a/src/app.py
+++ b/src/app.py
@@ -19,6 +19,7 @@ from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_community.vectorstores import FAISS
 from langchain_core.documents import Document
+from api_client import api_base_url, chat_via_api, chat_via_api_stream
 from rag import (
     generate_answer,
     generate_answer_stream,
@@ -1795,23 +1796,38 @@ if query and query.strip() and chat_ready:
         timer_placeholder.empty()
 
         # Stream tokens after retrieval so the UI feels responsive; fall back if needed.
+        # When API_BASE_URL is set, generation goes through the thin FastAPI /chat.
         if need_stream_generation:
             generation_start = time.perf_counter()
             dummy_mode = st.session_state.dummy_generator_only
+            use_api = bool(api_base_url())
             try:
                 try:
+                    stream_fn = (
+                        chat_via_api_stream
+                        if use_api
+                        else generate_answer_stream
+                    )
                     streamed = st.write_stream(
-                        generate_answer_stream(
+                        stream_fn(
                             context=context,
                             query=query,
                             dummy_mode=dummy_mode,
                         )
                     )
                 except Exception:
-                    full_answer = generate_answer(
-                        context=context,
-                        query=query,
-                        dummy_mode=dummy_mode,
+                    full_answer = (
+                        chat_via_api(
+                            context=context,
+                            query=query,
+                            dummy_mode=dummy_mode,
+                        )
+                        if use_api
+                        else generate_answer(
+                            context=context,
+                            query=query,
+                            dummy_mode=dummy_mode,
+                        )
                     )
                     streamed = st.write_stream(_stream_text_chunks(full_answer))
                     if not streamed:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,72 @@
+"""Tests for optional Streamlit → FastAPI client."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+import api_client  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clear_api_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("API_BASE_URL", raising=False)
+
+
+def test_api_base_url_unset() -> None:
+    assert api_client.api_base_url() is None
+
+
+def test_api_base_url_strips_trailing_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_BASE_URL", "http://api:8000/")
+    assert api_client.api_base_url() == "http://api:8000"
+
+
+def test_chat_via_api_posts_and_returns_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_BASE_URL", "http://api.test")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/chat"
+        body = request.read()
+        assert b"notice period" in body
+        return httpx.Response(200, json={"answer": "30 days", "provider": "dummy"})
+
+    transport = httpx.MockTransport(handler)
+
+    class _Client(httpx.Client):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(api_client.httpx, "Client", _Client)
+    answer = api_client.chat_via_api(
+        context="Section A: 30 days notice.",
+        query="What is the notice period?",
+        dummy_mode=True,
+    )
+    assert answer == "30 days"
+
+
+def test_chat_via_api_stream_yields_one_chunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_BASE_URL", "http://api.test")
+    monkeypatch.setattr(
+        api_client,
+        "chat_via_api",
+        lambda **kwargs: "full answer",
+    )
+    assert list(
+        api_client.chat_via_api_stream(context="ctx", query="q", dummy_mode=True)
+    ) == ["full answer"]
+
+
+def test_chat_via_api_requires_base_url() -> None:
+    with pytest.raises(RuntimeError, match="API_BASE_URL"):
+        api_client.chat_via_api(context="ctx", query="q")


### PR DESCRIPTION
## Main contribution

Lets Streamlit optionally call the thin FastAPI `/chat` when `API_BASE_URL` is set, while keeping the default in-process generation path unchanged. Operators can split UI and API processes without requiring it for the pilot.

## Summary
- Add `src/api_client.py` (httpx POST /chat)
- Wire Streamlit generation to use API when env is set
- Document `API_BASE_URL` in `.env.example` and DEPLOYMENT
- Unit tests for the client

## Test plan
- [x] `pytest tests/ -q` (91 passed)
- [ ] Streamlit without `API_BASE_URL` still answers in-process
- [ ] With API up and `API_BASE_URL=http://127.0.0.1:8000`, chat still returns answers

Closes #60

Made with [Cursor](https://cursor.com)