### PR TITLE
Forward Host headers and flush SSE for receipt n8n

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -76,7 +76,13 @@ roxanatapia.dev, www.roxanatapia.dev {
 # Use handle_path /app/* (not /app*) so only the /app prefix is stripped — otherwise /app/static/*
 # is stripped to / and CSS never loads.
 n8n.receipt-intelligence.roxanatapia.dev {
-	reverse_proxy receipt-n8n:5678
+	reverse_proxy receipt-n8n:5678 {
+		header_up Host {host}
+		header_up X-Forwarded-Host {host}
+		header_up X-Forwarded-Proto {scheme}
+		# SSE / long-lived editor push
+		flush_interval -1
+	}
 }
 
 receipt-intelligence.roxanatapia.dev {


### PR DESCRIPTION
## Main contribution

Hardens the n8n subdomain reverse proxy: explicit `Host` / `X-Forwarded-*` and `flush_interval -1` so the editor’s long-lived push (SSE) works through Caddy.

Pairs with receipt-intelligence-demo `N8N_PUSH_BACKEND=sse`.

## Test plan
- [ ] Login on n8n host — no “Could not connect to server”
- [ ] Workflows list loads; Active ingest workflow visible
- [ ] `/app` and other hosts unchanged


Made with [Cursor](https://cursor.com)