### PR TITLE
A cleaner code tree for the retrieval path

### DIFF
--- a/.cursor/agents/config-guardian.md
+++ b/.cursor/agents/config-guardian.md
@@ -21,7 +21,7 @@ You are the **config-guardian** for ai-doc-to-chat-pipeline.
 ## Standards
 
 - New env vars: empty value + comment in `.env.example`.
-- YAML keys must match what `src/rag.py` and `src/app.py` load.
+- YAML keys must match what `src/rag/` and `src/app.py` load.
 - Never commit real API keys or filled `.env`.
 
 ## Workflow

--- a/.cursor/agents/deploy-engineer.md
+++ b/.cursor/agents/deploy-engineer.md
@@ -3,7 +3,7 @@ name: deploy-engineer
 description: >-
   Deploy specialist for Docker, Compose, Ollama sidecar, Caddy HTTPS, VPS pilot.
   Owns everything under deploy/ (Dockerfile, compose, Caddy, scripts). Use for M7,
-  M7.96 repo layout, and M11. Must not edit src/app.py or src/rag.py. Prefer real
+  M7.96 repo layout, and M11. Must not edit src/app.py or src/rag/. Prefer real
   path updates over shim stubs when moving files.
 ---
 
@@ -22,7 +22,7 @@ You are the **deploy-engineer** for ai-doc-to-chat-pipeline.
 
 ## Must NOT touch
 
-- `src/app.py`, `src/rag.py`, `src/api/**`
+- `src/app.py`, `src/rag/`, `src/api/**`
 - `configs/**` (defer to config-guardian)
 
 ## Standards

--- a/.cursor/agents/rag-core-engineer.md
+++ b/.cursor/agents/rag-core-engineer.md
@@ -1,8 +1,7 @@
 ---
 name: rag-core-engineer
 description: >-
-  RAG core and FastAPI engineer. Owns src/rag.py, src/sectioning.py,
-  src/retrieval_quality.py, src/rag/ package, src/api/, LLM providers, chunking and
+  RAG core and FastAPI engineer. Owns src/rag/, src/api/, LLM providers, chunking and
   Sources-ranking helpers. Use for M7.8, M7.95, M8, M9. Must not edit Streamlit
   layout or Docker.
 ---
@@ -11,9 +10,9 @@ You are the **rag-core-engineer** for ai-doc-to-chat-pipeline.
 
 ## Owns
 
-- `src/rag.py`, `src/sectioning.py`, `src/retrieval_quality.py`, future `src/rag/**`
+- `src/rag/**`
 - `src/api/**` (M8+)
-- Tests for RAG generation, sectioning, retrieval-quality helpers, and API routes
+- Tests for RAG generation, chunking, citations, and API routes
 
 ## Must NOT touch
 
@@ -29,7 +28,7 @@ You are the **rag-core-engineer** for ai-doc-to-chat-pipeline.
 
 ## Workflow
 
-1. Extract/refactor without breaking Streamlit imports until orchestrator says wire UI.
+1. Keep retrieval in `src/rag/` (ingest, chunk, retrieve, cite, generate). Do not put pipeline logic back in Streamlit.
 2. **Do not run `git commit`.**
 3. Report: files changed, test commands, suggested 2–4 commit split for large refactors.
 

--- a/.cursor/agents/streamlit-engineer.md
+++ b/.cursor/agents/streamlit-engineer.md
@@ -16,7 +16,7 @@ You are the **streamlit-engineer** for ai-doc-to-chat-pipeline.
 
 - `Dockerfile`, `docker-compose*.yml`
 - `src/api/**` internals (M8+)
-- `src/rag.py` unless issue explicitly spans UI + generation wiring
+- `src/rag/` unless the issue explicitly spans UI + generation wiring
 
 ## Standards
 

--- a/.cursor/agents/streamlit-ux-designer.md
+++ b/.cursor/agents/streamlit-ux-designer.md
@@ -19,7 +19,7 @@ You are the **streamlit-ux-designer** for ai-doc-to-chat-pipeline.
 ## Must NOT touch
 
 - `Dockerfile`, `docker-compose*.yml`, Caddy
-- `src/rag.py` provider / generation logic (coordinate via orchestrator if a UI need requires a rag helper)
+- `src/rag/` provider / generation logic (coordinate via orchestrator if a UI need requires a rag helper)
 - `src/api/**` internals
 - Secrets, real hostnames, or salesy “hire-me” chrome in the product UI
 

--- a/.cursor/rules/config-and-env.mdc
+++ b/.cursor/rules/config-and-env.mdc
@@ -8,6 +8,6 @@ alwaysApply: false
 
 - Keep `configs/config.yaml` and `configs/prompts.yaml` in sync with code that loads them.
 - Every new env var must appear in `.env.example` with an **empty** value and a short comment.
-- Use `OLLAMA_*`, `USE_DUMMY_GENERATOR`, `LLM_PROVIDER` naming consistently with `src/rag.py`.
+- Use `OLLAMA_*`, `USE_DUMMY_GENERATOR`, `LLM_PROVIDER` naming consistently with `src/rag/`.
 - Never commit filled `.env` files or API keys.
 - For M12+, `generation.provider` in YAML should match env override docs.

--- a/.cursor/rules/fastapi-api.mdc
+++ b/.cursor/rules/fastapi-api.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # FastAPI API (M8+)
 
-- Keep API thin: delegate to `src/rag/` (or `src/rag.py` until extracted).
+- Keep API thin: delegate to `src/rag/`.
 - Required routes: `GET /health`, `POST /chat` (context + query or document ref).
 - Expose OpenAPI at `/docs`; use Pydantic models for request/response.
 - No Streamlit imports in `src/api/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,9 @@ M7.96 ✅ → packaging (minus video) → #58 → #59 → #60 → #57 → [pause
 | Role (`name`) | Milestones | Owns | Must NOT touch |
 |---------------|------------|------|----------------|
 | `milestone-orchestrator` | All | Queue, branches, commits, PRs, **merges**, pulses | Direct app code edits |
-| `deploy-engineer` | M7, M7.96, M11 | `deploy/**` (Dockerfile, Compose, Caddy, scripts) | `src/app.py`, `src/rag.py` |
+| `deploy-engineer` | M7, M7.96, M11 | `deploy/**` (Dockerfile, Compose, Caddy, scripts) | `src/app.py`, `src/rag/` |
 | `config-guardian` | M7–M12 | `configs/**`, `.env.example` | Application logic |
-| `rag-core-engineer` | M7.8, M7.95, M8, M9, M12 | `src/rag.py`, `src/sectioning.py`, `src/retrieval_quality.py`, `src/rag/**`, `src/api/**` | Streamlit layout polish, Docker |
+| `rag-core-engineer` | M7.8, M7.95, M8, M9, M12 | `src/rag/**`, `src/api/**` | Streamlit layout polish, Docker |
 | `streamlit-engineer` | Feature UI wiring | `src/app.py` session/chat/upload/Sources payload wiring | Docker, FastAPI internals, visual redesigns |
 | `streamlit-ux-designer` | M7.9 UI polish | Layout, IA, microcopy, chat/sources readability | Docker, FastAPI, RAG providers |
 | `docs-writer` | M7, M7.8, M10–M12 | `docs/**`, `DEPLOYMENT*.md`, **README**, PR/issue prose, **blocker card polish** | Python except docstrings |
@@ -158,9 +158,9 @@ Invoke by role name. Files live in `.cursor/agents/`.
 
 **Safe in parallel:** #56 docs-writer while #55 streamlit (different files).
 
-**Must be serial:** #53 → #54 → #55 (`src/rag.py`, `src/app.py`); #58 → #59 → #60; verifier last before PR.
+**Must be serial:** #53 → #54 → #55 (`src/rag/`, `src/app.py`); #58 → #59 → #60; verifier last before PR.
 
-**Do not parallelize** two agents on `src/rag.py`, `src/app.py`, or `README.md` in one issue.
+**Do not parallelize** two agents on `src/rag/`, `src/app.py`, or `README.md` in one issue.
 
 Only **milestone-orchestrator** runs `git commit`, push, and merge.
 

--- a/docs/operators/ROADMAP.md
+++ b/docs/operators/ROADMAP.md
@@ -120,7 +120,7 @@ flowchart TD
 
 | Issue | Read / learn |
 |-------|----------------|
-| M7.8-1 | How `generate_answer()` in `src/rag.py` becomes a small provider protocol |
+| M7.8-1 | How `generate_answer()` in `src/rag/` becomes a small provider protocol |
 | M7.8-2 | How API keys stay in `.env`, never git; same RAG context, different backend |
 | M7.8-3 | Streamlit `st.write_stream` or generator pattern |
 | M7.8-4 | Product narrative ≠ code; eval corpus (NDA) ≠ market vertical |
@@ -178,7 +178,7 @@ Cited answers only help when Sources feels like an audit trail: short, ranked, a
 
 | Wave | Work | Agents | Parallel notes |
 |------|------|--------|----------------|
-| 1a ∥ 1b | **#80** display cap · **#83** section chunking | config + streamlit ∥ rag-core | YAML/UI vs `sectioning.py` |
+| 1a ∥ 1b | **#80** display cap · **#83** section chunking | config + streamlit ∥ rag-core | YAML/UI vs `src/rag/chunking.py` |
 | 2 | **#81** sort on-section → score | rag-core → streamlit | After #83 preferred |
 | 3 | **#82** answer-overlap + fallback | rag-core → streamlit | After #80 + #81 |
 | * | verifier | every issue | pytest green before PR |

--- a/src/retrieval_quality.py
+++ b/src/retrieval_quality.py
@@ -1,3 +1,0 @@
-"""Compatibility shim. Citation and honesty helpers live in ``rag.citations``."""
-
-from rag.citations import *  # noqa: F403

--- a/src/sectioning.py
+++ b/src/sectioning.py
@@ -1,3 +1,0 @@
-"""Compatibility shim. Chunking lives in ``rag.chunking``."""
-
-from rag.chunking import *  # noqa: F403

--- a/tests/test_retrieval_quality.py
+++ b/tests/test_retrieval_quality.py
@@ -8,7 +8,7 @@ SRC_DIR = PROJECT_ROOT / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-from retrieval_quality import (  # noqa: E402
+from rag.citations import (  # noqa: E402
     DEFAULT_ANSWER_OVERLAP_MIN_SCORE,
     context_has_obligation_markers,
     context_sufficient_for_query,

--- a/tests/test_section_parsing.py
+++ b/tests/test_section_parsing.py
@@ -8,7 +8,7 @@ SRC_DIR = PROJECT_ROOT / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-from sectioning import (  # noqa: E402
+from rag.chunking import (  # noqa: E402
     annotate_chunk_sections,
     apply_hard_section_context_filter,
     apply_section_aware_retrieval,


### PR DESCRIPTION
## Main contribution

The repository tree now matches the retrieval story. There is one place for chunking and one place for citations. Old stand-in files at the src root are gone, so a visitor is not looking at two names for the same step.

## What you will see

- Header-aware chunking lives only in `src/rag/chunking.py`
- Page citations and honesty checks live only in `src/rag/citations.py`
- Tests import those modules directly

The product behaves the same. This is layout, not a new feature.

## Test plan

- [x] `src/` no longer lists `sectioning.py` or `retrieval_quality.py`
- [x] The docs map still points at `src/rag/` for each retrieval step
- [x] A sample question still returns a page citation (or a refusal) as before


Made with [Cursor](https://cursor.com)