### PR TITLE
docs: thin M8 shipped; video is next

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Full detail: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
 
 ## 🎯 Current focus
 
-- **Ship next:** packaging soft pass (no video URL required) → thin M8 (#58–#60) → demo video (#57) last.
+- **Ship next:** demo video (#57) last — thin M8 (#58–#60) shipped; need public walkthrough URL.
 - **Do not** bump `deploy/stable` unless the operator asks (VPS/Cloud stay on v0.8.0).
 - **Then pause** this repo for the Support MVP sibling unless a paid engagement needs more depth here.
 - **Later / on demand:** M8.5, M9–M11.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Follow the [Deployment Guide](DEPLOYMENT.md). It covers VPS sizing, HTTPS with C
 
 Eval corpus: [sample NDA](docs/product/sample-nda.pdf) · [sample retention policy](docs/product/sample-policy.md) · [pilot evaluation](docs/product/pilot-evaluation.md).
 
-**What's next on this product:** a thin `/health` + `/chat` API, then a calm walkthrough video. Deeper production (persistence, SSO, ops) lands when a pilot needs it. Full sequencing for contributors: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
+**What's next on this product:** a calm walkthrough video (thin `/health` + `/chat` API is ready). Deeper production (persistence, SSO, ops) lands when a pilot needs it. Full sequencing for contributors: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
 
 ---
 


### PR DESCRIPTION
## Main contribution

Updates operator and README focus after thin M8 landed: the walkthrough video is the remaining closing step before phase pause.

## Summary
- AGENTS current focus → #57
- README what's next → walkthrough video

## Test plan
- [ ] Skim AGENTS delivery train matches shipped state


Made with [Cursor](https://cursor.com)