### PR TITLE
Caddy site block for receipt-intelligence.roxanatapia.dev

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -157,6 +157,28 @@ Open `https://YOUR_DOMAIN/` for the gate, then **Sign in** → `/app`. Upload a 
 
 **Apex landing** (`roxanatapia.dev`) is served from the same Caddy process via static files under `/srv/roxanatapia-web/sites/apex`. Marketing sites and cutover steps: [roxanatapia-web deploy/CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md). Deploy those files on the VPS before reloading Caddy.
 
+**Receipt Intelligence host** (`receipt-intelligence.roxanatapia.dev`) is also terminated by this repo's Caddy (same edge as pilot + apex). Create the shared Docker network once (`docker network create edge`); the Caddy overlay attaches only the `caddy` service to it. Upstream API and n8n run in the sibling project [receipt-intelligence-demo](https://github.com/RoxanaTapia/receipt-intelligence-demo) via its `docker-compose.shared-edge.yml` overlay, with stable aliases `receipt-api:8000` and `receipt-n8n:5678`. Edge basic auth (`caddy-basicauth.conf`) wraps the whole receipt host, including `/health`. This repo owns TLS and reverse-proxy routes only; it does **not** define receipt Compose services or workflows. Do not run a second Caddy from the receipt repo on this host.
+
+Cross-repo ship order:
+
+1. DNS for `receipt-intelligence.roxanatapia.dev` → this VPS
+2. receipt-intelligence-demo: shared-host compose (api + n8n joined to `edge`)
+3. This Caddy change (reload the edge)
+4. VPS smoke (commands below)
+5. Portfolio tile in [roxanatapia-web](https://github.com/RoxanaTapia/roxanatapia-web)
+
+```bash
+# Receipt host: 401 without credentials, 200 with edge basic auth
+curl -sk -o /dev/null -w "%{http_code}\n" \
+  https://receipt-intelligence.roxanatapia.dev/health
+curl -sk -o /dev/null -w "%{http_code}\n" \
+  -u demo:YOUR_PASSWORD https://receipt-intelligence.roxanatapia.dev/health
+
+# Regression: pilot gate + apex still behave as today
+curl -sk -o /dev/null -w "%{http_code}\n" https://ai-doc-pilot.roxanatapia.dev/
+curl -sk -o /dev/null -w "%{http_code}\n" https://roxanatapia.dev/
+```
+
 **IP-only mode** (`Caddyfile.ip`) still puts basic auth on the whole listener (no static gate). Use domain mode for the hybrid front door.
 
 **Later, switch from IP to domain:** set `SITE_ADDRESS=your.domain.com` + `ACME_EMAIL`, remove `CADDYFILE=./Caddyfile.ip`, recreate Caddy. Let's Encrypt issues the cert automatically.

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -8,6 +8,11 @@
 # Cutover checklist: https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md
 # Apply only after those directories exist on the VPS (otherwise apex/gate 404).
 #
+# receipt-intelligence.roxanatapia.dev (when present below) proxies an external
+# compose project on Docker network edge (aliases receipt-api, receipt-n8n).
+# Upstream stack: https://github.com/RoxanaTapia/receipt-intelligence-demo
+# This repo does not own receipt compose internals. Operator notes: DEPLOYMENT.md.
+#
 # Do not use {$ACME_EMAIL:you@example.com} — a default containing "@" breaks Caddy's
 # placeholder parser. ACME contact is optional; existing certs in caddy_data keep working.
 
@@ -56,4 +61,20 @@ roxanatapia.dev, www.roxanatapia.dev {
 
 	root * /srv/roxanatapia-web/sites/apex
 	file_server
+}
+
+# Receipt Intelligence (sibling stack on Docker network `edge`).
+# Upstream aliases (stable across recreate): receipt-api:8000 · receipt-n8n:5678
+# Sibling must join `edge` via its shared-edge overlay — see receipt-intelligence-demo DEPLOYMENT.md.
+# Edge basic auth wraps the whole host (including /health).
+receipt-intelligence.roxanatapia.dev {
+	import /etc/caddy/caddy-basicauth.conf
+
+	handle /n8n* {
+		reverse_proxy receipt-n8n:5678
+	}
+
+	handle {
+		reverse_proxy receipt-api:8000
+	}
 }

--- a/deploy/docker-compose.caddy.yml
+++ b/deploy/docker-compose.caddy.yml
@@ -59,7 +59,20 @@ services:
     depends_on:
       - app
       - invite
+    # default: app + invite on the project network
+    # edge (external): receipt-api / receipt-n8n aliases from sibling compose
+    networks:
+      - default
+      - edge
 
 volumes:
   caddy_data:
   caddy_config:
+
+# Create once on the VPS: docker network create edge
+# Receipt stack joins the same network with aliases receipt-api / receipt-n8n.
+networks:
+  edge:
+    external: true
+    name: edge
+


### PR DESCRIPTION
## Main contribution

Receipt Intelligence gets a second hostname on the existing VPS edge: TLS and basic auth terminate in this repo’s Caddy, while API and n8n stay in the sibling compose project on the shared `edge` network. Operators can bring the URL live without a second public Caddy on 80/443, and pilot/apex keep their current behavior.

## Summary
- Add `receipt-intelligence.roxanatapia.dev` site block (whole-host edge basic auth; `/n8n*` → `receipt-n8n:5678`; `/` → `receipt-api:8000`)
- Attach Caddy to external Docker network `edge` alongside the project default
- Document ship order and smoke curls in `DEPLOYMENT.md`

## Test plan
- [ ] `docker network create edge` once on VPS (ignore if exists)
- [ ] Recreate Caddy overlay from repo root with usual compose flags
- [ ] Confirm receipt api+n8n are up on `edge` with aliases `receipt-api` / `receipt-n8n`
- [ ] `curl` `/health` without creds → **401**; with edge basic auth → **200**
- [ ] Regression: `ai-doc-pilot.roxanatapia.dev` and `roxanatapia.dev` still behave as today
- [ ] CI green

Closes #111

Made with [Cursor](https://cursor.com)