### PR TITLE
Exit demo: clear invite cookie and return to public home

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -141,7 +141,7 @@ Set `INVITE_SECRET` and SMTP settings in `.env` (required for the Caddy overlay 
 python deploy/invite/mint.py --ttl 72h --label client-acme
 ```
 
-Invitees redeem via **I have an invite** or the signed URL. Operators use corner **Login** (basic auth). Details: [deploy/invite/README.md](deploy/invite/README.md).
+Invitees redeem via **I have an invite** or the signed URL. Operators use corner **Login** (basic auth). **Exit demo** / **Back to home** hits `/invite/exit` (clears the site invite cookie, redirects to public `/`); it does not clear browser Basic Auth. Details: [deploy/invite/README.md](deploy/invite/README.md).
 
 With the hybrid Caddyfile (public gate + app under `/app`):
 
@@ -168,7 +168,7 @@ Create the shared Docker network once (`docker network create edge`); the Caddy 
 | Host / path | Access | Upstream |
 |------|--------|----------|
 | `receipt-intelligence…` `/` | Public (no auth) | Static HTML from `/srv/roxanatapia-web/sites/receipt-gate` |
-| `receipt-intelligence…` `/invite*` | Public (invite request / redeem) | Shared invite service (`invite:8090`) |
+| `receipt-intelligence…` `/invite*` | Public (request / redeem / exit) | Shared invite service (`invite:8090`) |
 | `receipt-intelligence…` `/app*` | `receipt_invite` cookie + `forward_auth`, **or** edge Basic Auth | `receipt-ux:8080` (prefix stripped; health is `/app/health`) |
 | `receipt-intelligence…` `/n8n*` | 308 → n8n subdomain `/` | (legacy bookmarks) |
 | `n8n.receipt-intelligence…` `/` | n8n owner login (no edge Basic Auth) | `receipt-n8n:5678` (sibling `N8N_PATH=` + `N8N_BASIC_AUTH_ACTIVE=false`) |

--- a/deploy/invite/README.md
+++ b/deploy/invite/README.md
@@ -142,6 +142,25 @@ curl -si "http://localhost:8090/invite/redeem?token=$TOKEN"
 # Expect: 303  Set-Cookie: pilot_invite=…
 ```
 
+### Exit demo
+
+Visitors and operators leave the invited session via **`GET` or `POST` `/invite/exit`**. The service clears the site invite cookie (`pilot_invite` or `receipt_invite`) and responds **303** to `/` (public gate / home). Caddy already treats `/invite*` as public, so no proxy change is needed.
+
+UI copy should say **Exit demo** or **Back to home**, not "Log out." Exit clears only the invite cookie; it does **not** clear browser Basic Auth credentials used by the operator **Login** fallback.
+
+```bash
+# After a redeem smoke (cookie set), exit clears it and redirects home
+curl -si -H "Host: receipt-intelligence.roxanatapia.dev" \
+  -H "Cookie: receipt_invite=$TOKEN" \
+  http://localhost:8090/invite/exit
+# Expect: 303 Location=/  Set-Cookie: receipt_invite=… (Max-Age=0 / expired)
+
+# Pilot (no Host → defaults to pilot)
+curl -si -H "Cookie: pilot_invite=$TOKEN" \
+  http://localhost:8090/invite/exit
+# Expect: 303 Location=/  Set-Cookie: pilot_invite=… (expired)
+```
+
 ## Revoke
 
 Rotate `INVITE_SECRET` and recreate the `invite` service. All outstanding tokens become invalid immediately.

--- a/deploy/invite/server.py
+++ b/deploy/invite/server.py
@@ -115,7 +115,7 @@ def _structured_log(event: str, **fields: Any) -> None:
 
 
 class Handler(BaseHTTPRequestHandler):
-    server_version = "InviteAuth/1.3"
+    server_version = "InviteAuth/1.4"
 
     def log_message(self, fmt: str, *args) -> None:
         # Quiet access-style lines for health/verify; structured logs are the paper trail.
@@ -186,6 +186,22 @@ class Handler(BaseHTTPRequestHandler):
             http_status=http_status,
         )
 
+    def _log_exit(
+        self,
+        *,
+        site: str,
+        outcome: str,
+        http_status: int,
+    ) -> None:
+        meta = self._request_meta()
+        _structured_log(
+            "invite_exit",
+            client_ip=meta["client_ip"],
+            site=site,
+            outcome=outcome,
+            http_status=http_status,
+        )
+
     def _resolved_site(self, data: dict | None = None) -> SiteConfig:
         host = self.headers.get("Host", "").strip()
         site_param = (data or {}).get("site") if data else None
@@ -196,6 +212,10 @@ class Handler(BaseHTTPRequestHandler):
             f"{site_cfg.cookie}={token}; Path=/; HttpOnly; Secure; SameSite=Lax; "
             f"Max-Age={COOKIE_MAX_AGE}"
         )
+
+    def _clear_cookie_header(self, site_cfg: SiteConfig) -> str:
+        """Expire the site invite cookie (same attributes as set, empty value)."""
+        return f"{site_cfg.cookie}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0"
 
     def _token_from_cookie(self, site_cfg: SiteConfig) -> str | None:
         raw = self.headers.get("Cookie", "")
@@ -256,6 +276,10 @@ class Handler(BaseHTTPRequestHandler):
             self._redeem(token, site_cfg)
             return
 
+        if path == "/invite/exit":
+            self._exit(self._resolved_site())
+            return
+
         status, body, ctype = _html_page(
             "Invite",
             "<p>Use the gate to <strong>Request an invite</strong> or "
@@ -277,6 +301,10 @@ class Handler(BaseHTTPRequestHandler):
             token = str(data.get("token") or data.get("code") or "")
             site_cfg = self._resolved_site(data)
             self._redeem(token, site_cfg)
+            return
+
+        if path == "/invite/exit":
+            self._exit(self._resolved_site(data))
             return
 
         self._send(404, b"not found\n", "text/plain; charset=utf-8")
@@ -422,6 +450,15 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         respond(200, "Check your email", SUCCESS_MESSAGE, outcome="ok")
+
+    def _exit(self, site_cfg: SiteConfig) -> None:
+        """Clear the site invite cookie and return to that host's public home."""
+        self._log_exit(site=site_cfg.key, outcome="ok", http_status=303)
+        self.send_response(303)
+        self.send_header("Location", "/")
+        self.send_header("Set-Cookie", self._clear_cookie_header(site_cfg))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
 
     def _notify_redeem(self, site_cfg: SiteConfig, label: str | None) -> None:
         if not should_notify_on_redeem():

--- a/src/app.py
+++ b/src/app.py
@@ -1247,7 +1247,7 @@ _init_session_state()
 _on_new_browser_session()
 _apply_presentation_mode_lock()
 
-# Sidebar IA: Generator → About → How to use → Cloud → developer controls
+# Sidebar IA: Generator → About → How to use → Exit demo / Cloud → developer controls
 st.sidebar.markdown("**Generator**")
 st.sidebar.caption(_active_generator_label(st.session_state.dummy_generator_only))
 
@@ -1291,6 +1291,9 @@ if _is_probably_streamlit_cloud():
         "[Live pilot](https://ai-doc-pilot.roxanatapia.dev) · "
         "[Deploy your own](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/blob/main/DEPLOYMENT.md)"
     )
+else:
+    # No invite-gate signal in-app; show on local + VPS pilot (not Streamlit Cloud).
+    st.sidebar.link_button("Exit demo", "/invite/exit")
 
 # Developer controls stay below client-facing sections
 if _dev_toggle_allowed() or st.session_state.developer_mode:

--- a/tests/test_invite_exit.py
+++ b/tests/test_invite_exit.py
@@ -1,0 +1,141 @@
+"""Tests for GET/POST /invite/exit (clear cookie → public home) (#132)."""
+
+from __future__ import annotations
+
+import sys
+import threading
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+INVITE_DIR = Path(__file__).resolve().parents[1] / "deploy" / "invite"
+if str(INVITE_DIR) not in sys.path:
+    sys.path.insert(0, str(INVITE_DIR))
+
+
+@pytest.fixture
+def invite_server(monkeypatch: pytest.MonkeyPatch):
+    """Start invite Handler on an ephemeral port with a loaded site registry."""
+    monkeypatch.setenv("INVITE_SECRET", "test-invite-secret-for-exit")
+    monkeypatch.setenv("INVITE_BASE_URL", "https://ai-doc-pilot.roxanatapia.dev")
+    monkeypatch.setenv(
+        "RECEIPT_INVITE_BASE_URL",
+        "https://receipt-intelligence.roxanatapia.dev",
+    )
+
+    import server as invite_server_mod
+    from sites import load_registry
+
+    invite_server_mod._REGISTRY = load_registry()
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), invite_server_mod.Handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    host, port = httpd.server_address[:2]
+    try:
+        yield {"host": host, "port": port, "mod": invite_server_mod}
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+
+def _request(
+    invite_server: dict,
+    *,
+    method: str,
+    path: str,
+    host: str,
+) -> tuple[int, dict[str, str]]:
+    conn = HTTPConnection(invite_server["host"], invite_server["port"], timeout=5)
+    try:
+        conn.request(method, path, headers={"Host": host})
+        resp = conn.getresponse()
+        headers = {k.lower(): v for k, v in resp.getheaders()}
+        # Drain body so connection can close cleanly.
+        resp.read()
+        return resp.status, headers
+    finally:
+        conn.close()
+
+
+def _assert_exit_clears(
+    status: int,
+    headers: dict[str, str],
+    *,
+    cookie_name: str,
+) -> None:
+    assert status == 303
+    assert headers.get("location") == "/"
+    set_cookie = headers.get("set-cookie", "")
+    assert set_cookie.startswith(f"{cookie_name}=")
+    assert "Max-Age=0" in set_cookie
+    assert "Path=/" in set_cookie
+    assert "HttpOnly" in set_cookie
+    assert "Secure" in set_cookie
+    assert "SameSite=Lax" in set_cookie
+    # Empty cookie value: name=; or name= followed by attribute separator.
+    prefix = f"{cookie_name}="
+    after = set_cookie[len(prefix) :]
+    assert after.startswith(";") or after.startswith(" ;")
+
+
+def test_exit_get_pilot_default_host(invite_server: dict) -> None:
+    status, headers = _request(
+        invite_server,
+        method="GET",
+        path="/invite/exit",
+        host="ai-doc-pilot.roxanatapia.dev",
+    )
+    _assert_exit_clears(status, headers, cookie_name="pilot_invite")
+
+
+def test_exit_get_pilot_unknown_host_defaults(invite_server: dict) -> None:
+    """Unrecognized Host falls back to pilot cookie (resolve_site default)."""
+    status, headers = _request(
+        invite_server,
+        method="GET",
+        path="/invite/exit",
+        host="localhost",
+    )
+    _assert_exit_clears(status, headers, cookie_name="pilot_invite")
+
+
+def test_exit_get_receipt_host(invite_server: dict) -> None:
+    status, headers = _request(
+        invite_server,
+        method="GET",
+        path="/invite/exit",
+        host="receipt-intelligence.roxanatapia.dev",
+    )
+    _assert_exit_clears(status, headers, cookie_name="receipt_invite")
+
+
+def test_exit_post_also_clears(invite_server: dict) -> None:
+    status, headers = _request(
+        invite_server,
+        method="POST",
+        path="/invite/exit",
+        host="receipt-intelligence.roxanatapia.dev",
+    )
+    _assert_exit_clears(status, headers, cookie_name="receipt_invite")
+
+
+def test_clear_cookie_header_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INVITE_SECRET", "test-invite-secret-for-exit")
+    import server as invite_server_mod
+    from sites import SiteConfig
+
+    cfg = SiteConfig(
+        key="pilot",
+        cookie="pilot_invite",
+        base_url="https://example.test",
+        product_name="AI Doc",
+        host_label="AI Doc",
+        access_phrase="by invitation",
+        notify_to="ops@example.test",
+    )
+    # Instance method does not use self; exercise the Set-Cookie shape directly.
+    header = invite_server_mod.Handler._clear_cookie_header(object(), cfg)  # type: ignore[arg-type]
+    assert header == "pilot_invite=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0"


### PR DESCRIPTION
## Main contribution

Visitors and operators get a single **Exit demo** path: clear the site invite cookie and land on the public gate. Invite access ends without promising a Basic Auth logout, so leaving the demo feels intentional and reversible with a new redeem or Login.

## Summary
- `GET`/`POST` `/invite/exit` clears `pilot_invite` or `receipt_invite` (Host-aware) and **303**s to `/`
- Structured `invite_exit` log; Caddy unchanged (`/invite*` already public)
- Docs in `deploy/invite/README.md` + `DEPLOYMENT.md`
- Optional pilot sidebar **Exit demo** control (not Streamlit Cloud)
- Sister UX: [receipt-intelligence-demo#32](https://github.com/RoxanaTapia/receipt-intelligence-demo/pull/32)

## Test plan
- [x] `pytest tests/` (113 passed locally, including `tests/test_invite_exit.py`)
- [ ] Recreate `invite` on VPS; smoke `curl -sI https://HOST/invite/exit` → 303, `Set-Cookie: …Max-Age=0`, `Location: /`
- [ ] Redeem → `/app` → Exit demo → gate `/` → `/app` locked without new redeem/Login
- [ ] Operator Login path: Exit demo still lands on `/` (no error)
- [ ] Merge/recreate receipt UX with linked PR #32 for the Receipt button

Closes #132

Made with [Cursor](https://cursor.com)