### PR TITLE
Serve receipt n8n on a dedicated subdomain

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -157,14 +157,20 @@ Open `https://YOUR_DOMAIN/` for the gate, then **Sign in** → `/app`. Upload a 
 
 **Apex landing** (`roxanatapia.dev`) is served from the same Caddy process via static files under `/srv/roxanatapia-web/sites/apex`. Marketing sites and cutover steps: [roxanatapia-web deploy/CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md). Deploy those files on the VPS before reloading Caddy.
 
-**Receipt Intelligence host** (`receipt-intelligence.roxanatapia.dev`) is also terminated by this repo's Caddy (same edge as pilot + apex). It mirrors the AI Doc pilot hybrid: public static gate at `/`, time-limited invites on `/invite*` and `/app*`, and Basic Auth as the operator **Login** fallback. `/n8n*` stays Basic Auth only (no invites). Create the shared Docker network once (`docker network create edge`); the Caddy overlay attaches only the `caddy` service to it. Upstream API, n8n, and demo UX run in the sibling project [receipt-intelligence-demo](https://github.com/RoxanaTapia/receipt-intelligence-demo) via its `docker-compose.shared-edge.yml` overlay, with stable aliases `receipt-api:8000`, `receipt-n8n:5678`, and `receipt-ux:8080`.
+**Receipt Intelligence** is terminated by this repo's Caddy (same edge as pilot + apex) on two hostnames:
 
-| Path | Access | Upstream |
+- **`receipt-intelligence.roxanatapia.dev`** — public static gate at `/`, invites on `/invite*` and `/app*`, Basic Auth as the operator **Login** fallback for `/app`.
+- **`n8n.receipt-intelligence.roxanatapia.dev`** — n8n operator UI at **/** (edge Basic Auth only; no invites). Sibling sets `N8N_PATH=` (root) so login avoids n8n’s known path-prefix redirect bug. Keep `N8N_BASIC_AUTH_ACTIVE=false` so only edge Basic Auth challenges once.
+
+Create the shared Docker network once (`docker network create edge`); the Caddy overlay attaches only the `caddy` service to it. Upstream API, n8n, and demo UX run in the sibling project [receipt-intelligence-demo](https://github.com/RoxanaTapia/receipt-intelligence-demo) via its `docker-compose.shared-edge.yml` overlay, with stable aliases `receipt-api:8000`, `receipt-n8n:5678`, and `receipt-ux:8080`.
+
+| Host / path | Access | Upstream |
 |------|--------|----------|
-| `/` | Public (no auth) | Static HTML from `/srv/roxanatapia-web/sites/receipt-gate` |
-| `/invite*` | Public (invite request / redeem) | Shared invite service (`invite:8090`) |
-| `/app*` | `receipt_invite` cookie + `forward_auth`, **or** edge Basic Auth | `receipt-ux:8080` (prefix stripped; health is `/app/health`) |
-| `/n8n*` | Edge Basic Auth only (no invites) | `receipt-n8n:5678` (**no** path strip; sibling `N8N_PATH=/n8n/` + `N8N_BASIC_AUTH_ACTIVE=false`) |
+| `receipt-intelligence…` `/` | Public (no auth) | Static HTML from `/srv/roxanatapia-web/sites/receipt-gate` |
+| `receipt-intelligence…` `/invite*` | Public (invite request / redeem) | Shared invite service (`invite:8090`) |
+| `receipt-intelligence…` `/app*` | `receipt_invite` cookie + `forward_auth`, **or** edge Basic Auth | `receipt-ux:8080` (prefix stripped; health is `/app/health`) |
+| `receipt-intelligence…` `/n8n*` | 308 → n8n subdomain `/` | (legacy bookmarks) |
+| `n8n.receipt-intelligence…` `/` | Edge Basic Auth only | `receipt-n8n:5678` (sibling `N8N_PATH=` + `N8N_BASIC_AUTH_ACTIVE=false`) |
 
 The same invite service covers both hosts. Set `RECEIPT_INVITE_BASE_URL` in `.env` (alongside the shared `INVITE_SECRET` / SMTP settings). Mint a receipt token with `python deploy/invite/mint.py --site receipt`. Full contract and local smoke: [deploy/invite/README.md](deploy/invite/README.md).
 
@@ -172,8 +178,8 @@ Gate HTML lives in [roxanatapia-web](https://github.com/RoxanaTapia/roxanatapia-
 
 Cross-repo ship order:
 
-1. DNS for `receipt-intelligence.roxanatapia.dev` → this VPS
-2. receipt-intelligence-demo: shared-host compose (api + n8n joined to `edge`)
+1. DNS for `receipt-intelligence.roxanatapia.dev` **and** `n8n.receipt-intelligence.roxanatapia.dev` → this VPS
+2. receipt-intelligence-demo: shared-host compose (api + n8n joined to `edge`) with `N8N_HOST=n8n.receipt-intelligence.roxanatapia.dev`, empty `N8N_PATH`, matching `WEBHOOK_URL`
 3. Multi-site invite service live (receipt cookie + verify; see [deploy/invite/README.md](deploy/invite/README.md))
 4. VPS: `cd /srv/roxanatapia-web && git pull` (so `sites/receipt-gate` exists)
 5. This Caddy change (recreate the edge with the caddy overlay, receipt-gate mounted)
@@ -195,7 +201,11 @@ curl -sk -o /dev/null -w "%{http_code}\n" \
 # python deploy/invite/mint.py --site receipt --ttl 72h --label smoke
 # → redeem the printed URL on the receipt host; expect Set-Cookie: receipt_invite=… then /app without Basic Auth
 
-# /n8n* still requires Basic Auth only (expect 401 without credentials)
+# n8n subdomain: Basic Auth only (expect 401 without credentials)
+curl -sk -o /dev/null -w "%{http_code}\n" \
+  https://n8n.receipt-intelligence.roxanatapia.dev/
+
+# Legacy /n8n* redirects to the n8n subdomain (expect 308)
 curl -sk -o /dev/null -w "%{http_code}\n" \
   https://receipt-intelligence.roxanatapia.dev/n8n/
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -67,23 +67,25 @@ roxanatapia.dev, www.roxanatapia.dev {
 # Upstream aliases (stable across recreate):
 #   receipt-api:8000 · receipt-n8n:5678 · receipt-ux:8080
 # Sibling must join `edge` via its shared-edge overlay — see receipt-intelligence-demo DEPLOYMENT.md.
-# Hybrid gate: public / → receipt-gate; /app/* invite cookie or Basic Auth → receipt-ux:8080; /n8n* Basic Auth only.
+# Hybrid gate: public / → receipt-gate; /app/* invite cookie or Basic Auth → receipt-ux:8080.
+# n8n on its own host at / — avoids n8n's known path-prefix login redirect bug.
+# Sibling: N8N_PATH= empty, N8N_HOST=n8n.receipt-intelligence.roxanatapia.dev,
+# N8N_BASIC_AUTH_ACTIVE=false (edge basicauth only on the n8n host).
 # Use handle_path /app/* (not /app*) so only the /app prefix is stripped — otherwise /app/static/*
 # is stripped to / and CSS never loads.
-# /n8n*: do NOT strip. Sibling sets N8N_PATH=/n8n/ so n8n serves under that prefix. handle_path
-# strip + N8N_PATH caused /n8n/n8n/ login redirects (404). Keep N8N_BASIC_AUTH_ACTIVE=false in the
-# sibling so edge basicauth is the only HTTP Basic layer (avoids a double-challenge loop).
+n8n.receipt-intelligence.roxanatapia.dev {
+	import /etc/caddy/caddy-basicauth.conf
+	reverse_proxy receipt-n8n:5678
+}
+
 receipt-intelligence.roxanatapia.dev {
 	handle /invite* {
 		reverse_proxy invite:8090
 	}
 
-	redir /n8n /n8n/ 308
-
-	handle /n8n* {
-		import /etc/caddy/caddy-basicauth.conf
-		reverse_proxy receipt-n8n:5678
-	}
+	# Legacy /n8n* bookmarks → n8n subdomain root.
+	redir /n8n https://n8n.receipt-intelligence.roxanatapia.dev/ 308
+	redir /n8n/* https://n8n.receipt-intelligence.roxanatapia.dev/ 308
 
 	redir /app /app/ 308
 


### PR DESCRIPTION
## Main contribution

Moves the receipt n8n operator UI to `n8n.receipt-intelligence.roxanatapia.dev` at `/` so n8n runs with an empty `N8N_PATH` and no longer hits the known `/n8n/n8n/` login redirect bug. Legacy `/n8n*` on the demo host redirects to the new subdomain.

## Summary
- New Caddy site block for `n8n.receipt-intelligence.roxanatapia.dev` (edge Basic Auth → `receipt-n8n:5678`)
- Demo host `/n8n*` → 308 to the n8n subdomain root
- DEPLOYMENT.md ship order + smoke curls updated (DNS for both hosts)

## Test plan
- [ ] DNS A/AAAA for `n8n.receipt-intelligence.roxanatapia.dev` → VPS
- [ ] Sibling `.env`: `N8N_HOST=n8n.receipt-intelligence.roxanatapia.dev`, `N8N_PATH=`, matching `WEBHOOK_URL`, `N8N_BASIC_AUTH_ACTIVE=false`
- [ ] Recreate Caddy; recreate receipt `n8n` after env change
- [ ] `curl` n8n host → 401 without creds; 200 with edge Basic Auth
- [ ] Browser login on n8n host lands on editor (no `/n8n/n8n/` 404)
- [ ] Legacy `…/n8n/` → 308 to n8n subdomain
- [ ] `/app` invite + demo path unchanged


Made with [Cursor](https://cursor.com)