### PR TITLE
Multi-site invite service for Receipt Intelligence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,12 +104,18 @@ ACME_EMAIL=
 # Time-limited pilot invites (deploy/invite/). Required when using the Caddy overlay.
 # Generate: openssl rand -hex 32
 # Mint codes: python deploy/invite/mint.py --ttl 72h --label client-acme
+# Multi-site: add --site receipt for receipt-intelligence invites
 INVITE_SECRET=
 
 # Public base URL for redeem links in auto-sent emails
 INVITE_BASE_URL=https://ai-doc-pilot.roxanatapia.dev
 INVITE_REQUEST_TTL=72h
 INVITE_NOTIFY_TO=hello@roxanatapia.dev
+
+# Receipt Intelligence site (multi-site invite; #115)
+RECEIPT_INVITE_BASE_URL=https://receipt-intelligence.roxanatapia.dev
+# Optional override; empty means use INVITE_NOTIFY_TO
+RECEIPT_INVITE_NOTIFY_TO=
 
 # SMTP for auto invite emails (required for POST /invite/request)
 SMTP_HOST=

--- a/deploy/docker-compose.caddy.yml
+++ b/deploy/docker-compose.caddy.yml
@@ -27,8 +27,10 @@ services:
       INVITE_BIND: 0.0.0.0
       INVITE_PORT: "8090"
       INVITE_BASE_URL: ${INVITE_BASE_URL:-https://ai-doc-pilot.roxanatapia.dev}
+      RECEIPT_INVITE_BASE_URL: ${RECEIPT_INVITE_BASE_URL:-https://receipt-intelligence.roxanatapia.dev}
       INVITE_REQUEST_TTL: ${INVITE_REQUEST_TTL:-72h}
       INVITE_NOTIFY_TO: ${INVITE_NOTIFY_TO:-hello@roxanatapia.dev}
+      RECEIPT_INVITE_NOTIFY_TO: ${RECEIPT_INVITE_NOTIFY_TO:-}
       SMTP_HOST: ${SMTP_HOST:-}
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USER: ${SMTP_USER:-}

--- a/deploy/invite/README.md
+++ b/deploy/invite/README.md
@@ -1,18 +1,42 @@
-# Time-limited pilot invites
+# Invite service — multi-site
 
-HMAC-signed tokens for `ai-doc-pilot` `/app`, plus auto email on **Request an invite**.
+HMAC-signed, time-limited invite tokens for `/app` on both the AI Doc pilot and Receipt Intelligence hosts.
+One service handles both sites; site is resolved per-request from the `Host` header.
 Caddy basic auth remains the operator **Login** fallback.
 
-## Setup
+## Supported sites
 
-1. Repo-root `.env`:
+| Key | Cookie | Default host | Product |
+|-----|--------|--------------|---------|
+| `pilot` | `pilot_invite` | `ai-doc-pilot.roxanatapia.dev` | AI Doc pilot |
+| `receipt` | `receipt_invite` | `receipt-intelligence.roxanatapia.dev` | Receipt Intelligence |
+
+## Site resolution order
+
+1. **Host header** — matched against the configured `base_url` hostname for each site.
+2. **`site` POST field** — `pilot` or `receipt` sent by the gate form (fallback when Host is ambiguous, e.g. direct IP access).
+3. **Default: `pilot`** — backward-compatible; existing codes keep working.
+
+Old tokens (minted before multi-site) have no `site` claim and are treated as `pilot`.
+
+## Env contract
+
+Add to repo-root `.env` (`.env.example` is owned by config-guardian):
 
 ```bash
+# Shared
 INVITE_SECRET=$(openssl rand -hex 32)
-INVITE_BASE_URL=https://ai-doc-pilot.roxanatapia.dev
 INVITE_REQUEST_TTL=72h
-INVITE_NOTIFY_TO=hello@roxanatapia.dev
 
+# AI Doc pilot (existing)
+INVITE_BASE_URL=https://ai-doc-pilot.roxanatapia.dev
+INVITE_NOTIFY_TO=hello@roxanatapia.dev   # shared notify unless overridden
+
+# Receipt Intelligence (new)
+RECEIPT_INVITE_BASE_URL=https://receipt-intelligence.roxanatapia.dev
+# RECEIPT_INVITE_NOTIFY_TO=team@example.com  # optional; falls back to INVITE_NOTIFY_TO
+
+# SMTP (shared for both sites)
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USER=hello@roxanatapia.dev
@@ -21,7 +45,7 @@ SMTP_FROM=hello@roxanatapia.dev
 SMTP_TLS=true
 ```
 
-2. Recreate (repo root):
+## Start
 
 ```bash
 docker compose --env-file .env -p ai-doc-to-chat-pipeline \
@@ -31,8 +55,8 @@ docker compose --env-file .env -p ai-doc-to-chat-pipeline \
 ## Request flow (visitors)
 
 1. Gate → **Request an invite** → email
-2. `POST /invite/request` mints a TTL token, emails the visitor (Jinja HTML), notifies `INVITE_NOTIFY_TO`
-3. Rate limit: 3 requests / hour per IP and per email
+2. `POST /invite/request` resolves site from Host, mints a TTL token embedding the site claim, emails the visitor (branded per site), notifies the site's `notify_to` address
+3. Rate limit: 3 requests / hour per IP and per email (shared across sites)
 4. Visitor opens the link or pastes the code under **I have an invite**
 
 The browser response never includes the token.
@@ -40,9 +64,60 @@ The browser response never includes the token.
 ## Manual mint
 
 ```bash
+# AI Doc pilot (default)
 python deploy/invite/mint.py --ttl 72h --label client-acme
+
+# Receipt Intelligence
+python deploy/invite/mint.py --site receipt --ttl 24h --label client-beta
+
+# Override URL explicitly
+python deploy/invite/mint.py --site receipt --base-url https://receipt-intelligence.roxanatapia.dev --ttl 48h
+```
+
+## Smoke-test (local / no SMTP)
+
+Start the server with a dummy secret:
+
+```bash
+cd deploy/invite
+INVITE_SECRET=localtestonly INVITE_BASE_URL=http://localhost:8090 \
+  RECEIPT_INVITE_BASE_URL=http://localhost:8090 python server.py &
+```
+
+Mint a receipt token:
+
+```bash
+INVITE_SECRET=localtestonly python mint.py --site receipt --ttl 72h
+# → code=v1.<body>.<sig>   url=http://localhost:8090/invite/redeem?token=…
+```
+
+Redeem via Host-spoofed curl (simulates receipt host):
+
+```bash
+TOKEN=<paste code here>
+curl -si -H "Host: receipt-intelligence.roxanatapia.dev" \
+  "http://localhost:8090/invite/redeem?token=$TOKEN"
+# Expect: 303 Location=/app  Set-Cookie: receipt_invite=…
+```
+
+Verify the receipt cookie:
+
+```bash
+curl -si -H "Host: receipt-intelligence.roxanatapia.dev" \
+  -H "Cookie: receipt_invite=$TOKEN" \
+  http://localhost:8090/verify
+# Expect: 200 X-Invite-Ok: 1
+```
+
+Pilot path unchanged (no Host header → defaults to pilot):
+
+```bash
+INVITE_SECRET=localtestonly python mint.py --site pilot --ttl 72h
+TOKEN=<paste code>
+curl -si "http://localhost:8090/invite/redeem?token=$TOKEN"
+# Expect: 303  Set-Cookie: pilot_invite=…
 ```
 
 ## Revoke
 
-Rotate `INVITE_SECRET` and recreate the `invite` service.
+Rotate `INVITE_SECRET` and recreate the `invite` service. All outstanding tokens become invalid immediately.

--- a/deploy/invite/mint.py
+++ b/deploy/invite/mint.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Mint a time-limited pilot invite code / signed URL.
+"""Mint a time-limited invite code / signed URL for a given site.
 
 Usage (repo root, INVITE_SECRET in env or .env):
   python deploy/invite/mint.py --ttl 72h --label client-acme
+  python deploy/invite/mint.py --site receipt --ttl 24h --label client-beta
 """
 
 from __future__ import annotations
@@ -12,9 +13,9 @@ import os
 import sys
 from pathlib import Path
 
-# Allow running as `python deploy/invite/mint.py`
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from sites import VALID_SITES  # noqa: E402
 from tokens import mint, parse_ttl  # noqa: E402
 
 
@@ -34,26 +35,43 @@ def _load_dotenv() -> None:
             os.environ[key] = value
 
 
+def _default_base_url(site: str) -> str:
+    """Return the env-configured base URL for a site, with fallback."""
+    if site == "receipt":
+        return os.environ.get(
+            "RECEIPT_INVITE_BASE_URL", "https://receipt-intelligence.roxanatapia.dev"
+        )
+    return os.environ.get("INVITE_BASE_URL", "https://ai-doc-pilot.roxanatapia.dev")
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Mint a time-limited pilot invite")
+    parser = argparse.ArgumentParser(description="Mint a time-limited invite")
+    parser.add_argument(
+        "--site",
+        default="pilot",
+        choices=VALID_SITES,
+        help="Target site: pilot (default) or receipt",
+    )
     parser.add_argument("--ttl", default="72h", help="TTL like 24h, 72h, 7d (default 72h)")
     parser.add_argument("--label", default="", help="Optional label stored in the token")
     parser.add_argument(
         "--base-url",
-        default=os.environ.get("INVITE_BASE_URL", "https://ai-doc-pilot.roxanatapia.dev"),
-        help="Public pilot host for the redeem URL",
+        default=None,
+        help="Override the public host for the redeem URL (default: env-configured per site)",
     )
     args = parser.parse_args()
     _load_dotenv()
 
+    base = (args.base_url or _default_base_url(args.site)).rstrip("/")
+
     try:
         ttl = parse_ttl(args.ttl)
-        token = mint(ttl, label=args.label)
+        token = mint(ttl, label=args.label, site=args.site)
     except (RuntimeError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    base = args.base_url.rstrip("/")
+    print(f"site={args.site}")
     print(f"ttl_seconds={ttl}")
     if args.label:
         print(f"label={args.label}")

--- a/deploy/invite/server.py
+++ b/deploy/invite/server.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Invite redeem, request-by-email, and forward_auth verify service."""
+"""Invite redeem, request-by-email, and forward_auth verify service.
+
+Serves both ai-doc-pilot and receipt-intelligence from a single process.
+Site is resolved per-request from the Host header (or explicit ``site`` POST
+field, falling back to pilot for backward compatibility).
+"""
 
 from __future__ import annotations
 
@@ -18,17 +23,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from mail import send_email, smtp_configured  # noqa: E402
 from rate_limit import RateLimiter  # noqa: E402
-from tokens import COOKIE_NAME, mint, parse_ttl, verify  # noqa: E402
+from sites import SiteConfig, load_registry, resolve_site  # noqa: E402
+from tokens import mint, parse_ttl, verify  # noqa: E402
 
 HOST = os.environ.get("INVITE_BIND", "0.0.0.0")
 PORT = int(os.environ.get("INVITE_PORT", "8090"))
 COOKIE_MAX_AGE = int(os.environ.get("INVITE_COOKIE_MAX_AGE", str(7 * 86400)))
 APP_PATH = os.environ.get("INVITE_APP_PATH", "/app")
-BASE_URL = os.environ.get(
-    "INVITE_BASE_URL", "https://ai-doc-pilot.roxanatapia.dev"
-).rstrip("/")
 REQUEST_TTL = os.environ.get("INVITE_REQUEST_TTL", "72h")
-NOTIFY_TO = os.environ.get("INVITE_NOTIFY_TO", "hello@roxanatapia.dev").strip()
 RATE_MAX = int(os.environ.get("INVITE_REQUEST_MAX", "3"))
 RATE_WINDOW = int(os.environ.get("INVITE_REQUEST_WINDOW_SECONDS", "3600"))
 
@@ -40,6 +42,9 @@ jinja_env = Environment(
 )
 ip_limiter = RateLimiter(RATE_MAX, RATE_WINDOW)
 email_limiter = RateLimiter(RATE_MAX, RATE_WINDOW)
+
+# Loaded once at startup; all threads read (no writes after init).
+_REGISTRY: dict[str, SiteConfig] = {}
 
 
 def _html_page(title: str, body: str, status: int = 200) -> tuple[int, bytes, str]:
@@ -87,10 +92,10 @@ def _client_ip(handler: BaseHTTPRequestHandler) -> str:
 
 
 class Handler(BaseHTTPRequestHandler):
-    server_version = "InviteAuth/1.1"
+    server_version = "InviteAuth/1.2"
 
     def log_message(self, fmt: str, *args) -> None:
-        sys.stderr.write("%s - %s\n" % (self.address_string(), fmt % args))
+        sys.stderr.write(f"{self.address_string()} - {fmt % args}\n")
 
     def _send(
         self,
@@ -109,19 +114,24 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-    def _cookie_header(self, token: str) -> str:
+    def _resolved_site(self, data: dict | None = None) -> SiteConfig:
+        host = self.headers.get("Host", "").strip()
+        site_param = (data or {}).get("site") if data else None
+        return resolve_site(host, site_param, _REGISTRY)
+
+    def _cookie_header(self, token: str, site_cfg: SiteConfig) -> str:
         return (
-            f"{COOKIE_NAME}={token}; Path=/; HttpOnly; Secure; SameSite=Lax; "
+            f"{site_cfg.cookie}={token}; Path=/; HttpOnly; Secure; SameSite=Lax; "
             f"Max-Age={COOKIE_MAX_AGE}"
         )
 
-    def _token_from_cookie(self) -> str | None:
+    def _token_from_cookie(self, site_cfg: SiteConfig) -> str | None:
         raw = self.headers.get("Cookie", "")
         if not raw:
             return None
         cookie = SimpleCookie()
         cookie.load(raw)
-        morsel = cookie.get(COOKIE_NAME)
+        morsel = cookie.get(site_cfg.cookie)
         return morsel.value if morsel else None
 
     def _read_body(self) -> tuple[str, dict]:
@@ -150,13 +160,18 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         if path == "/verify":
-            token = self._token_from_cookie()
+            site_cfg = self._resolved_site()
+            token = self._token_from_cookie(site_cfg)
             if not token:
                 self._send(401, b"missing invite\n", "text/plain; charset=utf-8")
                 return
             try:
-                verify(token)
+                payload = verify(token)
             except (RuntimeError, ValueError):
+                self._send(401, b"invalid invite\n", "text/plain; charset=utf-8")
+                return
+            # Token site must match resolved site.
+            if payload.get("site", "pilot") != site_cfg.key:
                 self._send(401, b"invalid invite\n", "text/plain; charset=utf-8")
                 return
             self._send(200, b"ok\n", "text/plain; charset=utf-8", {"X-Invite-Ok": "1"})
@@ -165,7 +180,8 @@ class Handler(BaseHTTPRequestHandler):
         if path == "/invite/redeem":
             qs = parse_qs(parsed.query)
             token = (qs.get("token") or [""])[0]
-            self._redeem(token)
+            site_cfg = self._resolved_site()
+            self._redeem(token, site_cfg)
             return
 
         status, body, ctype = _html_page(
@@ -181,17 +197,19 @@ class Handler(BaseHTTPRequestHandler):
         _, data = self._read_body()
 
         if path == "/invite/request":
-            self._request_invite(str(data.get("email") or ""))
+            site_cfg = self._resolved_site(data)
+            self._request_invite(str(data.get("email") or ""), site_cfg)
             return
 
         if path == "/invite/redeem":
             token = str(data.get("token") or data.get("code") or "")
-            self._redeem(token)
+            site_cfg = self._resolved_site(data)
+            self._redeem(token, site_cfg)
             return
 
         self._send(404, b"not found\n", "text/plain; charset=utf-8")
 
-    def _request_invite(self, email: str) -> None:
+    def _request_invite(self, email: str, site_cfg: SiteConfig) -> None:
         email = (email or "").strip().lower()
         wants_json = "application/json" in self.headers.get("Accept", "")
 
@@ -229,34 +247,41 @@ class Handler(BaseHTTPRequestHandler):
 
         try:
             ttl_seconds = parse_ttl(REQUEST_TTL)
-            token = mint(ttl_seconds, label=f"request:{email}")
+            token = mint(ttl_seconds, label=f"request:{email}", site=site_cfg.key)
         except (RuntimeError, ValueError) as exc:
             respond(503, "Invite unavailable", str(exc), err=True)
             return
 
-        redeem_url = f"{BASE_URL}/invite/redeem?token={token}"
+        redeem_url = f"{site_cfg.base_url}/invite/redeem?token={token}"
         ttl_label = _ttl_label(ttl_seconds)
-        ctx = {"code": token, "redeem_url": redeem_url, "ttl_label": ttl_label}
+        ctx = {
+            "code": token,
+            "redeem_url": redeem_url,
+            "ttl_label": ttl_label,
+            "product_name": site_cfg.product_name,
+            "host_label": site_cfg.host_label,
+            "access_phrase": site_cfg.access_phrase,
+        }
         try:
             html_body = jinja_env.get_template("invite_email.html").render(**ctx)
             text_body = jinja_env.get_template("invite_email.txt").render(**ctx)
             send_email(
                 to=email,
-                subject="Your temporary AI Doc invite",
+                subject=f"Your temporary {site_cfg.product_name} invite",
                 text_body=text_body,
                 html_body=html_body,
             )
-            if NOTIFY_TO and NOTIFY_TO.lower() != email:
+            if site_cfg.notify_to and site_cfg.notify_to.lower() != email:
                 send_email(
-                    to=NOTIFY_TO,
-                    subject=f"Invite requested: {email}",
+                    to=site_cfg.notify_to,
+                    subject=f"Invite requested: {email} ({site_cfg.host_label})",
                     text_body=(
-                        f"{email} requested a temporary AI Doc invite "
+                        f"{email} requested a temporary {site_cfg.product_name} invite "
                         f"(TTL {ttl_label}).\n"
                     ),
                     html_body=(
                         f"<p><strong>{email}</strong> requested a temporary "
-                        f"AI Doc invite (TTL {ttl_label}).</p>"
+                        f"{site_cfg.product_name} invite (TTL {ttl_label}).</p>"
                     ),
                 )
         except Exception as exc:  # noqa: BLE001 — surface as calm 503
@@ -277,40 +302,46 @@ class Handler(BaseHTTPRequestHandler):
             "I have an invite.",
         )
 
-    def _redeem(self, token: str) -> None:
+    def _redeem(self, token: str, site_cfg: SiteConfig) -> None:
         token = (token or "").strip()
         if not token:
             status, body, ctype = _html_page(
                 "Invite needed",
-                '<p class="err">Paste an invite code, or open the signed link '
-                "from your email.</p>",
+                '<p class="err">Paste an invite code, or open the signed link from your email.</p>',
                 400,
             )
             self._send(status, body, ctype)
             return
         try:
-            verify(token)
+            payload = verify(token)
         except RuntimeError as exc:
-            status, body, ctype = _html_page(
-                "Invite unavailable", f'<p class="err">{exc}</p>', 503
-            )
+            status, body, ctype = _html_page("Invite unavailable", f'<p class="err">{exc}</p>', 503)
             self._send(status, body, ctype)
             return
         except ValueError as exc:
+            status, body, ctype = _html_page("Invite invalid", f'<p class="err">{exc}</p>', 401)
+            self._send(status, body, ctype)
+            return
+
+        # Token site claim must match the resolved site (old tokens default to pilot).
+        if payload.get("site", "pilot") != site_cfg.key:
             status, body, ctype = _html_page(
-                "Invite invalid", f'<p class="err">{exc}</p>', 401
+                "Invite invalid",
+                '<p class="err">This invite is not valid for this site.</p>',
+                401,
             )
             self._send(status, body, ctype)
             return
 
         self.send_response(303)
         self.send_header("Location", APP_PATH)
-        self.send_header("Set-Cookie", self._cookie_header(token))
+        self.send_header("Set-Cookie", self._cookie_header(token, site_cfg))
         self.send_header("Cache-Control", "no-store")
         self.end_headers()
 
 
 def main() -> int:
+    global _REGISTRY
     try:
         from tokens import get_secret
 
@@ -318,6 +349,8 @@ def main() -> int:
     except RuntimeError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
+
+    _REGISTRY = load_registry()
 
     if not smtp_configured():
         print(

--- a/deploy/invite/sites.py
+++ b/deploy/invite/sites.py
@@ -1,0 +1,87 @@
+"""Site registry: maps pilot / receipt to per-site config loaded from env."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+PILOT = "pilot"
+RECEIPT = "receipt"
+
+VALID_SITES = (PILOT, RECEIPT)
+
+
+@dataclass(frozen=True)
+class SiteConfig:
+    key: str
+    cookie: str
+    base_url: str
+    product_name: str
+    host_label: str
+    access_phrase: str
+    notify_to: str
+
+
+def load_registry() -> dict[str, SiteConfig]:
+    """Build the site registry from environment variables."""
+    pilot_base = os.environ.get("INVITE_BASE_URL", "https://ai-doc-pilot.roxanatapia.dev").rstrip(
+        "/"
+    )
+    receipt_base = os.environ.get(
+        "RECEIPT_INVITE_BASE_URL", "https://receipt-intelligence.roxanatapia.dev"
+    ).rstrip("/")
+    shared_notify = os.environ.get("INVITE_NOTIFY_TO", "hello@roxanatapia.dev").strip()
+    receipt_notify = os.environ.get("RECEIPT_INVITE_NOTIFY_TO", "").strip() or shared_notify
+
+    return {
+        PILOT: SiteConfig(
+            key=PILOT,
+            cookie="pilot_invite",
+            base_url=pilot_base,
+            product_name="AI Doc",
+            host_label="AI Doc pilot",
+            access_phrase="Access to the AI Doc pilot is by invitation.",
+            notify_to=shared_notify,
+        ),
+        RECEIPT: SiteConfig(
+            key=RECEIPT,
+            cookie="receipt_invite",
+            base_url=receipt_base,
+            product_name="Receipt Intelligence",
+            host_label="Receipt Intelligence",
+            access_phrase="Access to Receipt Intelligence is by invitation.",
+            notify_to=receipt_notify,
+        ),
+    }
+
+
+def _host_to_site(host: str, registry: dict[str, SiteConfig]) -> str | None:
+    """Strip port from Host header and match to a configured base_url hostname."""
+    bare = host.split(":")[0].lower().strip()
+    if not bare:
+        return None
+    for key, cfg in registry.items():
+        configured_host = urlparse(cfg.base_url).hostname or ""
+        if bare == configured_host:
+            return key
+    return None
+
+
+def resolve_site(
+    host_header: str,
+    site_param: str | None,
+    registry: dict[str, SiteConfig],
+) -> SiteConfig:
+    """
+    Resolve the active site config using priority:
+    1. Host header matched against configured base_url hostnames.
+    2. Explicit `site` field (pilot|receipt) from POST body.
+    3. Default: pilot (backward compatible).
+    """
+    from_host = _host_to_site(host_header or "", registry)
+    if from_host:
+        return registry[from_host]
+    if site_param and site_param in registry:
+        return registry[site_param]
+    return registry[PILOT]

--- a/deploy/invite/templates/invite_email.html
+++ b/deploy/invite/templates/invite_email.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Your AI Doc invite</title>
+  <title>Your {{ product_name }} invite</title>
 </head>
 <body style="margin:0;padding:0;background:#0c1218;color:#e8eef0;font-family:'Segoe UI',Helvetica,Arial,sans-serif;line-height:1.55;">
   <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#0c1218;padding:32px 16px;">
@@ -13,13 +13,13 @@
           <tr>
             <td>
               <p style="margin:0 0 8px;font-size:12px;letter-spacing:0.12em;text-transform:lowercase;color:#a8bdc4;">
-                ai-doc-pilot.roxanatapia.dev
+                {{ host_label }}
               </p>
               <h1 style="margin:0 0 12px;font-family:Georgia,'Times New Roman',serif;font-size:28px;font-weight:600;color:#e8eef0;">
                 Your temporary invite
               </h1>
               <p style="margin:0 0 16px;font-size:16px;color:#c5d4d8;">
-                Access to the AI Doc pilot is by invitation. This invite expires in
+                {{ access_phrase }} This invite expires in
                 <strong style="color:#e8eef0;">{{ ttl_label }}</strong>.
               </p>
               <p style="margin:0 0 24px;">

--- a/deploy/invite/templates/invite_email.txt
+++ b/deploy/invite/templates/invite_email.txt
@@ -1,6 +1,6 @@
-Your temporary AI Doc invite
+Your temporary {{ product_name }} invite
 
-Access to the AI Doc pilot is by invitation.
+{{ access_phrase }}
 This invite expires in {{ ttl_label }}.
 
 Open invite:

--- a/deploy/invite/tokens.py
+++ b/deploy/invite/tokens.py
@@ -11,8 +11,10 @@ import secrets
 import time
 from typing import Any
 
-
+# Deprecated: kept for backwards compatibility with callers that imported this directly.
+# New code should use site_cfg.cookie from sites.SiteConfig instead.
 COOKIE_NAME = "pilot_invite"
+
 TOKEN_PREFIX = "v1"
 
 
@@ -32,12 +34,14 @@ def get_secret() -> bytes:
     return secret.encode("utf-8")
 
 
-def mint(ttl_seconds: int, label: str = "") -> str:
+def mint(ttl_seconds: int, label: str = "", site: str = "pilot") -> str:
+    """Mint a signed token embedding exp, jti, site (and optionally label)."""
     if ttl_seconds < 60:
         raise ValueError("ttl_seconds must be at least 60")
     payload: dict[str, Any] = {
         "exp": int(time.time()) + ttl_seconds,
         "jti": secrets.token_urlsafe(12),
+        "site": site,
     }
     if label:
         payload["label"] = label
@@ -47,6 +51,11 @@ def mint(ttl_seconds: int, label: str = "") -> str:
 
 
 def verify(token: str) -> dict[str, Any]:
+    """Verify signature and expiry; return the decoded payload.
+
+    Tokens without a ``site`` claim (minted before multi-site support) are
+    treated as ``pilot`` for backward compatibility.
+    """
     token = (token or "").strip()
     parts = token.split(".")
     if len(parts) != 3 or parts[0] != TOKEN_PREFIX:
@@ -62,6 +71,9 @@ def verify(token: str) -> dict[str, Any]:
     exp = int(payload.get("exp", 0))
     if exp < int(time.time()):
         raise ValueError("token expired")
+    # Back-fill site for tokens minted before multi-site support.
+    if "site" not in payload:
+        payload["site"] = "pilot"
     return payload
 
 


### PR DESCRIPTION
## Main contribution

The invite service can now mint, email, redeem, and verify access for both AI Doc pilot and Receipt Intelligence from one process. Receipt visitors get receipt-branded redeem URLs and a `receipt_invite` cookie, while the pilot path stays the regression bar for existing invites.

## Summary
- Add `deploy/invite/sites.py` registry (`pilot` / `receipt`) resolved from Host (or optional `site` field)
- Embed `site` in tokens; set/read `pilot_invite` vs `receipt_invite`; parameterized email templates
- Wire `RECEIPT_INVITE_BASE_URL` / `RECEIPT_INVITE_NOTIFY_TO` through compose + `.env.example`
- `mint.py --site receipt`; README multi-site docs and smoke curls

## Test plan
- [x] Unit: Host resolution + mint/verify site claim
- [x] Local smoke: receipt redeem → `Set-Cookie: receipt_invite`; `/verify` → 200 `X-Invite-Ok`
- [x] Pilot redeem still sets `pilot_invite`; cross-site redeem rejected
- [x] `pytest tests/` (91 passed)
- [ ] VPS: recreate `invite` with new env; mint `--site receipt`; pilot request/Login still OK

Closes #115

Made with [Cursor](https://cursor.com)