### PR TITLE
Strip Authorization when proxying receipt n8n

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -170,7 +170,7 @@ Create the shared Docker network once (`docker network create edge`); the Caddy 
 | `receipt-intelligence…` `/invite*` | Public (invite request / redeem) | Shared invite service (`invite:8090`) |
 | `receipt-intelligence…` `/app*` | `receipt_invite` cookie + `forward_auth`, **or** edge Basic Auth | `receipt-ux:8080` (prefix stripped; health is `/app/health`) |
 | `receipt-intelligence…` `/n8n*` | 308 → n8n subdomain `/` | (legacy bookmarks) |
-| `n8n.receipt-intelligence…` `/` | Edge Basic Auth only | `receipt-n8n:5678` (sibling `N8N_PATH=` + `N8N_BASIC_AUTH_ACTIVE=false`) |
+| `n8n.receipt-intelligence…` `/` | Edge Basic Auth only | `receipt-n8n:5678` (sibling `N8N_PATH=` + `N8N_BASIC_AUTH_ACTIVE=false`; proxy strips `Authorization` so n8n pre-login 401s do not re-challenge the browser) |
 
 The same invite service covers both hosts. Set `RECEIPT_INVITE_BASE_URL` in `.env` (alongside the shared `INVITE_SECRET` / SMTP settings). Mint a receipt token with `python deploy/invite/mint.py --site receipt`. Full contract and local smoke: [deploy/invite/README.md](deploy/invite/README.md).
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -75,7 +75,11 @@ roxanatapia.dev, www.roxanatapia.dev {
 # is stripped to / and CSS never loads.
 n8n.receipt-intelligence.roxanatapia.dev {
 	import /etc/caddy/caddy-basicauth.conf
-	reverse_proxy receipt-n8n:5678
+	# Drop edge Basic Auth before n8n. Otherwise the browser keeps Authorization on
+	# /rest/* calls; n8n's pre-login 401s make Chrome re-prompt forever.
+	reverse_proxy receipt-n8n:5678 {
+		header_up -Authorization
+	}
 }
 
 receipt-intelligence.roxanatapia.dev {


### PR DESCRIPTION
## Main contribution

Keeps edge Basic Auth on `n8n.receipt-intelligence.roxanatapia.dev` but strips `Authorization` before `receipt-n8n`, so n8n’s pre-login `/rest/*` 401 responses no longer make Chrome re-prompt for the demo password forever.

## Test plan
- [ ] Open n8n host → one edge Basic Auth prompt → n8n owner login (no loop)
- [ ] Unauthenticated request still 401
- [ ] `/app` and gate unchanged


Made with [Cursor](https://cursor.com)