### PR TITLE
Point receipt /app at demo UX upstream

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -157,13 +157,13 @@ Open `https://YOUR_DOMAIN/` for the gate, then **Sign in** → `/app`. Upload a 
 
 **Apex landing** (`roxanatapia.dev`) is served from the same Caddy process via static files under `/srv/roxanatapia-web/sites/apex`. Marketing sites and cutover steps: [roxanatapia-web deploy/CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md). Deploy those files on the VPS before reloading Caddy.
 
-**Receipt Intelligence host** (`receipt-intelligence.roxanatapia.dev`) is also terminated by this repo's Caddy (same edge as pilot + apex). It mirrors the AI Doc pilot hybrid: public static gate at `/`, time-limited invites on `/invite*` and `/app*`, and Basic Auth as the operator **Login** fallback. `/n8n*` stays Basic Auth only (no invites). Create the shared Docker network once (`docker network create edge`); the Caddy overlay attaches only the `caddy` service to it. Upstream API and n8n run in the sibling project [receipt-intelligence-demo](https://github.com/RoxanaTapia/receipt-intelligence-demo) via its `docker-compose.shared-edge.yml` overlay, with stable aliases `receipt-api:8000` and `receipt-n8n:5678`.
+**Receipt Intelligence host** (`receipt-intelligence.roxanatapia.dev`) is also terminated by this repo's Caddy (same edge as pilot + apex). It mirrors the AI Doc pilot hybrid: public static gate at `/`, time-limited invites on `/invite*` and `/app*`, and Basic Auth as the operator **Login** fallback. `/n8n*` stays Basic Auth only (no invites). Create the shared Docker network once (`docker network create edge`); the Caddy overlay attaches only the `caddy` service to it. Upstream API, n8n, and demo UX run in the sibling project [receipt-intelligence-demo](https://github.com/RoxanaTapia/receipt-intelligence-demo) via its `docker-compose.shared-edge.yml` overlay, with stable aliases `receipt-api:8000`, `receipt-n8n:5678`, and `receipt-ux:8080`.
 
 | Path | Access | Upstream |
 |------|--------|----------|
 | `/` | Public (no auth) | Static HTML from `/srv/roxanatapia-web/sites/receipt-gate` |
 | `/invite*` | Public (invite request / redeem) | Shared invite service (`invite:8090`) |
-| `/app*` | `receipt_invite` cookie + `forward_auth`, **or** edge Basic Auth | `receipt-api:8000` (prefix stripped; health is `/app/health`) |
+| `/app*` | `receipt_invite` cookie + `forward_auth`, **or** edge Basic Auth | `receipt-ux:8080` (prefix stripped; health is `/app/health`) |
 | `/n8n*` | Edge Basic Auth only (no invites) | `receipt-n8n:5678` |
 
 The same invite service covers both hosts. Set `RECEIPT_INVITE_BASE_URL` in `.env` (alongside the shared `INVITE_SECRET` / SMTP settings). Mint a receipt token with `python deploy/invite/mint.py --site receipt`. Full contract and local smoke: [deploy/invite/README.md](deploy/invite/README.md).

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -64,10 +64,11 @@ roxanatapia.dev, www.roxanatapia.dev {
 }
 
 # Receipt Intelligence (sibling stack on Docker network `edge`).
-# Upstream aliases (stable across recreate): receipt-api:8000 · receipt-n8n:5678
+# Upstream aliases (stable across recreate):
+#   receipt-api:8000 · receipt-n8n:5678 · receipt-ux:8080
 # Sibling must join `edge` via its shared-edge overlay — see receipt-intelligence-demo DEPLOYMENT.md.
-# Hybrid gate: public / → receipt-gate; /app* invite cookie or Basic Auth → receipt-api:8000; /n8n* Basic Auth only.
-# handle_path strips /app prefix so receipt-api sees /health, /chat, etc. directly.
+# Hybrid gate: public / → receipt-gate; /app* invite cookie or Basic Auth → receipt-ux:8080; /n8n* Basic Auth only.
+# handle_path strips /app so the UX sees /, /health, /ask, etc. (API stays on Compose DNS for the UX).
 receipt-intelligence.roxanatapia.dev {
 	handle /invite* {
 		reverse_proxy invite:8090
@@ -88,12 +89,12 @@ receipt-intelligence.roxanatapia.dev {
 				uri /verify
 				copy_headers X-Invite-Ok
 			}
-			reverse_proxy receipt-api:8000
+			reverse_proxy receipt-ux:8080
 		}
 
 		handle {
 			import /etc/caddy/caddy-basicauth.conf
-			reverse_proxy receipt-api:8000
+			reverse_proxy receipt-ux:8080
 		}
 	}
 


### PR DESCRIPTION
## Main contribution

Switches the Receipt Intelligence `/app*` reverse proxy from `receipt-api` to `receipt-ux`, so invitees and Basic Auth operators land on the thin demo UX instead of a FastAPI `{"detail":"Not Found"}` JSON page.

## Summary

- Caddy: `/app*` → `receipt-ux:8080` (invite cookie + Basic Auth paths)
- Document the `receipt-ux` edge alias next to api/n8n

## Depends on

- [receipt-intelligence-demo #12](https://github.com/RoxanaTapia/receipt-intelligence-demo/pull/12) merged and deployed on the VPS (`receipt-ux` on Docker network `edge`, seed data loaded)

## Test plan

- [ ] On VPS: receipt compose shared-edge up with `ux` healthy / alias `receipt-ux`
- [ ] Pull this change and recreate ai-doc Caddy
- [ ] `https://receipt-intelligence.roxanatapia.dev/app` + Basic Auth shows the demo UI (not JSON 404)
- [ ] `/app/health` returns `{"status":"ok"}`
- [ ] Invite path still separate: confirm `invite` container is Up (receipt `/invite/request` should not 404 once invite is healthy)
- [ ] `/n8n*` and pilot/apex unchanged


Made with [Cursor](https://cursor.com)