### PR TITLE
Fix receipt /app static asset path stripping

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -67,8 +67,9 @@ roxanatapia.dev, www.roxanatapia.dev {
 # Upstream aliases (stable across recreate):
 #   receipt-api:8000 · receipt-n8n:5678 · receipt-ux:8080
 # Sibling must join `edge` via its shared-edge overlay — see receipt-intelligence-demo DEPLOYMENT.md.
-# Hybrid gate: public / → receipt-gate; /app* invite cookie or Basic Auth → receipt-ux:8080; /n8n* Basic Auth only.
-# handle_path strips /app so the UX sees /, /health, /ask, etc. (API stays on Compose DNS for the UX).
+# Hybrid gate: public / → receipt-gate; /app/* invite cookie or Basic Auth → receipt-ux:8080; /n8n* Basic Auth only.
+# Use handle_path /app/* (not /app*) so only the /app prefix is stripped — otherwise /app/static/*
+# is stripped to / and CSS never loads.
 receipt-intelligence.roxanatapia.dev {
 	handle /invite* {
 		reverse_proxy invite:8090
@@ -81,7 +82,7 @@ receipt-intelligence.roxanatapia.dev {
 
 	redir /app /app/ 308
 
-	handle_path /app* {
+	handle_path /app/* {
 		@hasInviteCookie {
 			header Cookie *receipt_invite=*
 		}


### PR DESCRIPTION
## Main contribution

Changes Receipt Intelligence Caddy from `handle_path /app*` to `handle_path /app/*` so only the `/app` prefix is stripped. With `/app*`, requests like `/app/static/demo.css` were stripped incorrectly and the UX never received the stylesheet (unstyled demo).

## Test plan

- [ ] VPS: `git pull` + force-recreate `caddy`
- [ ] Open `/app/` — page is styled
- [ ] DevTools → `/app/static/demo.css` returns CSS (`200`, not HTML)
- [ ] Example picker + Ask still work


Made with [Cursor](https://cursor.com)