### PR TITLE
Strip /n8n path prefix for receipt-n8n editor

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -164,7 +164,7 @@ Open `https://YOUR_DOMAIN/` for the gate, then **Sign in** → `/app`. Upload a 
 | `/` | Public (no auth) | Static HTML from `/srv/roxanatapia-web/sites/receipt-gate` |
 | `/invite*` | Public (invite request / redeem) | Shared invite service (`invite:8090`) |
 | `/app*` | `receipt_invite` cookie + `forward_auth`, **or** edge Basic Auth | `receipt-ux:8080` (prefix stripped; health is `/app/health`) |
-| `/n8n*` | Edge Basic Auth only (no invites) | `receipt-n8n:5678` |
+| `/n8n*` | Edge Basic Auth only (no invites) | `receipt-n8n:5678` (`handle_path` strips `/n8n`; sibling sets `N8N_PATH=/n8n/`) |
 
 The same invite service covers both hosts. Set `RECEIPT_INVITE_BASE_URL` in `.env` (alongside the shared `INVITE_SECRET` / SMTP settings). Mint a receipt token with `python deploy/invite/mint.py --site receipt`. Full contract and local smoke: [deploy/invite/README.md](deploy/invite/README.md).
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -70,12 +70,16 @@ roxanatapia.dev, www.roxanatapia.dev {
 # Hybrid gate: public / → receipt-gate; /app/* invite cookie or Basic Auth → receipt-ux:8080; /n8n* Basic Auth only.
 # Use handle_path /app/* (not /app*) so only the /app prefix is stripped — otherwise /app/static/*
 # is stripped to / and CSS never loads.
+# Same for /n8n/*: strip the prefix so n8n sees / and /assets/… (N8N_PATH=/n8n/ still set in
+# receipt-intelligence-demo for public URL generation). Plain handle /n8n* is flaky with n8n 2.x UI.
 receipt-intelligence.roxanatapia.dev {
 	handle /invite* {
 		reverse_proxy invite:8090
 	}
 
-	handle /n8n* {
+	redir /n8n /n8n/ 308
+
+	handle_path /n8n/* {
 		import /etc/caddy/caddy-basicauth.conf
 		reverse_proxy receipt-n8n:5678
 	}


### PR DESCRIPTION
## Main contribution

Receipt Intelligence operator UI under `/n8n*` now uses `handle_path /n8n/*` (plus `/n8n` → `/n8n/` redirect) so Caddy strips the prefix before proxying to `receipt-n8n`. This matches n8n’s recommended subfolder reverse-proxy pattern and avoids blank/`Cannot GET /n8n/` editor failures with n8n 2.x when the full path was forwarded.

## Test plan

- [ ] After deploy/reload Caddy: `curl -u demo:PASSWORD -sS https://receipt-intelligence.roxanatapia.dev/n8n/ | head` returns HTML
- [ ] Browser incognito: `/n8n/` loads editor after edge (+ n8n) basic auth
- [ ] `/app/` visitor path still works
- [ ] Receipt gate `/` unchanged


Made with [Cursor](https://cursor.com)