### PR TITLE
fix(invite): stale cookie no longer blocks /app with invalid invite

### DIFF
--- a/deploy/invite/README.md
+++ b/deploy/invite/README.md
@@ -148,6 +148,8 @@ Visitors and operators leave the invited session via **`GET` or `POST` `/invite/
 
 UI copy should say **Exit demo** or **Back to home**, not "Log out." Exit clears only the invite cookie; it does **not** clear browser Basic Auth credentials used by the operator **Login** fallback.
 
+If `/app` is hit with a **stale or invalid** invite cookie, Caddy still matches the cookie header and calls `forward_auth` → `/verify`. Verify now clears that cookie and **303**s to `/` (same as Exit) instead of returning a bare `invalid invite` page that blocked Login.
+
 ```bash
 # After a redeem smoke (cookie set), exit clears it and redirects home
 curl -si -H "Host: receipt-intelligence.roxanatapia.dev" \

--- a/deploy/invite/server.py
+++ b/deploy/invite/server.py
@@ -255,16 +255,18 @@ class Handler(BaseHTTPRequestHandler):
             site_cfg = self._resolved_site()
             token = self._token_from_cookie(site_cfg)
             if not token:
-                self._send(401, b"missing invite\n", "text/plain; charset=utf-8")
+                # Stale/empty cookie still matches Caddy *invite=*; clear and send
+                # to the gate instead of a bare 401 that blocks Basic Auth fallback.
+                self._exit(site_cfg, outcome="verify_missing")
                 return
             try:
                 payload = verify(token)
             except (RuntimeError, ValueError):
-                self._send(401, b"invalid invite\n", "text/plain; charset=utf-8")
+                self._exit(site_cfg, outcome="verify_invalid")
                 return
             # Token site must match resolved site.
             if payload.get("site", "pilot") != site_cfg.key:
-                self._send(401, b"invalid invite\n", "text/plain; charset=utf-8")
+                self._exit(site_cfg, outcome="verify_site_mismatch")
                 return
             self._send(200, b"ok\n", "text/plain; charset=utf-8", {"X-Invite-Ok": "1"})
             return
@@ -451,9 +453,13 @@ class Handler(BaseHTTPRequestHandler):
 
         respond(200, "Check your email", SUCCESS_MESSAGE, outcome="ok")
 
-    def _exit(self, site_cfg: SiteConfig) -> None:
-        """Clear the site invite cookie and return to that host's public home."""
-        self._log_exit(site=site_cfg.key, outcome="ok", http_status=303)
+    def _exit(self, site_cfg: SiteConfig, *, outcome: str = "ok") -> None:
+        """Clear the site invite cookie and return to that host's public home.
+
+        Also used when ``/verify`` fails under Caddy ``forward_auth``: a bare 401
+        was shown as the page and blocked the Basic Auth Login fallback.
+        """
+        self._log_exit(site=site_cfg.key, outcome=outcome, http_status=303)
         self.send_response(303)
         self.send_header("Location", "/")
         self.send_header("Set-Cookie", self._clear_cookie_header(site_cfg))

--- a/tests/test_invite_exit.py
+++ b/tests/test_invite_exit.py
@@ -47,15 +47,19 @@ def _request(
     method: str,
     path: str,
     host: str,
+    cookie: str | None = None,
 ) -> tuple[int, dict[str, str]]:
     conn = HTTPConnection(invite_server["host"], invite_server["port"], timeout=5)
     try:
-        conn.request(method, path, headers={"Host": host})
+        headers = {"Host": host}
+        if cookie:
+            headers["Cookie"] = cookie
+        conn.request(method, path, headers=headers)
         resp = conn.getresponse()
-        headers = {k.lower(): v for k, v in resp.getheaders()}
+        headers_out = {k.lower(): v for k, v in resp.getheaders()}
         # Drain body so connection can close cleanly.
         resp.read()
-        return resp.status, headers
+        return resp.status, headers_out
     finally:
         conn.close()
 
@@ -139,3 +143,42 @@ def test_clear_cookie_header_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     # Instance method does not use self; exercise the Set-Cookie shape directly.
     header = invite_server_mod.Handler._clear_cookie_header(object(), cfg)  # type: ignore[arg-type]
     assert header == "pilot_invite=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0"
+
+
+def test_verify_missing_cookie_redirects_home(invite_server: dict) -> None:
+    """Empty/stale cookie name still matches Caddy; verify must not 401 the page."""
+    status, headers = _request(
+        invite_server,
+        method="GET",
+        path="/verify",
+        host="ai-doc-pilot.roxanatapia.dev",
+        cookie="pilot_invite=",
+    )
+    _assert_exit_clears(status, headers, cookie_name="pilot_invite")
+
+
+def test_verify_invalid_token_redirects_home(invite_server: dict) -> None:
+    status, headers = _request(
+        invite_server,
+        method="GET",
+        path="/verify",
+        host="ai-doc-pilot.roxanatapia.dev",
+        cookie="pilot_invite=not-a-valid-token",
+    )
+    _assert_exit_clears(status, headers, cookie_name="pilot_invite")
+
+
+def test_verify_valid_token_still_ok(invite_server: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INVITE_SECRET", "test-invite-secret-for-exit")
+    from tokens import mint
+
+    token = mint(3600, label="smoke", site="pilot")
+    status, headers = _request(
+        invite_server,
+        method="GET",
+        path="/verify",
+        host="ai-doc-pilot.roxanatapia.dev",
+        cookie=f"pilot_invite={token}",
+    )
+    assert status == 200
+    assert headers.get("x-invite-ok") == "1"


### PR DESCRIPTION
## Main contribution

A bad or empty invite cookie no longer leaves `/app` stuck on a bare `invalid invite` page. `/verify` clears the cookie and sends the browser back to the public gate, so Login and redeem work again.

## Summary
- Failed `/verify` (missing / invalid / site mismatch) → clear cookie + **303** `/` (same as Exit)
- Valid cookie still returns **200** + `X-Invite-Ok`
- Docs note the stale-cookie path

## Test plan
- [x] `pytest tests/test_invite_exit.py` (8 passed)
- [ ] Recreate `invite` on VPS
- [ ] With a bad `pilot_invite` cookie, open `/app` → redirect to gate (not `invalid invite` text)
- [ ] Valid redeem still reaches `/app`


Made with [Cursor](https://cursor.com)