### PR TITLE
Harden invite requests against form spam (#124)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,11 +111,19 @@ INVITE_SECRET=
 INVITE_BASE_URL=https://ai-doc-pilot.roxanatapia.dev
 INVITE_REQUEST_TTL=72h
 INVITE_NOTIFY_TO=hello@roxanatapia.dev
+# Operator notify timing: redeem (default) | request (legacy) | none
+INVITE_NOTIFY_ON=redeem
 
 # Receipt Intelligence site (multi-site invite; #115)
 RECEIPT_INVITE_BASE_URL=https://receipt-intelligence.roxanatapia.dev
 # Optional override; empty means use INVITE_NOTIFY_TO
 RECEIPT_INVITE_NOTIFY_TO=
+
+# Cloudflare Turnstile (invite spam hardening #124). Secret only — site key is
+# on gate HTML in roxanatapia-web. Defaults to enabled when secret is set;
+# set TURNSTILE_ENABLED=false for local smoke without a widget.
+TURNSTILE_SECRET_KEY=
+TURNSTILE_ENABLED=
 
 # SMTP for auto invite emails (required for POST /invite/request)
 SMTP_HOST=

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -132,10 +132,11 @@ Set `COMPOSE_PROJECT_NAME=ai-doc-to-chat-pipeline` in `.env` (see `.env.example`
 
 ### Time-limited invites
 
-Set `INVITE_SECRET` and SMTP settings in `.env` (required for the Caddy overlay + **Request an invite**). See [deploy/invite/README.md](deploy/invite/README.md).
+Set `INVITE_SECRET` and SMTP settings in `.env` (required for the Caddy overlay + **Request an invite**). For production gates, also set `TURNSTILE_SECRET_KEY` (Cloudflare Turnstile; site key lives on gate HTML in roxanatapia-web). Operator notify defaults to redeem-only via `INVITE_NOTIFY_ON=redeem`. Local smoke without a widget: `TURNSTILE_ENABLED=false`. See [deploy/invite/README.md](deploy/invite/README.md).
 
 ```bash
-# Auto path: gate → Request an invite → POST /invite/request (emails visitor + notify)
+# Auto path: gate → Request an invite → POST /invite/request (emails visitor;
+#   operator notify on redeem by default)
 # Manual path:
 python deploy/invite/mint.py --ttl 72h --label client-acme
 ```

--- a/deploy/docker-compose.caddy.yml
+++ b/deploy/docker-compose.caddy.yml
@@ -31,6 +31,11 @@ services:
       INVITE_REQUEST_TTL: ${INVITE_REQUEST_TTL:-72h}
       INVITE_NOTIFY_TO: ${INVITE_NOTIFY_TO:-hello@roxanatapia.dev}
       RECEIPT_INVITE_NOTIFY_TO: ${RECEIPT_INVITE_NOTIFY_TO:-}
+      # redeem (default) | request (legacy) | none — see deploy/invite/spam_guards.py
+      INVITE_NOTIFY_ON: ${INVITE_NOTIFY_ON:-redeem}
+      # Cloudflare Turnstile secret (site key lives on gate HTML in roxanatapia-web)
+      TURNSTILE_SECRET_KEY: ${TURNSTILE_SECRET_KEY:-}
+      TURNSTILE_ENABLED: ${TURNSTILE_ENABLED:-}
       SMTP_HOST: ${SMTP_HOST:-}
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USER: ${SMTP_USER:-}

--- a/deploy/invite/Dockerfile
+++ b/deploy/invite/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.12-alpine
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-COPY tokens.py mail.py rate_limit.py sites.py server.py ./
+COPY tokens.py mail.py rate_limit.py sites.py server.py \
+     disposable_domains.py spam_guards.py turnstile.py ./
 COPY templates/ ./templates/
 ENV INVITE_BIND=0.0.0.0
 ENV INVITE_PORT=8090

--- a/deploy/invite/README.md
+++ b/deploy/invite/README.md
@@ -36,6 +36,15 @@ INVITE_NOTIFY_TO=hello@roxanatapia.dev   # shared notify unless overridden
 RECEIPT_INVITE_BASE_URL=https://receipt-intelligence.roxanatapia.dev
 # RECEIPT_INVITE_NOTIFY_TO=team@example.com  # optional; falls back to INVITE_NOTIFY_TO
 
+# Operator notify timing: redeem (default) | request (legacy) | none
+INVITE_NOTIFY_ON=redeem
+
+# Cloudflare Turnstile (server-side verify). Site key is public and lives on
+# gate HTML in roxanatapia-web — do not invent it here.
+TURNSTILE_SECRET_KEY=
+# Defaults to true when TURNSTILE_SECRET_KEY is set; set false for local smoke
+# TURNSTILE_ENABLED=false
+
 # SMTP (shared for both sites)
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
@@ -54,12 +63,23 @@ docker compose --env-file .env -p ai-doc-to-chat-pipeline \
 
 ## Request flow (visitors)
 
-1. Gate → **Request an invite** → email
-2. `POST /invite/request` resolves site from Host, mints a TTL token embedding the site claim, emails the visitor (branded per site), notifies the site's `notify_to` address
+1. Gate → **Request an invite** → email (Turnstile widget + honeypot on the form; sister repo)
+2. `POST /invite/request` resolves site from Host, checks honeypot / disposable domain / Turnstile, then mints a TTL token and emails the visitor (branded per site)
 3. Rate limit: 3 requests / hour per IP and per email (shared across sites)
 4. Visitor opens the link or pastes the code under **I have an invite**
+5. On successful redeem, operator notify email is sent (default `INVITE_NOTIFY_ON=redeem`)
 
 The browser response never includes the token.
+
+### Spam defenses (#124)
+
+| Check | Behavior |
+|-------|----------|
+| Cloudflare Turnstile | Required when enabled; missing/invalid → calm **400**, no mint/email/notify |
+| Honeypot (`company` / `website`) | Filled → **200** success-looking response, no mint/email/notify |
+| Disposable domains | Known throwaways → calm **400**, no mint/email/notify |
+| Operator notify | Default **redeem-only**; `request` = legacy per-request; `none` = off |
+| Structured logs | One JSON line per request/redeem attempt on stderr (`event`, `email`/`label`, `client_ip`, `user_agent`, `referer`, `site`, `outcome`, `http_status`) |
 
 ## Manual mint
 
@@ -76,13 +96,17 @@ python deploy/invite/mint.py --site receipt --base-url https://receipt-intellige
 
 ## Smoke-test (local / no SMTP)
 
-Start the server with a dummy secret:
+Start the server with a dummy secret and Turnstile off (no Cloudflare widget locally):
 
 ```bash
 cd deploy/invite
 INVITE_SECRET=localtestonly INVITE_BASE_URL=http://localhost:8090 \
-  RECEIPT_INVITE_BASE_URL=http://localhost:8090 python server.py &
+  RECEIPT_INVITE_BASE_URL=http://localhost:8090 \
+  TURNSTILE_ENABLED=false INVITE_NOTIFY_ON=none \
+  python server.py &
 ```
+
+With SMTP unset, `POST /invite/request` returns **503** (`smtp_unconfigured`) after spam checks — that is expected. Redeem / verify still work with minted tokens.
 
 Mint a receipt token:
 

--- a/deploy/invite/disposable_domains.py
+++ b/deploy/invite/disposable_domains.py
@@ -1,0 +1,85 @@
+"""Small reject list for disposable / throwaway email domains.
+
+Keep this set short and maintainable. Fail closed primarily on known-bad
+domains; cheap local-part heuristics are secondary.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ~20 common throwaways — expand carefully; prefer precision over coverage.
+DISPOSABLE_DOMAINS: frozenset[str] = frozenset(
+    {
+        "mailinator.com",
+        "guerrillamail.com",
+        "guerrillamailblock.com",
+        "sharklasers.com",
+        "grr.la",
+        "guerrillamail.info",
+        "spam4.me",
+        "tempmail.com",
+        "temp-mail.org",
+        "temp-mail.io",
+        "10minutemail.com",
+        "10minutemail.net",
+        "yopmail.com",
+        "yopmail.fr",
+        "trashmail.com",
+        "trashmail.me",
+        "discard.email",
+        "discardmail.com",
+        "mailnesia.com",
+        "getnada.com",
+        "nada.email",
+        "maildrop.cc",
+        "throwaway.email",
+        "fakeinbox.com",
+        "emailondeck.com",
+        "moakt.com",
+        "tmpmail.org",
+        "tmpmail.net",
+    }
+)
+
+# Local part that is only digits and unusually long (bot gibberish).
+_LONG_DIGIT_LOCAL = re.compile(r"^\d{12,}$")
+# Domain must have a plausible TLD of 2+ letters (rejects "user@host" / "a@b.c1").
+_HAS_TLD = re.compile(r"\.[a-zA-Z]{2,}$")
+
+
+def email_domain(email: str) -> str:
+    """Return the lowercased domain part, or empty if missing."""
+    email = (email or "").strip().lower()
+    if "@" not in email:
+        return ""
+    return email.rsplit("@", 1)[-1].strip()
+
+
+def is_disposable_email(email: str) -> bool:
+    """True when the address uses a known disposable domain (or cheap fake pattern)."""
+    email = (email or "").strip().lower()
+    if "@" not in email:
+        return False
+
+    local, _, domain = email.partition("@")
+    domain = domain.strip().rstrip(".")
+    if not domain:
+        return False
+
+    # Strip one leading subdomain level for lists like mail.yopmail.com — only
+    # when the registrable-looking suffix is in the set.
+    if domain in DISPOSABLE_DOMAINS:
+        return True
+    parts = domain.split(".")
+    if len(parts) > 2:
+        parent = ".".join(parts[-2:])
+        if parent in DISPOSABLE_DOMAINS:
+            return True
+
+    if _LONG_DIGIT_LOCAL.match(local):
+        return True
+    if not _HAS_TLD.search(domain):
+        return True
+
+    return False

--- a/deploy/invite/server.py
+++ b/deploy/invite/server.py
@@ -15,16 +15,28 @@ import sys
 from http.cookies import SimpleCookie
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from disposable_domains import is_disposable_email  # noqa: E402
 from mail import send_email, smtp_configured  # noqa: E402
 from rate_limit import RateLimiter  # noqa: E402
 from sites import SiteConfig, load_registry, resolve_site  # noqa: E402
+from spam_guards import (  # noqa: E402
+    honeypot_triggered,
+    should_notify_on_redeem,
+    should_notify_on_request,
+)
 from tokens import mint, parse_ttl, verify  # noqa: E402
+from turnstile import (  # noqa: E402
+    extract_turnstile_token,
+    turnstile_enabled,
+    verify_turnstile,
+)
 
 HOST = os.environ.get("INVITE_BIND", "0.0.0.0")
 PORT = int(os.environ.get("INVITE_PORT", "8090"))
@@ -36,6 +48,11 @@ RATE_WINDOW = int(os.environ.get("INVITE_REQUEST_WINDOW_SECONDS", "3600"))
 
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+SUCCESS_MESSAGE = (
+    "If that address can receive mail, a temporary invite is on its way. "
+    "The invite expires soon—open the link or paste the code under "
+    "I have an invite."
+)
 jinja_env = Environment(
     loader=FileSystemLoader(str(TEMPLATE_DIR)),
     autoescape=select_autoescape(["html", "xml"]),
@@ -91,10 +108,17 @@ def _client_ip(handler: BaseHTTPRequestHandler) -> str:
     return handler.client_address[0]
 
 
+def _structured_log(event: str, **fields: Any) -> None:
+    """One JSON line to stderr for invite paper trail (separate from quiet access logs)."""
+    payload = {"event": event, **{k: v for k, v in fields.items() if v is not None}}
+    sys.stderr.write(json.dumps(payload, separators=(",", ":")) + "\n")
+
+
 class Handler(BaseHTTPRequestHandler):
-    server_version = "InviteAuth/1.2"
+    server_version = "InviteAuth/1.3"
 
     def log_message(self, fmt: str, *args) -> None:
+        # Quiet access-style lines for health/verify; structured logs are the paper trail.
         sys.stderr.write(f"{self.address_string()} - {fmt % args}\n")
 
     def _send(
@@ -113,6 +137,54 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_header(key, value)
         self.end_headers()
         self.wfile.write(body)
+
+    def _request_meta(self) -> dict[str, str]:
+        return {
+            "client_ip": _client_ip(self),
+            "user_agent": self.headers.get("User-Agent", "")[:500],
+            "referer": self.headers.get("Referer", "")[:500],
+        }
+
+    def _log_request(
+        self,
+        *,
+        email: str,
+        site: str,
+        outcome: str,
+        http_status: int,
+    ) -> None:
+        meta = self._request_meta()
+        _structured_log(
+            "invite_request",
+            email=email or None,
+            client_ip=meta["client_ip"],
+            user_agent=meta["user_agent"] or None,
+            referer=meta["referer"] or None,
+            site=site,
+            outcome=outcome,
+            http_status=http_status,
+        )
+
+    def _log_redeem(
+        self,
+        *,
+        site: str,
+        outcome: str,
+        http_status: int,
+        label: str | None = None,
+    ) -> None:
+        meta = self._request_meta()
+        _structured_log(
+            "invite_redeem",
+            email=None,
+            label=label or None,
+            client_ip=meta["client_ip"],
+            user_agent=meta["user_agent"] or None,
+            referer=meta["referer"] or None,
+            site=site,
+            outcome=outcome,
+            http_status=http_status,
+        )
 
     def _resolved_site(self, data: dict | None = None) -> SiteConfig:
         host = self.headers.get("Host", "").strip()
@@ -198,7 +270,7 @@ class Handler(BaseHTTPRequestHandler):
 
         if path == "/invite/request":
             site_cfg = self._resolved_site(data)
-            self._request_invite(str(data.get("email") or ""), site_cfg)
+            self._request_invite(data, site_cfg)
             return
 
         if path == "/invite/redeem":
@@ -209,11 +281,25 @@ class Handler(BaseHTTPRequestHandler):
 
         self._send(404, b"not found\n", "text/plain; charset=utf-8")
 
-    def _request_invite(self, email: str, site_cfg: SiteConfig) -> None:
-        email = (email or "").strip().lower()
+    def _request_invite(self, data: dict, site_cfg: SiteConfig) -> None:
+        email = str(data.get("email") or "").strip().lower()
         wants_json = "application/json" in self.headers.get("Accept", "")
+        site_key = site_cfg.key
 
-        def respond(status: int, title: str, message: str, err: bool = False) -> None:
+        def respond(
+            status: int,
+            title: str,
+            message: str,
+            *,
+            err: bool = False,
+            outcome: str,
+        ) -> None:
+            self._log_request(
+                email=email,
+                site=site_key,
+                outcome=outcome,
+                http_status=status,
+            )
             if wants_json:
                 payload = json.dumps({"ok": not err, "message": message}).encode()
                 self._send(status, payload, "application/json; charset=utf-8")
@@ -222,9 +308,42 @@ class Handler(BaseHTTPRequestHandler):
             st, html, ctype = _html_page(title, body, status)
             self._send(st, html, ctype)
 
-        if not EMAIL_RE.match(email):
-            respond(400, "Check your email", "Enter a valid email address.", err=True)
+        # Honeypot first: look like success, mint nothing, tip off nobody.
+        if honeypot_triggered(data):
+            respond(200, "Check your email", SUCCESS_MESSAGE, outcome="honeypot")
             return
+
+        if not EMAIL_RE.match(email):
+            respond(
+                400,
+                "Check your email",
+                "Enter a valid email address.",
+                err=True,
+                outcome="invalid_email",
+            )
+            return
+
+        if is_disposable_email(email):
+            respond(
+                400,
+                "Check your email",
+                "That email domain is not accepted. Please use a different address.",
+                err=True,
+                outcome="disposable",
+            )
+            return
+
+        if turnstile_enabled():
+            token = extract_turnstile_token(data)
+            if not verify_turnstile(token, remoteip=_client_ip(self)):
+                respond(
+                    400,
+                    "Please try again",
+                    "Could not verify this request. Refresh the page and try again.",
+                    err=True,
+                    outcome="turnstile_failed",
+                )
+                return
 
         if not smtp_configured():
             respond(
@@ -232,6 +351,7 @@ class Handler(BaseHTTPRequestHandler):
                 "Invite unavailable",
                 "Email delivery is not configured yet. Please try again later.",
                 err=True,
+                outcome="smtp_unconfigured",
             )
             return
 
@@ -242,20 +362,21 @@ class Handler(BaseHTTPRequestHandler):
                 "Please wait",
                 "Too many invite requests. Try again in about an hour.",
                 err=True,
+                outcome="rate_limited",
             )
             return
 
         try:
             ttl_seconds = parse_ttl(REQUEST_TTL)
-            token = mint(ttl_seconds, label=f"request:{email}", site=site_cfg.key)
+            invite_token = mint(ttl_seconds, label=f"request:{email}", site=site_cfg.key)
         except (RuntimeError, ValueError) as exc:
-            respond(503, "Invite unavailable", str(exc), err=True)
+            respond(503, "Invite unavailable", str(exc), err=True, outcome="mint_failed")
             return
 
-        redeem_url = f"{site_cfg.base_url}/invite/redeem?token={token}"
+        redeem_url = f"{site_cfg.base_url}/invite/redeem?token={invite_token}"
         ttl_label = _ttl_label(ttl_seconds)
         ctx = {
-            "code": token,
+            "code": invite_token,
             "redeem_url": redeem_url,
             "ttl_label": ttl_label,
             "product_name": site_cfg.product_name,
@@ -271,7 +392,12 @@ class Handler(BaseHTTPRequestHandler):
                 text_body=text_body,
                 html_body=html_body,
             )
-            if site_cfg.notify_to and site_cfg.notify_to.lower() != email:
+            # INVITE_NOTIFY_ON default is redeem (see spam_guards). Legacy: request.
+            if (
+                should_notify_on_request()
+                and site_cfg.notify_to
+                and site_cfg.notify_to.lower() != email
+            ):
                 send_email(
                     to=site_cfg.notify_to,
                     subject=f"Invite requested: {email} ({site_cfg.host_label})",
@@ -291,20 +417,47 @@ class Handler(BaseHTTPRequestHandler):
                 "Invite unavailable",
                 "Could not send the invite email. Please try again later.",
                 err=True,
+                outcome="email_failed",
             )
             return
 
-        respond(
-            200,
-            "Check your email",
-            "If that address can receive mail, a temporary invite is on its way. "
-            "The invite expires soon—open the link or paste the code under "
-            "I have an invite.",
+        respond(200, "Check your email", SUCCESS_MESSAGE, outcome="ok")
+
+    def _notify_redeem(self, site_cfg: SiteConfig, label: str | None) -> None:
+        if not should_notify_on_redeem():
+            return
+        if not site_cfg.notify_to or not smtp_configured():
+            return
+        who = (label or "unknown").strip() or "unknown"
+        subject = f"Invite redeemed: {who} ({site_cfg.host_label})"
+        text_body = (
+            f"Invite redeemed for {site_cfg.product_name} ({site_cfg.host_label}).\n"
+            f"Token label: {who}\n"
         )
+        html_body = (
+            f"<p>Invite redeemed for <strong>{site_cfg.product_name}</strong> "
+            f"({site_cfg.host_label}).</p>"
+            f"<p>Token label: <code>{who}</code></p>"
+        )
+        try:
+            send_email(
+                to=site_cfg.notify_to,
+                subject=subject,
+                text_body=text_body,
+                html_body=html_body,
+            )
+        except Exception as exc:  # noqa: BLE001 — redeem already succeeded
+            sys.stderr.write(f"invite redeem notify failed: {exc}\n")
 
     def _redeem(self, token: str, site_cfg: SiteConfig) -> None:
         token = (token or "").strip()
+        site_key = site_cfg.key
         if not token:
+            self._log_redeem(
+                site=site_key,
+                outcome="redeem_missing",
+                http_status=400,
+            )
             status, body, ctype = _html_page(
                 "Invite needed",
                 '<p class="err">Paste an invite code, or open the signed link from your email.</p>',
@@ -315,16 +468,32 @@ class Handler(BaseHTTPRequestHandler):
         try:
             payload = verify(token)
         except RuntimeError as exc:
+            self._log_redeem(
+                site=site_key,
+                outcome="redeem_unavailable",
+                http_status=503,
+            )
             status, body, ctype = _html_page("Invite unavailable", f'<p class="err">{exc}</p>', 503)
             self._send(status, body, ctype)
             return
         except ValueError as exc:
+            self._log_redeem(
+                site=site_key,
+                outcome="redeem_invalid",
+                http_status=401,
+            )
             status, body, ctype = _html_page("Invite invalid", f'<p class="err">{exc}</p>', 401)
             self._send(status, body, ctype)
             return
 
         # Token site claim must match the resolved site (old tokens default to pilot).
         if payload.get("site", "pilot") != site_cfg.key:
+            self._log_redeem(
+                site=site_key,
+                outcome="redeem_site_mismatch",
+                http_status=401,
+                label=str(payload.get("label") or "") or None,
+            )
             status, body, ctype = _html_page(
                 "Invite invalid",
                 '<p class="err">This invite is not valid for this site.</p>',
@@ -332,6 +501,15 @@ class Handler(BaseHTTPRequestHandler):
             )
             self._send(status, body, ctype)
             return
+
+        label = str(payload.get("label") or "") or None
+        self._notify_redeem(site_cfg, label)
+        self._log_redeem(
+            site=site_key,
+            outcome="redeem_ok",
+            http_status=303,
+            label=label,
+        )
 
         self.send_response(303)
         self.send_header("Location", APP_PATH)
@@ -357,6 +535,10 @@ def main() -> int:
             "warning: SMTP_HOST/SMTP_FROM not set; /invite/request will return 503",
             flush=True,
         )
+    if turnstile_enabled():
+        print("turnstile: enabled (siteverify before mint)", flush=True)
+    else:
+        print("turnstile: disabled (local smoke / TURNSTILE_ENABLED=false)", flush=True)
 
     server = ThreadingHTTPServer((HOST, PORT), Handler)
     print(f"invite auth listening on {HOST}:{PORT}", flush=True)

--- a/deploy/invite/spam_guards.py
+++ b/deploy/invite/spam_guards.py
@@ -1,0 +1,32 @@
+"""Honeypot + operator-notify policy helpers for invite spam hardening."""
+
+from __future__ import annotations
+
+import os
+
+# Default: notify the operator only after a successful redeem (cookie set),
+# not on every /invite/request. That cuts inbox noise from bots that never
+# open the app. Override with INVITE_NOTIFY_ON=request (legacy) or none.
+_VALID_NOTIFY = frozenset({"redeem", "request", "none"})
+
+
+def honeypot_triggered(data: dict) -> bool:
+    """True when a hidden honeypot field was filled (bots often autofill these)."""
+    for key in ("company", "website"):
+        if str(data.get(key) or "").strip():
+            return True
+    return False
+
+
+def invite_notify_on() -> str:
+    """Return redeem | request | none (default redeem)."""
+    raw = os.environ.get("INVITE_NOTIFY_ON", "redeem").strip().lower() or "redeem"
+    return raw if raw in _VALID_NOTIFY else "redeem"
+
+
+def should_notify_on_request() -> bool:
+    return invite_notify_on() == "request"
+
+
+def should_notify_on_redeem() -> bool:
+    return invite_notify_on() == "redeem"

--- a/deploy/invite/turnstile.py
+++ b/deploy/invite/turnstile.py
@@ -1,0 +1,75 @@
+"""Cloudflare Turnstile server-side verification (stdlib urllib)."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+DEFAULT_TIMEOUT_S = 5.0
+
+
+def turnstile_secret() -> str:
+    return os.environ.get("TURNSTILE_SECRET_KEY", "").strip()
+
+
+def turnstile_enabled() -> bool:
+    """Enabled by default when TURNSTILE_SECRET_KEY is set; opt out with TURNSTILE_ENABLED=false."""
+    explicit = os.environ.get("TURNSTILE_ENABLED", "").strip().lower()
+    if explicit in ("0", "false", "no"):
+        return False
+    if explicit in ("1", "true", "yes"):
+        return True
+    return bool(turnstile_secret())
+
+
+def extract_turnstile_token(data: dict) -> str:
+    """Accept Cloudflare's standard form field or JSON aliases."""
+    return str(
+        data.get("cf-turnstile-response")
+        or data.get("turnstile_token")
+        or data.get("cf_turnstile_response")
+        or ""
+    ).strip()
+
+
+def verify_turnstile(
+    token: str,
+    *,
+    remoteip: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT_S,
+) -> bool:
+    """POST siteverify; return True only when Cloudflare reports success.
+
+    Fail closed on missing secret, empty token, HTTP errors, or malformed JSON.
+    """
+    secret = turnstile_secret()
+    if not secret or not token:
+        return False
+
+    form: dict[str, str] = {"secret": secret, "response": token}
+    if remoteip:
+        form["remoteip"] = remoteip
+
+    body = urllib.parse.urlencode(form).encode("utf-8")
+    req = urllib.request.Request(
+        SITEVERIFY_URL,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return False
+
+    return bool(isinstance(payload, dict) and payload.get("success") is True)

--- a/tests/test_invite_spam.py
+++ b/tests/test_invite_spam.py
@@ -1,0 +1,97 @@
+"""Unit tests for invite spam-hardening helpers (#124)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+INVITE_DIR = Path(__file__).resolve().parents[1] / "deploy" / "invite"
+if str(INVITE_DIR) not in sys.path:
+    sys.path.insert(0, str(INVITE_DIR))
+
+from disposable_domains import is_disposable_email  # noqa: E402
+from spam_guards import (  # noqa: E402
+    honeypot_triggered,
+    invite_notify_on,
+    should_notify_on_redeem,
+    should_notify_on_request,
+)
+from turnstile import extract_turnstile_token, turnstile_enabled  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "bot@mailinator.com",
+        "x@guerrillamail.com",
+        "a@yopmail.com",
+        "user@mail.yopmail.com",
+        "spam@temp-mail.org",
+        "12345678901234@example.com",  # long all-digit local
+    ],
+)
+def test_disposable_email_rejected(email: str) -> None:
+    assert is_disposable_email(email) is True
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "person@example.com",
+        "roxana@roxanatapia.dev",
+        "ok@company.co.uk",
+    ],
+)
+def test_normal_email_accepted(email: str) -> None:
+    assert is_disposable_email(email) is False
+
+
+def test_honeypot_empty_ok() -> None:
+    assert honeypot_triggered({"email": "a@b.com"}) is False
+    assert honeypot_triggered({"company": "", "website": "  "}) is False
+
+
+def test_honeypot_company_or_website() -> None:
+    assert honeypot_triggered({"company": "Acme"}) is True
+    assert honeypot_triggered({"website": "https://spam.example"}) is True
+
+
+def test_notify_policy_default_redeem(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("INVITE_NOTIFY_ON", raising=False)
+    assert invite_notify_on() == "redeem"
+    assert should_notify_on_redeem() is True
+    assert should_notify_on_request() is False
+
+
+def test_notify_policy_request_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INVITE_NOTIFY_ON", "request")
+    assert should_notify_on_request() is True
+    assert should_notify_on_redeem() is False
+
+
+def test_notify_policy_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INVITE_NOTIFY_ON", "none")
+    assert should_notify_on_request() is False
+    assert should_notify_on_redeem() is False
+
+
+def test_turnstile_enabled_defaults_with_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TURNSTILE_ENABLED", raising=False)
+    monkeypatch.setenv("TURNSTILE_SECRET_KEY", "sekrit")
+    assert turnstile_enabled() is True
+    monkeypatch.setenv("TURNSTILE_ENABLED", "false")
+    assert turnstile_enabled() is False
+
+
+def test_turnstile_disabled_without_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TURNSTILE_ENABLED", raising=False)
+    monkeypatch.delenv("TURNSTILE_SECRET_KEY", raising=False)
+    assert turnstile_enabled() is False
+
+
+def test_extract_turnstile_token_aliases() -> None:
+    assert extract_turnstile_token({"cf-turnstile-response": "abc"}) == "abc"
+    assert extract_turnstile_token({"turnstile_token": "xyz"}) == "xyz"
+    assert extract_turnstile_token({}) == ""


### PR DESCRIPTION
## Main contribution

Stops automated invite floods on the public Request an invite path: Cloudflare Turnstile, honeypot, and a small disposable-domain list block mint/send before SMTP burns, while operator notify moves to redeem-by-default so inbox noise drops without removing self-serve access for real visitors.

## Summary
- Server-side Turnstile siteverify before mint/send (`TURNSTILE_SECRET_KEY`; opt out with `TURNSTILE_ENABLED=false`)
- Honeypot (`company` / `website`) returns a success-shaped response without minting
- Small disposable-domain reject list + cheap fake-pattern heuristics
- `INVITE_NOTIFY_ON=redeem` default (legacy `request` / `none` supported)
- Structured JSON stderr logs for request/redeem (IP, UA, Referer, email/site, outcome)
- Compose + `.env.example` + docs wiring
- Sister gate PR in roxanatapia-web (Turnstile widget + honeypot fields)

## Test plan
- [x] `pytest tests/` (108 passed locally)
- [ ] Recreate invite on VPS with `TURNSTILE_SECRET_KEY` set after gate HTML has the real site key
- [ ] Smoke pilot + receipt: request → email → redeem → `/app`
- [ ] Confirm POSTs without Turnstile do not mint/send
- [ ] Confirm honeypot/disposable rejects do not notify and do not email a token
- [ ] Confirm `docker logs …-invite-1` shows structured `invite_request` / `invite_redeem` lines

Closes #124

Made with [Cursor](https://cursor.com)