### PR TITLE
Fix invite image missing sites.py

### DIFF
--- a/deploy/invite/Dockerfile
+++ b/deploy/invite/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-alpine
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-COPY tokens.py mail.py rate_limit.py server.py ./
+COPY tokens.py mail.py rate_limit.py sites.py server.py ./
 COPY templates/ ./templates/
 ENV INVITE_BIND=0.0.0.0
 ENV INVITE_PORT=8090


### PR DESCRIPTION
## Main contribution

The invite service crash-loops because the Docker image never copied `sites.py`, which `server.py` imports for multi-site (pilot + receipt) hosting. Adding that file to the image so `/invite/request` can stay up.

## Test plan

- [ ] On VPS: `docker compose … up --build -d invite` → STATUS `Up` (not `Restarting`)
- [ ] `docker compose … logs invite` shows `invite auth listening on 0.0.0.0:8090`
- [ ] `POST https://receipt-intelligence.roxanatapia.dev/invite/request` no longer Chrome 404/502 (SMTP still required for a successful email)
- [ ] Pilot invite path also healthy again


Made with [Cursor](https://cursor.com)