### PR TITLE
Redirect receipt /app to /app/

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -79,6 +79,8 @@ receipt-intelligence.roxanatapia.dev {
 		reverse_proxy receipt-n8n:5678
 	}
 
+	redir /app /app/ 308
+
 	handle_path /app* {
 		@hasInviteCookie {
 			header Cookie *receipt_invite=*


### PR DESCRIPTION
## Main contribution

Adds `redir /app /app/ 308` on the Receipt Intelligence host so visitors always hit a trailing-slash URL before `handle_path` strips the prefix. That keeps demo CSS/forms working even when bookmarks omit the slash.

## Depends on

- Companion demo change: https://github.com/RoxanaTapia/receipt-intelligence-demo/pull/13

## Test plan

- [ ] Pull + recreate Caddy on the VPS
- [ ] Open `/app` → lands on `/app/`
- [ ] Demo page is styled; example links and Ask still work