### PR TITLE
Stop stripping /n8n before proxying receipt-n8n

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -164,7 +164,7 @@ Open `https://YOUR_DOMAIN/` for the gate, then **Sign in** → `/app`. Upload a 
 | `/` | Public (no auth) | Static HTML from `/srv/roxanatapia-web/sites/receipt-gate` |
 | `/invite*` | Public (invite request / redeem) | Shared invite service (`invite:8090`) |
 | `/app*` | `receipt_invite` cookie + `forward_auth`, **or** edge Basic Auth | `receipt-ux:8080` (prefix stripped; health is `/app/health`) |
-| `/n8n*` | Edge Basic Auth only (no invites) | `receipt-n8n:5678` (`handle_path` strips `/n8n`; sibling sets `N8N_PATH=/n8n/`) |
+| `/n8n*` | Edge Basic Auth only (no invites) | `receipt-n8n:5678` (**no** path strip; sibling `N8N_PATH=/n8n/` + `N8N_BASIC_AUTH_ACTIVE=false`) |
 
 The same invite service covers both hosts. Set `RECEIPT_INVITE_BASE_URL` in `.env` (alongside the shared `INVITE_SECRET` / SMTP settings). Mint a receipt token with `python deploy/invite/mint.py --site receipt`. Full contract and local smoke: [deploy/invite/README.md](deploy/invite/README.md).
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -70,8 +70,9 @@ roxanatapia.dev, www.roxanatapia.dev {
 # Hybrid gate: public / → receipt-gate; /app/* invite cookie or Basic Auth → receipt-ux:8080; /n8n* Basic Auth only.
 # Use handle_path /app/* (not /app*) so only the /app prefix is stripped — otherwise /app/static/*
 # is stripped to / and CSS never loads.
-# Same for /n8n/*: strip the prefix so n8n sees / and /assets/… (N8N_PATH=/n8n/ still set in
-# receipt-intelligence-demo for public URL generation). Plain handle /n8n* is flaky with n8n 2.x UI.
+# /n8n*: do NOT strip. Sibling sets N8N_PATH=/n8n/ so n8n serves under that prefix. handle_path
+# strip + N8N_PATH caused /n8n/n8n/ login redirects (404). Keep N8N_BASIC_AUTH_ACTIVE=false in the
+# sibling so edge basicauth is the only HTTP Basic layer (avoids a double-challenge loop).
 receipt-intelligence.roxanatapia.dev {
 	handle /invite* {
 		reverse_proxy invite:8090
@@ -79,7 +80,7 @@ receipt-intelligence.roxanatapia.dev {
 
 	redir /n8n /n8n/ 308
 
-	handle_path /n8n/* {
+	handle /n8n* {
 		import /etc/caddy/caddy-basicauth.conf
 		reverse_proxy receipt-n8n:5678
 	}


### PR DESCRIPTION
## Main contribution

Receipt Intelligence `/n8n*` again uses `handle /n8n*` **without** path strip so n8n (with sibling `N8N_PATH=/n8n/`) no longer redirects login to `/n8n/n8n/` (404). Edge Basic Auth stays on this path; the sibling should keep `N8N_BASIC_AUTH_ACTIVE=false` so operators get a single HTTP Basic challenge plus n8n owner login.

Supports [receipt-intelligence-demo#18](https://github.com/RoxanaTapia/receipt-intelligence-demo/issues/18).
Paired demo PR: https://github.com/RoxanaTapia/receipt-intelligence-demo/pull/20

## Test plan

- [ ] After Caddy reload: login at `https://receipt-intelligence.roxanatapia.dev/n8n/` does not land on `/n8n/n8n/`
- [ ] Edge Basic Auth still required for `/n8n*`
- [ ] `/app/` visitor path unchanged
- [ ] With workflow Active, `/app` live ingest still works