### PR TITLE
Private PDF Q&A you can try, with cited answers

### DIFF
--- a/.cursor/agents/docs-writer.md
+++ b/.cursor/agents/docs-writer.md
@@ -13,7 +13,7 @@ You are the **docs-writer** for ai-doc-to-chat-pipeline.
 
 - `docs/**` (structure in `docs/README.md`: `product/`, `operators/`, `archive/`)
 - `DEPLOYMENT.md`, `DEPLOYMENT-ANTHROPIC.md`, `RUNBOOK.md` (when created)
-- **README.md** (client-facing: demo vs pilot, outcomes, consulting CTA, short pointers to DEPLOYMENT; no compose commands, issue numbers, or env priority chains)
+- **README.md** (client-facing: one live-pilot CTA, outcomes, consulting link; no compose commands, issue numbers, self-host hero, or env priority chains)
 - **`docs-private/`** (local operator notes, gitignored); sync when public deploy/sales docs change
 - **GitHub PR descriptions** (rewrite/polish for open or draft PRs)
 - **GitHub issue titles and bodies** (rewrite/polish when asked, or when docs issues need clearer acceptance criteria)

--- a/.cursor/rules/docs-commercial.mdc
+++ b/.cursor/rules/docs-commercial.mdc
@@ -44,7 +44,7 @@ Audience, structure, and tone for public docs. Keep secrets and client names out
 
 - Write for a technical buyer in DEPLOYMENT; write for a business buyer in README.
 - Use placeholders (`YOUR_VPS_IP`, `demo.example.com`) until human provides real values.
-- Link README → DEPLOYMENT for setup; do not duplicate compose commands in README.
+- README is the shop window: one demo CTA (the live pilot), no deploy commands, no self-host hero. Operators start from `docs/README.md` and `DEPLOYMENT.md`.
 - Prefer `docs/product/` for client reads (including sample NDA) and `docs/operators/` for contributors.
 - Do not create a top-level `docs/samples/` folder (`samples/` is gitignored).
 - Keep milestone jargon out of client pages.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Upload a policy, SOP, report, or contract. Ask in plain language. Every answer c
 
 🟢 **Live** · <a href="https://ai-doc-pilot.roxanatapia.dev/" target="_blank" rel="noopener noreferrer"><strong>ai-doc-pilot.roxanatapia.dev</strong></a>
 
-Real answers, HTTPS, invite-protected. [Request a walkthrough on Upwork](https://www.upwork.com/freelancers/roxanadev). Once you have access, try the [sample NDA](docs/product/sample-nda.pdf).
+- Request an invite on the gate, then upload a PDF and ask a question
+- Start with the [sample NDA](docs/product/sample-nda.pdf) if you want a ready document
+- Optional: [ask for a walkthrough on Upwork](https://www.upwork.com/freelancers/roxanadev)
 
 Uploaded files are processed in memory and never stored. Each session starts fresh. Use only sample or non-confidential documents on the shared pilot.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Upload a policy, SOP, report, or contract. Ask in plain language. Every answer c
 
 ## Try the pilot
 
-**[ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev/)**
+🟢 **Live** · <a href="https://ai-doc-pilot.roxanatapia.dev/" target="_blank" rel="noopener noreferrer"><strong>ai-doc-pilot.roxanatapia.dev</strong></a>
 
 Real answers, HTTPS, invite-protected. [Request a walkthrough on Upwork](https://www.upwork.com/freelancers/roxanadev). Once you have access, try the [sample NDA](docs/product/sample-nda.pdf).
 

--- a/README.md
+++ b/README.md
@@ -34,30 +34,35 @@ flowchart LR
   F --> G[Cited answer]
 ```
 
-| Step | Technique | Why it matters |
-|------|-----------|----------------|
-| **Ingest** | PyMuPDF, plus OCR on scanned pages | Text and page number travel together, so a citation can point at a real page. |
-| **Chunk** | Split at section headers | Nearby clauses stay separate. A question about Section 3 should not pull the end of Section 2. |
-| **Embed** | Local sentence-transformers | Search by meaning without sending the document to an outside embedding API. |
-| **Retrieve** | Hybrid search: FAISS + BM25, fused with RRF | Embeddings catch paraphrases. Keyword search catches exact terms such as section numbers. |
-| **Rerank** | Cross-encoder (`bge-reranker`) | A second pass reads the question and each passage together, so the model sees the best evidence first. |
-| **Cite or refuse** | Page + excerpt, or "not in the document" | You can check the source. If retrieval found too little, the system does not invent a clause. |
+| Step | Technique | Why? |
+|------|-----------|------|
+| **Ingest** | PyMuPDF, plus OCR on scanned pages | PDFs mix digital text and scans. Page numbers stay on the passage so a citation is checkable. |
+| **Chunk** | Split at section headers | A sliding window glues neighboring clauses. Headers are the document's own boundaries. |
+| **Embed** | Local sentence-transformers | Search by meaning without sending the file to an outside embedding API. |
+| **Retrieve** | Hybrid search: FAISS + BM25, fused with RRF | Embeddings miss exact terms. Keyword search misses paraphrases. Fusion keeps both. |
+| **Rerank** | Cross-encoder (`bge-reranker`) | First-stage ranking is approximate. Re-score question and passage together before the LLM sees them. |
+| **Cite or refuse** | Page + excerpt, or "not in the document" | An answer you cannot open on a page is not grounded. No evidence means no invented clause. |
 
 ---
 
 ## What it does well
 
-- **Policies, SOPs, reports, contracts:** find definitions, obligations, dates, and rules in the PDF you uploaded
-- **Sourced answers:** every response cites the page and excerpt it used
-- **Private by design:** local embeddings; local LLM for air-gap, or a swappable API model for demos
-- **Honest when empty:** refuses to invent a clause that is not in the document
+| Feature | In practice |
+|---------|-------------|
+| **Citations** | Page and excerpt on every answer |
+| **Model choice** | Local Ollama for air-gap, or a fast API model for demos. Same retrieval stack. |
+| **Private embeddings** | Vectors stay on your server |
+| **Honest refusals** | Says so when the PDF does not contain the answer |
+| **Document types** | Policies, SOPs, reports, contracts |
 
 ## Known limits
 
-- **Session-based:** re-upload after restart; no shared document library yet
-- **One PDF at a time:** not enterprise search across a file store
-- **Read, don't calculate:** finds printed numbers; does not sum or verify math
-- **Document Q&A:** answers questions about the uploaded file; does not connect to CRM, email, or ticketing
+| Limit | In practice |
+|-------|-------------|
+| **Session only** | Re-upload after a restart; no shared library yet |
+| **One PDF** | Not search across a file store |
+| **No math** | Finds printed numbers; does not calculate |
+| **Q&A only** | No CRM, email, or ticketing |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ flowchart LR
 | Feature | In practice |
 |---------|-------------|
 | **Citations** | Page and excerpt on every answer |
-| **Model choice** | Local Ollama for air-gap, or a fast API model for demos. Same retrieval stack. |
+| **Model choice** | Ollama writes answers on your server. Anthropic is optional when you want quicker replies. Search and citations stay the same. |
 | **Private embeddings** | Vectors stay on your server |
 | **Honest refusals** | Says so when the PDF does not contain the answer |
 | **Document types** | Policies, SOPs, reports, contracts |

--- a/README.md
+++ b/README.md
@@ -1,98 +1,66 @@
-# AI Doc to Chat
+# Private PDF Q&A
 
-> Private, grounded answers from your PDFs, on infrastructure you control.
+> Grounded answers from a confidential PDF, with page citations, on infrastructure you control.
 
-[Live Pilot](https://ai-doc-pilot.roxanatapia.dev) · [Public Demo](https://ai-doc-to-chat-demo.streamlit.app) · [Deployment Guide](DEPLOYMENT.md) · [Docs](docs/README.md)
+Upload a policy, SOP, report, or contract. Ask in plain language. Every answer cites the page it used. Documents stay on **your server**.
 
-Upload a confidential PDF (policies, SOPs, reports, contracts, or internal handbooks), ask questions in plain language, and get sourced answers with page-level citations. Documents stay on **your server**. Local embeddings by default; choose a local LLM for air-gap pilots, or a fast API model for demos.
-
----
-
-## 🚀 Try it
-
-| | Where | What you get |
-|-|--------|--------------|
-| **Public demo** | [Streamlit Cloud](https://ai-doc-to-chat-demo.streamlit.app) | UI walkthrough (no login, no LLM) |
-| **Live pilot** | [ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev) | Real answers, HTTPS, password-protected |
-| **Your deployment** | Your VPS or cloud | Full private stack under your control |
-
-The live pilot is password-protected. Credentials are not published here.
-[Request access on Upwork](https://www.upwork.com/freelancers/roxanadev) for a walkthrough, or once you have access use the [sample NDA](docs/product/sample-nda.pdf) or the [sample retention policy](docs/product/sample-policy.md) (export the markdown to PDF).
-
-**Demo video:** Coming after the thin API pass. Storyboard: [docs/product/demo-script.md](docs/product/demo-script.md).
-
-> **Privacy note:** Uploaded files are processed in memory and never stored. Each session starts fresh. Use only sample or non-confidential documents on the shared pilot. For sensitive documents, [deploy your own instance](DEPLOYMENT.md).
+> **Takeaway:** This is a retrieval system, not a chatbot that guesses. If the document cannot answer, it says so.
 
 ---
 
-## 🔄 How it works
+## Try the pilot
+
+**[ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev/)**
+
+Real answers, HTTPS, invite-protected. [Request a walkthrough on Upwork](https://www.upwork.com/freelancers/roxanadev). Once you have access, try the [sample NDA](docs/product/sample-nda.pdf).
+
+Uploaded files are processed in memory and never stored. Each session starts fresh. Use only sample or non-confidential documents on the shared pilot.
+
+---
+
+## How an answer is grounded
 
 ```mermaid
 flowchart LR
-  A[Browser] --> B[Upload PDF]
-  B --> C[Extract text]
-  C --> D[Local embeddings]
-  D --> E[FAISS search]
-  E --> F[LLM on your stack]
-  F --> G[Sourced answer]
+  A[Upload PDF] --> B[Extract]
+  B --> C[Chunk]
+  C --> D[Embed locally]
+  D --> E[Hybrid search]
+  E --> F[Rerank]
+  F --> G[Cited answer]
 ```
 
-Everything runs on one VM. Your documents never leave your environment (self-host tier), or you can use a fast demo-tier LLM when latency matters. Details: [DEPLOYMENT.md](DEPLOYMENT.md) · [Architecture](docs/product/architecture.md).
+| Step | What happens |
+|------|----------------|
+| **Ingest** | PyMuPDF reads the PDF. Scanned pages go through OCR. Page numbers stay on every passage. |
+| **Chunk** | Text is split at section headers so clauses do not bleed across chunks. |
+| **Embed** | Local sentence-transformers. Vectors never leave the server. |
+| **Retrieve** | Hybrid search: dense (FAISS) plus BM25, fused with reciprocal rank fusion. |
+| **Rerank** | A cross-encoder scores the shortlist so the model sees the best passages first. |
+| **Cite or refuse** | The answer shows page and excerpt. If the document does not contain the answer, the system says so. |
+
+How that was tested: [pilot evaluation](docs/product/pilot-evaluation.md).
 
 ---
 
-## 🗂️ Repository layout
+## What it does well
 
-| Path | Role |
-|------|------|
-| `src/` | Application code (Streamlit UI; RAG under `src/rag/`) |
-| `docs/` | Product and operator docs ([index](docs/README.md)) |
-| `deploy/` | Docker, Compose, and Caddy assets for self-host |
-| `.cursor/` | Agent rules, specialists, and slash commands |
-| [`AGENTS.md`](AGENTS.md) | Contributor playbook (issues, agents, delivery train) |
-
-To run your own instance, follow the [Deployment Guide](DEPLOYMENT.md). Full tree: [docs/operators/REPO-STRUCTURE.md](docs/operators/REPO-STRUCTURE.md).
-
----
-
-## ✨ What it does well
-
-- **Policies, SOPs, reports, contracts, handbooks:** find rules, obligations, dates, and definitions in the PDF you uploaded
+- **Policies, SOPs, reports, contracts:** find definitions, obligations, dates, and rules in the PDF you uploaded
 - **Sourced answers:** every response cites the page and excerpt it used
 - **Private by design:** local embeddings; local LLM for air-gap, or a swappable API model for demos
-- **Auditable:** Docker Compose stack your IT team can review and reproduce
+- **Honest when empty:** refuses to invent a clause that is not in the document
 
-## ⚠️ Known limits (evaluation pilot)
+## Known limits
 
 - **Session-based:** re-upload after restart; no shared document library yet
+- **One PDF at a time:** not enterprise search across a file store
 - **Read, don't calculate:** finds printed numbers; does not sum or verify math
-- **Single document per session:** not enterprise search across file stores
-- **Document Q&A, not a support bot:** answers questions about the uploaded PDF; does not integrate with CRM, email, or ticketing
-
----
-
-## 🤝 For teams evaluating a private stack
-
-> Teams that cannot paste confidential PDFs into a public chatbot need a stack they can run, audit, and own. That is the aim here.
-
-Typical path: pilot on a modest VM → validate answers on your own sample documents → harden for production with your IT team (auth, persistence, runbooks) when you are ready.
-
-**Get in touch:** [Upwork](https://www.upwork.com/freelancers/roxanadev) · [GitHub](https://github.com/RoxanaTapia)
-
----
-
-## 🛠️ Self-host
-
-Follow the [Deployment Guide](DEPLOYMENT.md). It covers VPS sizing, HTTPS with Caddy, basic auth, the Anthropic **demo tier**, and the Ollama **self-host tier**.
-
-Eval corpus: [sample NDA](docs/product/sample-nda.pdf) · [sample retention policy](docs/product/sample-policy.md) · [pilot evaluation](docs/product/pilot-evaluation.md).
-
-**What's next on this product:** a calm walkthrough video (thin `/health` + `/chat` API is ready). Deeper production (persistence, SSO, ops) lands when a pilot needs it. Full sequencing for contributors: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
+- **Document Q&A:** answers questions about the uploaded file; does not connect to CRM, email, or ticketing
 
 ---
 
 ## Stack
 
-Streamlit · LangChain · FAISS · sentence-transformers · PyMuPDF · Tesseract · Ollama · Docker
+PyMuPDF · FAISS · BM25 · bge-reranker · sentence-transformers · Streamlit · FastAPI · Ollama or Anthropic
 
-MIT licensed · Made by [Roxana Tapia](https://github.com/RoxanaTapia) · 2026
+MIT licensed · [Roxana Tapia](https://github.com/RoxanaTapia) · [Upwork](https://www.upwork.com/freelancers/roxanadev)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Uploaded files are processed in memory and never stored. Each session starts fre
 
 ## How an answer is grounded
 
+Each step exists to keep the answer inside the PDF you uploaded.
+
 ```mermaid
 flowchart LR
   A[Upload PDF] --> B[Extract]
@@ -32,16 +34,14 @@ flowchart LR
   F --> G[Cited answer]
 ```
 
-| Step | What happens |
-|------|----------------|
-| **Ingest** | PyMuPDF reads the PDF. Scanned pages go through OCR. Page numbers stay on every passage. |
-| **Chunk** | Text is split at section headers so clauses do not bleed across chunks. |
-| **Embed** | Local sentence-transformers. Vectors never leave the server. |
-| **Retrieve** | Hybrid search: dense (FAISS) plus BM25, fused with reciprocal rank fusion. |
-| **Rerank** | A cross-encoder scores the shortlist so the model sees the best passages first. |
-| **Cite or refuse** | The answer shows page and excerpt. If the document does not contain the answer, the system says so. |
-
-How that was tested: [pilot evaluation](docs/product/pilot-evaluation.md).
+| Step | Technique | Why it matters |
+|------|-----------|----------------|
+| **Ingest** | PyMuPDF, plus OCR on scanned pages | Text and page number travel together, so a citation can point at a real page. |
+| **Chunk** | Split at section headers | Nearby clauses stay separate. A question about Section 3 should not pull the end of Section 2. |
+| **Embed** | Local sentence-transformers | Search by meaning without sending the document to an outside embedding API. |
+| **Retrieve** | Hybrid search: FAISS + BM25, fused with RRF | Embeddings catch paraphrases. Keyword search catches exact terms such as section numbers. |
+| **Rerank** | Cross-encoder (`bge-reranker`) | A second pass reads the question and each passage together, so the model sees the best evidence first. |
+| **Cite or refuse** | Page + excerpt, or "not in the document" | You can check the source. If retrieval found too little, the system does not invent a clause. |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,66 +2,136 @@
 
 ## Background
 
-Start here when you want to understand the product, deploy it, or contribute. Docs are split by audience so you can skip what you do not need.
+This page is the map of the repository. The [root README](../README.md) is the client shop window. Start here when you want to know where code lives, how an answer is produced, and how work ships.
 
-> **Takeaway:** Clients start in `product/`. Operators and contributors start in `operators/`.
-
----
-
-## 📖 Where to go
-
-| If you are… | Read first | Then |
-|-------------|------------|------|
-| **Evaluating the product** | [How it works](product/architecture.md) | [Demo storyboard](product/demo-script.md) |
-| **Deploying on a VPS** | [DEPLOYMENT.md](../DEPLOYMENT.md) | [Architecture](product/architecture.md) |
-| **Browsing as a buyer** | [README](../README.md) | [Live pilot](https://ai-doc-pilot.roxanatapia.dev/) + [sample NDA](product/sample-nda.pdf) |
-| **Shipping milestones** | [PROJECT-DIRECTION](operators/PROJECT-DIRECTION.md) | [ROADMAP](operators/ROADMAP.md), [AGENTS.md](../AGENTS.md) |
-| **Finding files in the repo** | [REPO-STRUCTURE](operators/REPO-STRUCTURE.md) | Current layout (`src/`, `docs/`, `deploy/`, `.cursor/`) |
-| **Testing OCR** | [Testing OCR](operators/testing-ocr.md) | Local Docker steps under `deploy/` |
-
-```mermaid
-flowchart LR
-  A[docs/README] --> B[product/]
-  A --> C[operators/]
-  A --> D[archive/]
-  B --> E[Buyers / IT]
-  C --> F[Contributors]
-  D --> G[Historical eval]
-```
+> **Takeaway:** Product code in `src/` and `configs/`. Ops in `deploy/`. Shipping in `.cursor/` and [AGENTS.md](../AGENTS.md).
 
 ---
 
-## 🗂️ Folder map
-
-Docs sit inside a calm top-level tree. Product code in `src/`, self-host assets in `deploy/`, agentic tooling in `.cursor/` + [AGENTS.md](../AGENTS.md). Detail: [REPO-STRUCTURE](operators/REPO-STRUCTURE.md).
+## Where to find what
 
 ```text
 .
-├── README.md            ← client-facing overview
-├── AGENTS.md            ← contributor / agent playbook
-├── DEPLOYMENT.md        ← self-host & pilot ops
-├── src/                 ← Streamlit + RAG
-├── deploy/              ← Dockerfile, Compose, Caddy, scripts
-├── .cursor/             ← rules, agents, slash commands
-└── docs/                ← you are here
-      README.md
-      product/           ← architecture, demo, evaluation, sample docs
-      operators/         ← roadmap, direction, repo structure, OCR testing
-      archive/           ← older eval rounds (not primary reading)
+├── README.md          Client overview and live pilot
+├── AGENTS.md          How Cursor agents ship issues
+├── DEPLOYMENT.md      Self-host and VPS notes
+├── src/               Application code
+├── configs/           Chunking, retrieval, and prompt tunables
+├── tests/             pytest suite
+├── deploy/            Docker, Compose, Caddy
+├── .cursor/           Agent roles, rules, slash commands
+└── docs/              You are here
+      product/         Architecture, demo script, sample NDA
+      operators/       Roadmap, direction, repo-structure detail
+      archive/         Historical eval notes (not current)
 ```
 
-| Folder | Role |
-|--------|------|
-| [`product/`](product/) | Client-readable: architecture, demo script, evaluation, sample NDA + policy |
-| [`operators/`](operators/) | Roadmap, project direction, [repo structure](operators/REPO-STRUCTURE.md), contributor how-tos |
-| [`archive/`](archive/) | Historical eval rounds; keep for reference, not day-one reading |
-| [`deploy/`](../deploy/) (repo root) | Docker, Compose, and Caddy only (no root shims); start from [DEPLOYMENT.md](../DEPLOYMENT.md) |
+| Path | Open it for |
+|------|-------------|
+| [`src/app.py`](../src/app.py) | Upload, chat UI, hybrid search, rerank, citations |
+| [`src/sectioning.py`](../src/sectioning.py) | Header-aware chunking and section routing |
+| [`src/retrieval_quality.py`](../src/retrieval_quality.py) | Dedupe, overlap filter, honesty guard |
+| [`src/ocr.py`](../src/ocr.py) | Scanned-page OCR |
+| [`src/rag/`](../src/rag/) | Answer generation (Ollama or Anthropic) |
+| [`src/api/`](../src/api/) | Thin FastAPI `/health` and `/chat` |
+| [`configs/config.yaml`](../configs/config.yaml) | Chunk size, hybrid weights, reranker |
+| [`configs/prompts.yaml`](../configs/prompts.yaml) | Grounded-answer prompt |
+| [`deploy/`](../deploy/) | Container stack and edge proxy |
+| [`docs/product/architecture.md`](product/architecture.md) | Single-VM deploy picture |
+| [`docs/operators/REPO-STRUCTURE.md`](operators/REPO-STRUCTURE.md) | Extra layout rules |
 
 ---
 
-## 🔗 Quick links
+## How an answer is produced
 
-- **Live pilot:** [ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev/)
-- **Sample upload:** [product/sample-nda.pdf](product/sample-nda.pdf)
-- **Repo layout:** [REPO-STRUCTURE](operators/REPO-STRUCTURE.md) · [AGENTS.md](../AGENTS.md)
-- **Self-host (operators):** [DEPLOYMENT.md](../DEPLOYMENT.md)
+Two layers: the running services, then the Python modules that do the retrieval work.
+
+### Runtime
+
+The browser never talks to the index or the model directly. Caddy terminates HTTPS. Streamlit holds the session (PDF, chunks, FAISS) in memory. The LLM is either Ollama on the same VM or Anthropic when that provider is selected.
+
+```mermaid
+flowchart LR
+  Browser --> Caddy
+  Caddy --> Streamlit
+  Streamlit --> FAISS
+  Streamlit --> LLM
+```
+
+```mermaid
+sequenceDiagram
+  participant U as Browser
+  participant S as Streamlit
+  participant I as In-memory index
+  participant M as Ollama or Anthropic
+
+  U->>S: Upload PDF
+  S->>S: Extract, OCR if needed, chunk
+  S->>I: Build FAISS + BM25
+  U->>S: Ask a question
+  S->>I: Hybrid search, then rerank
+  S->>M: Prompt with cited passages
+  M-->>S: Answer
+  S-->>U: Answer + page excerpts
+```
+
+### Code
+
+Most of the pipeline still lives in `src/app.py`. Helpers around it own chunking, quality, and generation. Tunables come from YAML, not hardcoded constants.
+
+```mermaid
+flowchart TB
+  App["src/app.py · UI + retrieval"]
+  OCR["src/ocr.py"]
+  Section["src/sectioning.py"]
+  Quality["src/retrieval_quality.py"]
+  Gen["src/rag/ · Ollama or Anthropic"]
+  Cfg["configs/config.yaml"]
+  Prompts["configs/prompts.yaml"]
+
+  App --> OCR
+  App --> Section
+  App --> Quality
+  App --> Gen
+  Cfg --> App
+  Prompts --> Gen
+```
+
+| Stage | Module | Role |
+|-------|--------|------|
+| Ingest | `app.py` + `ocr.py` | Read the PDF. Keep page numbers. OCR scanned pages. |
+| Chunk | `sectioning.py` | Split on section headers so clauses do not bleed. |
+| Index | `app.py` | Embed locally. Build FAISS and BM25 for this session. |
+| Retrieve | `app.py` | Hybrid search (FAISS + BM25, RRF), then `bge-reranker`. |
+| Filter | `retrieval_quality.py` | Drop near-duplicates. Refuse when context is too thin. |
+| Generate | `src/rag/` | Write the answer from the shortlist only. |
+| Show | `app.py` | Page + excerpt under the reply. |
+
+The FastAPI app in `src/api/` exposes the same generation path as `/chat`. It does not replace the Streamlit retrieval loop.
+
+---
+
+## How work ships
+
+This repo includes a Cursor setup that can take a GitHub issue to a pull request without hand-wiring the steps.
+
+| Piece | Role |
+|-------|------|
+| [`AGENTS.md`](../AGENTS.md) | Playbook: one issue, one branch, one PR |
+| [`.cursor/agents/`](../.cursor/agents/) | Specialists (RAG, Streamlit, docs, deploy, verifier) |
+| [`.cursor/commands/`](../.cursor/commands/) | `/ship-issue`, `/ship-milestone`, `/verify` |
+| [`.cursor/rules/`](../.cursor/rules/) | Always-on coding and docs conventions |
+
+Specialists edit only what they own. They do not commit. The milestone orchestrator commits, opens the PR, and can merge when checks are green. Full queue and human gates: [AGENTS.md](../AGENTS.md). Direction and sequencing: [operators/PROJECT-DIRECTION.md](operators/PROJECT-DIRECTION.md) · [operators/ROADMAP.md](operators/ROADMAP.md).
+
+---
+
+## Docs in this folder
+
+| Folder | What is here |
+|--------|----------------|
+| [`product/`](product/) | [Architecture](product/architecture.md), [demo storyboard](product/demo-script.md), [sample NDA](product/sample-nda.pdf) |
+| [`operators/`](operators/) | [Roadmap](operators/ROADMAP.md), [project direction](operators/PROJECT-DIRECTION.md), [repo structure](operators/REPO-STRUCTURE.md), [OCR testing](operators/testing-ocr.md) |
+| [`archive/`](archive/) | Early local-Ollama eval rounds. Historical only. |
+
+Self-host steps stay in [DEPLOYMENT.md](../DEPLOYMENT.md). Live pilot: [ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,10 +128,21 @@ Specialists edit only what they own. They do not commit. The milestone orchestra
 
 ## Docs in this folder
 
-| Folder | What is here |
-|--------|----------------|
-| [`product/`](product/) | [Architecture](product/architecture.md), [demo storyboard](product/demo-script.md), [sample NDA](product/sample-nda.pdf) |
-| [`operators/`](operators/) | [Roadmap](operators/ROADMAP.md), [project direction](operators/PROJECT-DIRECTION.md), [repo structure](operators/REPO-STRUCTURE.md), [OCR testing](operators/testing-ocr.md) |
-| [`archive/`](archive/) | Early local-Ollama eval rounds. Historical only. |
+If you only want the product story, these three pages are enough:
+
+| Page | What you get |
+|------|----------------|
+| [Architecture](product/architecture.md) | What runs on the VM |
+| [Walkthrough](product/demo-script.md) | What a live session shows, plus sample questions |
+| [Sample NDA](product/sample-nda.pdf) | A ready PDF to upload |
+
+Contributor pages (sequencing and how-tos):
+
+| Page | What you get |
+|------|----------------|
+| [Roadmap](operators/ROADMAP.md) · [Project direction](operators/PROJECT-DIRECTION.md) | What ships next |
+| [Repo structure](operators/REPO-STRUCTURE.md) | Layout rules that are easy to break |
+| [OCR testing](operators/testing-ocr.md) | How to verify scanned PDFs |
+| [Archive](archive/) | Early local-Ollama eval rounds. Historical only. |
 
 Self-host steps stay in [DEPLOYMENT.md](../DEPLOYMENT.md). Live pilot: [ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Start here when you want to understand the product, deploy it, or contribute. Do
 
 | If you are… | Read first | Then |
 |-------------|------------|------|
-| **Evaluating the product** | [How it works](product/architecture.md) | [Demo storyboard](product/demo-script.md), [Pilot evaluation](product/pilot-evaluation.md) |
+| **Evaluating the product** | [How it works](product/architecture.md) | [Demo storyboard](product/demo-script.md) |
 | **Deploying on a VPS** | [DEPLOYMENT.md](../DEPLOYMENT.md) | [Architecture](product/architecture.md) |
 | **Browsing as a buyer** | [README](../README.md) | [Live pilot](https://ai-doc-pilot.roxanatapia.dev/) + [sample NDA](product/sample-nda.pdf) |
 | **Shipping milestones** | [PROJECT-DIRECTION](operators/PROJECT-DIRECTION.md) | [ROADMAP](operators/ROADMAP.md), [AGENTS.md](../AGENTS.md) |
@@ -63,6 +63,5 @@ Docs sit inside a calm top-level tree. Product code in `src/`, self-host assets 
 
 - **Live pilot:** [ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev/)
 - **Sample upload:** [product/sample-nda.pdf](product/sample-nda.pdf)
-- **How retrieval was tested:** [product/pilot-evaluation.md](product/pilot-evaluation.md)
 - **Repo layout:** [REPO-STRUCTURE](operators/REPO-STRUCTURE.md) · [AGENTS.md](../AGENTS.md)
 - **Self-host (operators):** [DEPLOYMENT.md](../DEPLOYMENT.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Start here when you want to understand the product, deploy it, or contribute. Do
 |-------------|------------|------|
 | **Evaluating the product** | [How it works](product/architecture.md) | [Demo storyboard](product/demo-script.md), [Pilot evaluation](product/pilot-evaluation.md) |
 | **Deploying on a VPS** | [DEPLOYMENT.md](../DEPLOYMENT.md) | [Architecture](product/architecture.md) |
-| **Browsing as a buyer** | [README](../README.md) | Live pilot + [sample NDA](product/sample-nda.pdf) / [sample policy](product/sample-policy.md) |
+| **Browsing as a buyer** | [README](../README.md) | [Live pilot](https://ai-doc-pilot.roxanatapia.dev/) + [sample NDA](product/sample-nda.pdf) |
 | **Shipping milestones** | [PROJECT-DIRECTION](operators/PROJECT-DIRECTION.md) | [ROADMAP](operators/ROADMAP.md), [AGENTS.md](../AGENTS.md) |
 | **Finding files in the repo** | [REPO-STRUCTURE](operators/REPO-STRUCTURE.md) | Current layout (`src/`, `docs/`, `deploy/`, `.cursor/`) |
 | **Testing OCR** | [Testing OCR](operators/testing-ocr.md) | Local Docker steps under `deploy/` |
@@ -61,8 +61,8 @@ Docs sit inside a calm top-level tree. Product code in `src/`, self-host assets 
 
 ## 🔗 Quick links
 
-- **Live pilot:** [ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev)
-- **Public UI demo:** [Streamlit Cloud](https://ai-doc-to-chat-demo.streamlit.app)
-- **Self-host:** [DEPLOYMENT.md](../DEPLOYMENT.md)
+- **Live pilot:** [ai-doc-pilot.roxanatapia.dev](https://ai-doc-pilot.roxanatapia.dev/)
+- **Sample upload:** [product/sample-nda.pdf](product/sample-nda.pdf)
+- **How retrieval was tested:** [product/pilot-evaluation.md](product/pilot-evaluation.md)
 - **Repo layout:** [REPO-STRUCTURE](operators/REPO-STRUCTURE.md) · [AGENTS.md](../AGENTS.md)
-- **Sample uploads:** [product/sample-nda.pdf](product/sample-nda.pdf) · [product/sample-policy.md](product/sample-policy.md) (export to PDF)
+- **Self-host (operators):** [DEPLOYMENT.md](../DEPLOYMENT.md)

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,17 +1,9 @@
 # Archive
 
-## Background
+Early local-Ollama evaluation rounds. Kept so we can see why hybrid search, rerank, and header chunking landed.
 
-Older evaluation write-ups and plans. Useful if you need the full history of retrieval tuning. Not required for a first read of the product.
-
-> **Takeaway:** For current quality, use [product/pilot-evaluation.md](../product/pilot-evaluation.md).
-
----
-
-## 📦 Contents
+Not a current scorecard for the live pilot. Start at the [root README](../../README.md) or the [docs map](../README.md).
 
 | Path | What it is |
 |------|------------|
-| [`eval-history/`](eval-history/) | Rounds 1–5 of NDA pilot evaluation (results + some plans) |
-
-Round-by-round files link to each other inside that folder. Historical rounds live only under `docs/archive/eval-history/`.
+| [`eval-history/`](eval-history/) | Rounds 1–5 on the sample NDA (May 2026) |

--- a/docs/archive/eval-history/README.md
+++ b/docs/archive/eval-history/README.md
@@ -1,5 +1,5 @@
-# Eval history (archive)
+# Eval history
 
-Older pilot-evaluation rounds (1–5). Kept for tuning archaeology.
+Rounds 1–5 of NDA retrieval tuning (May 2026, local Ollama). Archaeology only.
 
-For the current summary, see [product/pilot-evaluation.md](../../product/pilot-evaluation.md).
+Product map: [docs/README.md](../../README.md).

--- a/docs/operators/PROJECT-DIRECTION.md
+++ b/docs/operators/PROJECT-DIRECTION.md
@@ -1,5 +1,7 @@
 # Project direction (operator guide)
 
+> **For clients:** start at the [root README](../../README.md). This page is contributor sequencing.
+
 ## Background
 
 How to finish this pipeline with Cursor discipline, code you understand, and a private document Q&A demo you can show without apologizing for latency.

--- a/docs/operators/REPO-STRUCTURE.md
+++ b/docs/operators/REPO-STRUCTURE.md
@@ -2,53 +2,15 @@
 
 ## Background
 
-As of **M7.96-2** ([#90](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/90)), the repo reads as one calm tree: product code and docs in the obvious places, deploy assets under `deploy/`, and agentic tooling kept intentional rather than hidden. This page describes the **current** layout.
+Operator addendum. The friendly map is [docs/README.md](../README.md). This page only records layout rules that are easy to break.
 
-> **Takeaway:** Product in `src/` + `docs/product/`. Ops in `deploy/` + `DEPLOYMENT.md`. Agents in `AGENTS.md` + `.cursor/`. No root “Moved to deploy/…” stubs.
-
-**Milestone rule:** M7.96 merges to **`main` only**. Do **not** bump `deploy/stable` for this chore (VPS and Streamlit Cloud stay on the current pin until you choose otherwise).
+> **Takeaway:** Product in `src/` and `configs/`. Ops in `deploy/`. Agents stay visible in `.cursor/` and [AGENTS.md](../../AGENTS.md).
 
 ---
 
-## 🗺️ Top-level layout
+## Deploy assets
 
-```text
-.
-├── README.md                 ← client-facing overview
-├── AGENTS.md                 ← contributor / agent playbook
-├── DEPLOYMENT.md             ← self-host & pilot ops
-├── LICENSE
-├── requirements.txt
-├── pyproject.toml
-├── .env.example
-├── .pre-commit-config.yaml
-├── .streamlit/               ← Streamlit theme / config
-├── .cursor/                  ← rules, agents, slash commands
-├── .github/                  ← issue templates, CI
-├── src/                      ← application code
-├── tests/
-├── configs/                  ← YAML (chunking, prompts, …)
-├── docs/                     ← product / operators / archive
-└── deploy/                   ← Docker, Compose, Caddy, scripts
-```
-
-| Area | Role |
-|------|------|
-| **Root prose** | README (buyers), DEPLOYMENT (IT), AGENTS (contributors) |
-| **`src/`** | Streamlit app, RAG, retrieval helpers |
-| **`tests/`** | pytest suite |
-| **`configs/`** | Tunables loaded at runtime |
-| **`docs/`** | Audience-split documentation (see below) |
-| **`deploy/`** | Everything needed to run the pilot container stack |
-| **`.cursor/` + `AGENTS.md`** | How humans and agents ship milestones |
-
-Contributors may run `pre-commit install` so local commits use [`.pre-commit-config.yaml`](../../.pre-commit-config.yaml) (ruff + basic hooks).
-
----
-
-## 🛠️ `deploy/` (no root shims)
-
-Deploy assets live **only** under `deploy/` (as of M7.96-2 / #90). `.dockerignore` stays at the **repo root** (build context is the repo root).
+Everything that runs the container stack lives under [`deploy/`](../../deploy/). `.dockerignore` stays at the repo root because the build context is the repo root.
 
 ```text
 deploy/
@@ -56,70 +18,35 @@ deploy/
 ├── docker-compose.yml
 ├── docker-compose.caddy.yml
 ├── Caddyfile
-├── Caddyfile.ip
-├── caddy-basicauth.conf.example
-├── generate-caddy-auth.sh
-├── generate-ip-tls.sh
-└── …                             ← other deploy scripts as needed
+└── invite/            Shared invite service (pilot + other sites)
 ```
 
-**Canonical Compose (from repo root):**
+- No root copies of Dockerfile, Compose, or Caddy files.
+- No stub files that say “Moved to `deploy/`…”.
+- Compose from the repo root: `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up --build -d`
 
-```bash
-docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up --build -d
-```
-
-**Rules**
-
-- No root copies of Dockerfile, `docker-compose*.yml`, or `Caddyfile*`.
-- No stub files at the root that say “Moved to `deploy/`…”. Update real paths in docs and CI instead.
-- Compose build context is `..` (repo root); `dockerfile: deploy/Dockerfile` (path relative to context).
-
-Operators still start from [DEPLOYMENT.md](../../DEPLOYMENT.md); the folder above is where the files actually live.
+Install narrative: [DEPLOYMENT.md](../../DEPLOYMENT.md).
 
 ---
 
-## 📖 `docs/` map
+## Docs split
 
-Unchanged by the Docker move; kept here so the full tree is one picture.
-
-```text
-docs/
-├── README.md          ← docs index (start here)
-├── product/           ← architecture, demo, evaluation, samples
-├── operators/         ← roadmap, direction, this file, OCR testing
-└── archive/           ← historical eval rounds
-```
-
-| Folder | Audience |
-|--------|----------|
-| [`docs/product/`](../product/) | Buyers and IT evaluating the product |
-| [`docs/operators/`](./) | Contributors shipping the delivery train |
-| [`docs/archive/`](../archive/) | Older eval notes; not day-one reading |
-
-Index: [docs/README.md](../README.md).
+| Folder | Role |
+|--------|------|
+| [`docs/README.md`](../README.md) | Map of the repo and how an answer is produced |
+| [`docs/product/`](../product/) | Architecture, walkthrough, sample documents |
+| [`docs/operators/`](./) | Contributor sequencing and how-tos |
+| [`docs/archive/`](../archive/) | Historical eval notes |
 
 ---
 
-## 🎯 Agentic surface (intentional)
+## Cursor surface
 
-Agentic files stay in the open tree on purpose:
+Keep these in the open tree. They are how issues ship.
 
-| Path | Purpose |
-|------|---------|
-| [`AGENTS.md`](../../AGENTS.md) | Issue → agent map, train mode, human gates |
-| [`.cursor/agents/`](../../.cursor/agents/) | Specialist role prompts |
-| [`.cursor/rules/`](../../.cursor/rules/) | Always-on coding and milestone rules |
-| [`.cursor/commands/`](../../.cursor/commands/) | Slash commands (`/ship-issue`, `/verify`, …) |
-
-Tidy and naming hygiene for this surface is [#91](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/91). Do not bury or delete the agentic layer for “cleaner GitHub cosmetics.”
-
----
-
-## ✅ What this milestone does not change
-
-- **Pin / release:** `deploy/stable` is not fast-forwarded by M7.96.
-- **Product features:** No RAG or UI work in this chore.
-- **Docs audiences:** `product/` vs `operators/` vs `archive/` stay as they are; README polish is [#92](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/issues/92).
-
-Related: [ROADMAP · M7.96](ROADMAP.md#m796-repo-clarity-chore--main-only).
+| Path | Role |
+|------|------|
+| [`AGENTS.md`](../../AGENTS.md) | One issue, one branch, one PR |
+| [`.cursor/agents/`](../../.cursor/agents/) | Specialist prompts |
+| [`.cursor/commands/`](../../.cursor/commands/) | `/ship-issue`, `/verify` |
+| [`.cursor/rules/`](../../.cursor/rules/) | Always-on conventions |

--- a/docs/operators/ROADMAP.md
+++ b/docs/operators/ROADMAP.md
@@ -1,5 +1,7 @@
 # Production roadmap
 
+> **For clients:** start at the [root README](../../README.md). This page is contributor sequencing.
+
 ## Background
 
 For contributors and operators. Moves the pipeline from a **reference deployment** to a **demo-ready** private document Q&A product: fast cited answers on a walkthrough, then a thin API for integrations. Deeper production work (persist / SSO / ops) is client-triggered, not the default climb after M7.

--- a/docs/operators/testing-ocr.md
+++ b/docs/operators/testing-ocr.md
@@ -1,5 +1,7 @@
 # Testing OCR
 
+> **For clients:** scanned pages are handled automatically in the Docker pilot. This page is for contributors verifying that path.
+
 ## Background
 
 For contributors verifying scanned-PDF support. Two levels: fast unit tests (no Tesseract binary) and an integration check on the local Docker stack.
@@ -112,8 +114,4 @@ Answer cites the correct page
 | `"OCR failed on page: …"` | Tesseract binary absent | Check `deploy/Dockerfile` installs `tesseract-ocr` |
 | Answer is gibberish | Low scan quality | Cleaner scan; OCR depends on DPI and contrast |
 
----
-
-## ☁️ Streamlit Cloud
-
-Streamlit Cloud does not allow custom system packages like the `tesseract` binary. The app catches the missing dependency and shows a user-facing warning. OCR is available only in the Docker stack (local or VPS).
+OCR needs the Docker image (Tesseract is installed there). It is not available on Streamlit Cloud.

--- a/docs/product/architecture.md
+++ b/docs/product/architecture.md
@@ -1,104 +1,57 @@
-# Architecture: single-VM pilot
+# Architecture
 
 ## Background
 
-For technical buyers and IT reviewers who want to see how the stack fits on one machine. Matches the Compose files in this repo (`deploy/docker-compose.yml` plus optional `deploy/docker-compose.caddy.yml` for HTTPS).
+How the live pilot runs on one machine. For the retrieval steps and module map, see [docs/README.md](../README.md). For install steps, see [DEPLOYMENT.md](../../DEPLOYMENT.md).
 
-> **Takeaway:** Browser traffic hits Caddy; Streamlit and Ollama stay internal. Documents live in memory for the session; only model weights persist on disk.
+> **Takeaway:** HTTPS at the edge. The app and the local model stay inside the VM. The PDF lives in memory for the session.
 
 ---
 
-## 🏗️ Stack overview
+## What runs where
 
-```text
-                    Internet (HTTPS :443, HTTP :80)
-                                │
-                                ▼
-                    ┌───────────────────────┐
-                    │  Caddy                │
-                    │  TLS + basic auth     │
-                    └───────────┬───────────┘
-                                │ reverse_proxy → app:8501
-                                ▼
-                    ┌───────────────────────┐
-                    │  Streamlit app        │
-                    │  PDF → chunk → FAISS  │
-                    │  (in-process / RAM)   │
-                    └───────────┬───────────┘
-                                │ OLLAMA_HOST
-                                ▼
-                    ┌───────────────────────┐
-                    │  Ollama               │
-                    │  volume: ollama_models│
-                    └───────────────────────┘
+```mermaid
+flowchart LR
+  Browser --> Caddy
+  Caddy --> App
+  App --> Index[Session index]
+  App --> LLM[Ollama or Anthropic]
 ```
 
-With the Caddy overlay active, Streamlit and Ollama are **not** published to the host. Only ports `80` and `443` are exposed.
+| Piece | Role |
+|-------|------|
+| **Caddy** | HTTPS and the invite gate. Only ports 80 and 443 face the internet. |
+| **App** | Streamlit UI plus retrieval. The PDF, chunks, and FAISS index stay in RAM. |
+| **Ollama** | Local model on the same VM, when that provider is selected. |
+| **Anthropic** | Optional. Quicker answers; retrieved passages leave the VM for generation. |
+
+Embeddings always run on the server. Switching the writer (Ollama vs Anthropic) does not change search or citations.
 
 ---
 
-## 🧩 Services
-
-| Service | Image / build | Published ports | Role |
-|---------|---------------|-----------------|------|
-| `caddy` | `caddy:2.9.1-alpine` | `80`, `443` | TLS, basic auth, reverse proxy |
-| `app` | `deploy/Dockerfile` (this repo) | *(none with Caddy)* | UI, RAG, local embeddings |
-| `ollama` | `ollama/ollama:0.6.5` | *(internal)* | Local LLM; models on `ollama_models` |
-
-**Pilot start (HTTPS):**
-
-```bash
-docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up -d
-```
-
-For local work without HTTPS, use `deploy/docker-compose.yml` alone. Then `app` binds `8501` on the host.
-
-Full steps: [DEPLOYMENT.md](../../DEPLOYMENT.md).
-
----
-
-## 🔄 Data flow (one question)
+## One question
 
 ```mermaid
 sequenceDiagram
   participant U as Browser
-  participant A as Streamlit app
-  participant F as FAISS (in memory)
-  participant O as Ollama
+  participant A as App
+  participant I as Session index
+  participant M as Ollama or Anthropic
 
   U->>A: Upload PDF
-  A->>A: Extract text, chunk
-  A->>F: Build session index
-  U->>A: Ask question
-  A->>F: Retrieve relevant chunks
-  A->>O: Prompt with context
-  O-->>A: Grounded answer
-  A-->>U: Answer + page citations
+  A->>A: Extract, chunk, embed
+  A->>I: Build FAISS + BM25
+  U->>A: Ask
+  A->>I: Hybrid search, then rerank
+  A->>M: Prompt with passages
+  M-->>A: Answer
+  A-->>U: Answer + page excerpts
 ```
 
-1. Upload PDF → PyMuPDF (optional OCR) → text chunks → in-memory FAISS index.
-2. Ask a question → retrieval → context with page metadata.
-3. App calls Ollama on the Compose network → answer and source excerpts in the UI.
-
-Documents and vectors live in the app process for the session. Only Ollama model weights persist (`ollama_models` volume).
+Nothing is written to a document library. Restart the app and you upload again. Model weights on disk are the only durable data (Ollama volume).
 
 ---
 
-## 🌱 What comes later
+## What this pilot does not include yet
 
-Production rollouts often add persistent document storage, a thin REST API for integrations, and enterprise login, while keeping the same retrieval and generation core. Local Ollama stays the default for air-gapped or private hosts; a cloud LLM can be used for faster demos when procurement allows it.
-
-See [operators/ROADMAP.md](../operators/ROADMAP.md) for the phased plan.
-
----
-
-## ⚙️ Environment (pilot)
-
-| Variable | Purpose |
-|----------|---------|
-| `OLLAMA_HOST` | Ollama URL (e.g. `http://ollama:11434` in Compose) |
-| `USE_DUMMY_GENERATOR` | `false` for real generation |
-| `OLLAMA_MODEL` | Model tag (e.g. `phi3:mini` on CPU hosts) |
-| `SITE_ADDRESS` / `ACME_EMAIL` | Domain and email for Let's Encrypt |
-
-Full operator notes: [DEPLOYMENT.md](../../DEPLOYMENT.md#environment-variables).
+A shared library, SSO, and multi-project tenancy. Those wait for a real engagement. The retrieval core stays the same when they land.

--- a/docs/product/demo-script.md
+++ b/docs/product/demo-script.md
@@ -1,63 +1,40 @@
-# Demo video: 5-minute storyboard
+# Walkthrough
 
 ## Background
 
-Public outline for a short walkthrough of the live pilot. A fuller recording script (pre-flight checks, operator notes, extended Q&A) lives in local **`docs-private/demo-script.md`** (gitignored, not in this repo).
+What a short session on the [live pilot](https://ai-doc-pilot.roxanatapia.dev/) should show. Request an invite on the gate; no approval is required.
 
-> **Takeaway:** Show privacy, upload, cited answers, and honest limits. Record on the Anthropic demo tier for pace; close with the Ollama self-host architecture so buyers know both paths.
-
----
-
-## 🎯 Audience
-
-A technical buyer or evaluator who saw the [public Streamlit demo](https://ai-doc-to-chat-demo.streamlit.app) and wants proof of grounded answers on infrastructure you control. Pitch is **confidential document Q&A** (policies, SOPs, reports, contracts), not a legal-only tool and not a website support chatbot.
+> **Takeaway:** Upload, ask, open the page citation, then ask something the PDF cannot answer.
 
 ---
 
-## ✅ Before you record
-
-- Live pilot reachable at your password-protected URL ([DEPLOYMENT.md](../../DEPLOYMENT.md))
-- **Demo tier for recording:** `LLM_PROVIDER=anthropic` with `ANTHROPIC_API_KEY` in `.env` only (never on camera or in git). Prefer Haiku for snappy answers. See [Anthropic demo tier](../../DEPLOYMENT.md#anthropic-demo-tier).
-- Sample PDF ready: [sample NDA](sample-nda.pdf) and/or export [sample retention policy](sample-policy.md) to PDF
-- Model warm (one throwaway question after login)
-- Browser window about 1280×720; hide bookmarks and unrelated tabs
-- Architecture slide or tab ready: [architecture.md](architecture.md) for the Ollama self-host close
-
-> **Two tiers.** Demo tier (Anthropic) is for smooth recording and low latency. Self-host tier (Compose + Ollama) is for private / air-gap evaluation. Say both on camera; do not imply the video latency is what CPU Ollama always feels like.
-
----
-
-## 🎬 Storyboard (~5 min)
+## What you will see
 
 ```mermaid
 flowchart LR
-  H[Hook] --> T[Trust]
-  T --> U[Upload]
-  U --> Q[Q&A]
-  Q --> L[Limits]
-  L --> C[Close + tiers]
+  Gate[Invite gate] --> Upload
+  Upload --> Ask
+  Ask --> Sources
+  Sources --> Refuse[Honest refuse]
 ```
 
-| Time | Scene | Show | Say (gist) |
-|------|-------|------|------------|
-| 0:00–0:30 | Hook | Public demo dummy banner → live pilot login | “The free demo is UI-only. Here is the same app with a real model on a private VM.” |
-| 0:30–1:00 | Trust | HTTPS lock, basic-auth login, privacy note | “Documents stay in memory for the session. Nothing is stored on the shared pilot.” |
-| 1:00–2:00 | Upload | Upload sample NDA or retention policy; expand extracted text | “Upload a PDF. Policies, SOPs, reports, contracts. The app extracts text, chunks it, and builds a searchable index in-process.” |
-| 2:00–3:30 | Q&A | Two or three grounded questions with sources | Ask about retention, parties, or a clause; point to page citations. Fast answers because this recording uses the Anthropic demo tier. |
-| 3:30–4:20 | Limits | One question the model should refuse or hedge | Show “not in document” or session scope. Contrast with generic chatbots that invent answers. |
-| 4:20–5:00 | Close + tiers | [Architecture](architecture.md) (Ollama box) + [DEPLOYMENT](../../DEPLOYMENT.md) | “What you saw used a fast demo-tier LLM for recording. For air-gap and full privacy, the same Compose stack runs Ollama on your VPS. Next step is evaluation on your documents.” |
+1. **Gate.** Request an invite, then open the app.
+2. **Upload.** Use the [sample NDA](sample-nda.pdf), or export the [sample policy](sample-policy.md) to PDF. Do not upload real company files on the shared pilot.
+3. **Ask.** A question the document can answer. Open **Sources** and check the page.
+4. **Refuse.** A question the document does not answer. The app should say so, not invent a clause.
+
+Uploaded files stay in memory for the session. Each visit starts fresh.
 
 ---
 
-## 💬 Sample questions
+## Sample questions
 
 ### Sample NDA
-
-Use questions that match numbered sections so citations are obvious:
 
 1. Who are the parties to this agreement?
 2. What is the term or duration?
 3. What obligations apply to confidentiality?
+4. Does this agreement specify liquidated damages? (It does not.)
 
 ### Sample retention policy
 
@@ -65,21 +42,13 @@ Use questions that match numbered sections so citations are obvious:
 2. What happens to project working notes after a project closes?
 3. What rule applies when Legal issues a litigation hold?
 
-Expected answer quality: [Pilot evaluation](pilot-evaluation.md).
-
 ---
 
-## 🗺️ Two-tier LLM story (say this once, clearly)
+## Where the answer is written
 
-| Tier | When | Backend |
-|------|------|---------|
-| **Demo** | Walkthrough video, snappy pilot demos | `LLM_PROVIDER=anthropic` (Haiku default) |
-| **Self-host** | Private eval, air-gap, documents must not leave your network | Compose + Ollama (`phi3:mini` on CPU, larger models if you have RAM/GPU) |
+| Choice | When |
+|--------|------|
+| **Ollama** | Answers stay on your server. |
+| **Anthropic** | Optional, when you want quicker replies. |
 
-Embeddings stay local either way. Switching tiers is an env change, not a rewrite. Details: [DEPLOYMENT.md](../../DEPLOYMENT.md).
-
----
-
-## 📤 After recording
-
-When the walkthrough is published (Loom, YouTube unlisted, etc.), add the URL to the **Demo video** line in [README.md](../../README.md). No other code change is required until the link exists.
+Search and citations stay on the server either way. How the pieces connect: [docs/README.md](../README.md).

--- a/docs/product/pilot-evaluation.md
+++ b/docs/product/pilot-evaluation.md
@@ -1,10 +1,12 @@
-# Pilot evaluation
+# Pilot evaluation (historical)
 
 ## Background
 
-Summary of how the RAG stack was tested on NDA-style contracts. Same three questions across rounds, with a gold standard for honesty and section alignment. Full round-by-round notes live in [`docs/archive/eval-history/`](../archive/eval-history/).
+May 2026 notes from local Ollama rounds on the sample NDA. Useful as a record of why hybrid search, rerank, and header chunking landed. Not a current scorecard for the live pilot.
 
-> **Takeaway:** Round 5 is the current bar: pass on the sample NDA for Q1–Q3, and solid honesty on a shorter unnumbered NDA.
+Round-by-round files: [`docs/archive/eval-history/`](../archive/eval-history/). Product map: [docs/README.md](../README.md).
+
+> **Takeaway:** These numbers are historical. Do not treat the latencies as what you will see today.
 
 ---
 
@@ -32,14 +34,14 @@ Sample document: [`sample-nda.pdf`](sample-nda.pdf)
 | **4** | Hard context filter, section-aware boost | Partial+ | Pass | Pass | Q2 on-section 1/1; Q3 honesty held |
 | **5** | Header-aware chunking, dedupe, context guard | Pass | Pass | Pass | Also works on 2-page unnumbered NDA |
 
-**Current bar (Round 5):** Q1–Q3 Pass on sample NDA · Q2/Q3 Pass on client-style 2-page NDA · ready for walkthrough demos.
+**Round 5 result (May 2026):** Q1–Q3 Pass on sample NDA · Q2/Q3 Pass on client-style 2-page NDA.
 
 ---
 
 ## ✅ Round 5 at a glance (latest)
 
-**Status:** Complete (May 2026)  
-**Stack:** Docker Compose · `llama3.1:8b` · hybrid · reranker · section metadata · hard context filter · header-aware chunking · dedupe · context sufficiency guard
+**When:** May 2026  
+**Stack then:** Docker Compose · `llama3.1:8b` · hybrid · reranker · section metadata · hard context filter · header-aware chunking · dedupe · context sufficiency guard
 
 ### Verdict
 
@@ -93,4 +95,4 @@ Q3 hedging is a small-model formatting quirk, not a hallucination. Larger models
 | Section-number questions + context purity | Sample NDA |
 | Obligation completeness + honesty on unnumbered layout | 2-page NDA |
 
-Storyboard: [demo-script.md](demo-script.md).
+Walkthrough: [demo-script.md](demo-script.md).

--- a/docs/product/sample-nda.md
+++ b/docs/product/sample-nda.md
@@ -103,4 +103,4 @@ subject matter and supersedes all prior negotiations, representations, and agree
 > 2. What obligations does Section 3 impose on the Receiving Party?
 > 3. Does this agreement specify liquidated damages or a fixed financial penalty?
 
-More on expected quality: [pilot evaluation](../product/pilot-evaluation.md).
+Questions to try: [Walkthrough](demo-script.md).

--- a/docs/product/sample-policy.md
+++ b/docs/product/sample-policy.md
@@ -69,4 +69,4 @@ Contact `governance@northwind.example` (fictional address) for retention questio
 > 2. What happens to project working notes after a project closes?
 > 3. What rule applies when Legal issues a litigation hold?
 
-More on expected quality: [pilot evaluation](pilot-evaluation.md).
+Questions to try: [Walkthrough](demo-script.md).


### PR DESCRIPTION
## Main contribution

This repository is now easy to judge in a few minutes: what the product does, how an answer stays inside your PDF, and a live pilot you can open without waiting for approval.

## What you will see

Upload a confidential PDF, ask a question, and get an answer with the page it came from. If the document does not contain the answer, the system says so.

The README walks through the design in plain language:

- How the file is read and split so neighboring clauses do not mix
- Why search uses both meaning and exact terms, then a second ranking pass
- Why every answer shows a page, or refuses
- What works today (citations, model choice, private embeddings) and what does not (one PDF per session, no math, no ticket system)

You choose where the answer is written: a model on your server (Ollama), or Anthropic when you want quicker replies. Search and citations stay on the server either way.

## Try it

Open the live pilot (new tab): https://ai-doc-pilot.roxanatapia.dev/

Request an invite on the gate, then upload a PDF. A sample NDA is ready if you want a document to start with. A walkthrough on Upwork is optional.

Files on the shared pilot stay in memory for the session. Use only sample or non-confidential documents there.

## Test plan

- [x] The GitHub page reads as Private PDF Q&A, not a deploy guide
- [x] The green Live link opens the pilot in a new tab
- [x] The retrieval table is understandable without opening the code
- [x] Extra docs (architecture, walkthrough) stay short if you click through