### PR TITLE
Keep both live demos on one reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,15 +77,24 @@ APP_ALLOW_DEV_TOGGLE=false
 # APP_ALLOW_DEV_TOGGLE=true
 
 # =============================================================================
-# HTTPS reverse proxy (deploy/docker-compose.caddy.yml + Caddy)
+# HTTPS reverse proxy
 # =============================================================================
-# Canonical start (from repo root):
+# Dedicated PDF Q&A VM (this repo's Caddy overlay):
 #   docker compose --env-file .env -p ai-doc-to-chat-pipeline \
 #     -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up --build -d
+#
+# Portfolio VPS (shared edge): keep THIS file as the single secrets file.
+# Do not rename keys below. roxanatapia-edge Compose reads the same file:
+#   docker compose --env-file /root/ai-doc-to-chat-pipeline/.env \
+#     -p roxanatapia-edge -f deploy/docker-compose.yml up -d
+# App on that host uses docker-compose.shared-edge.yml (alias `app` on network
+# `edge`). Cutover: https://github.com/RoxanaTapia/roxanatapia-edge/blob/main/CUTOVER.md
+#
 # Basic auth credentials live in deploy/caddy-basicauth.conf (not in .env).
 # Generate with: ./deploy/generate-caddy-auth.sh demo 'YOUR_PASSWORD'
 
-# Keep named volumes on the historical project (do not omit -p / this var).
+# Keep Ollama volume names on the historical project (do not omit -p / this var).
+# The edge stack must still pass -p roxanatapia-edge so it does not inherit this.
 COMPOSE_PROJECT_NAME=ai-doc-to-chat-pipeline
 
 # Production subdomain (Let's Encrypt). Example: ai-doc-pilot.roxanatapia.dev

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -6,7 +6,7 @@ For IT buyers and operators standing up a single-VM pilot: Docker Compose + Olla
 
 Architecture diagram: [docs/product/architecture.md](docs/product/architecture.md)
 
-> **Takeaway:** Two LLM tiers, one Compose app: **self-host** (Ollama, private / air-gap) and **demo** (Anthropic Haiku, low latency for recording). Start Ollama first for the default path, then bring up the app (and Caddy for HTTPS).
+> **Takeaway:** Two LLM tiers, one Compose app: **self-host** (Ollama, private / air-gap) and **demo** (Anthropic Haiku, low latency for recording). Start Ollama first for the default path, then bring up the app (and Caddy for HTTPS). On the portfolio VPS, Caddy lives in [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge); keep using this repo's `.env` as-is.
 
 ---
 
@@ -115,7 +115,7 @@ docker compose -f deploy/docker-compose.yml exec ollama ollama pull phi3:mini
 
 ### 5. Start the full stack with HTTPS
 
-From the **repo root** (so `.env` is found and volume names stay stable):
+**Dedicated PDF Q&A VM** (this repo owns Caddy). From the **repo root**:
 
 ```bash
 docker compose --env-file .env -p ai-doc-to-chat-pipeline \
@@ -128,11 +128,18 @@ Expect: `ollama` **healthy** · `app` **Up** · `caddy` **Up**. Port 8501 is not
 
 Set `COMPOSE_PROJECT_NAME=ai-doc-to-chat-pipeline` in `.env` (see `.env.example`) so you can omit `-p` later. Always pass `--env-file .env` when the first compose file lives under `deploy/`.
 
+**Portfolio VPS** (pilot + receipt + apex on one host): do not start this repo's Caddy overlay after cutover. Join `edge` with alias `app` and let [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge) bind 80/443. Reuse this repo's `.env` (same key names). Ordered steps: [roxanatapia-edge CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-edge/blob/main/CUTOVER.md).
+
+```bash
+docker compose --env-file .env -p ai-doc-to-chat-pipeline \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.shared-edge.yml up -d
+```
+
 ### 6. Verify
 
 ### Time-limited invites
 
-Set `INVITE_SECRET` and SMTP settings in `.env` (required for the Caddy overlay + **Request an invite**). For production gates, also set `TURNSTILE_SECRET_KEY` (Cloudflare Turnstile; site key lives on gate HTML in roxanatapia-web). Operator notify defaults to redeem-only via `INVITE_NOTIFY_ON=redeem`. Local smoke without a widget: `TURNSTILE_ENABLED=false`. See [deploy/invite/README.md](deploy/invite/README.md).
+Set `INVITE_SECRET` and SMTP settings in `.env` (required for the Caddy overlay + **Request an invite**). For production gates, also set `TURNSTILE_SECRET_KEY` (Cloudflare Turnstile; site key lives on gate HTML in roxanatapia-web). Operator notify defaults to redeem-only via `INVITE_NOTIFY_ON=redeem`. Local smoke without a widget: `TURNSTILE_ENABLED=false`. See [deploy/invite/README.md](deploy/invite/README.md). After cutover, mint from [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge); keep using this `.env`.
 
 ```bash
 # Auto path: gate → Request an invite → POST /invite/request (emails visitor;
@@ -156,14 +163,14 @@ curl -sk -o /dev/null -w "%{http_code}\n" -u demo:YOUR_PASSWORD https://YOUR_DOM
 
 Open `https://YOUR_DOMAIN/` for the gate, then **Sign in** → `/app`. Upload a PDF, ask a question.
 
-**Apex landing** (`roxanatapia.dev`) is served from the same Caddy process via static files under `/srv/roxanatapia-web/sites/apex`. Marketing sites and cutover steps: [roxanatapia-web deploy/CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md). Deploy those files on the VPS before reloading Caddy.
+**Apex landing** (`roxanatapia.dev`) is served by the shared Caddy process via static files under `/srv/roxanatapia-web/sites/apex`. After cutover that process runs in [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge). Static files: [roxanatapia-web deploy/CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md). Deploy those files on the VPS before reloading Caddy.
 
-**Receipt Intelligence** is terminated by this repo's Caddy (same edge as pilot + apex) on two hostnames:
+**Receipt Intelligence** is terminated by the same shared Caddy (pilot + apex + receipt) on two hostnames. After cutover, that Caddy is [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge); this overlay remains for rollback. Hostnames:
 
 - **`receipt-intelligence.roxanatapia.dev`** — public static gate at `/`, invites on `/invite*` and `/app*`, Basic Auth as the operator **Login** fallback for `/app`.
 - **`n8n.receipt-intelligence.roxanatapia.dev`** — n8n operator UI at **/** (no edge Basic Auth — it loops with n8n’s pre-login `/rest` 401s in Chrome). Protected by n8n **owner** login; keep sibling `N8N_BASIC_AUTH_ACTIVE=false` and `N8N_PATH=` empty. Do not advertise this host publicly.
 
-Create the shared Docker network once (`docker network create edge`); the Caddy overlay attaches only the `caddy` service to it. Upstream API, n8n, and demo UX run in the sibling project [receipt-intelligence-demo](https://github.com/RoxanaTapia/receipt-intelligence-demo) via its `docker-compose.shared-edge.yml` overlay, with stable aliases `receipt-api:8000`, `receipt-n8n:5678`, and `receipt-ux:8080`.
+Create the shared Docker network once (`docker network create edge`). Caddy (in this overlay, or in roxanatapia-edge after cutover) joins it. This app joins with alias `app` via `docker-compose.shared-edge.yml`. Upstream API, n8n, and demo UX run in [receipt-intelligence-demo](https://github.com/RoxanaTapia/receipt-intelligence-demo) via its overlay, with stable aliases `receipt-api:8000`, `receipt-n8n:5678`, and `receipt-ux:8080`.
 
 | Host / path | Access | Upstream |
 |------|--------|----------|
@@ -173,9 +180,9 @@ Create the shared Docker network once (`docker network create edge`); the Caddy 
 | `receipt-intelligence…` `/n8n*` | 308 → n8n subdomain `/` | (legacy bookmarks) |
 | `n8n.receipt-intelligence…` `/` | n8n owner login (no edge Basic Auth) | `receipt-n8n:5678` (sibling `N8N_PATH=` + `N8N_BASIC_AUTH_ACTIVE=false`) |
 
-The same invite service covers both hosts. Set `RECEIPT_INVITE_BASE_URL` in `.env` (alongside the shared `INVITE_SECRET` / SMTP settings). Mint a receipt token with `python deploy/invite/mint.py --site receipt`. Full contract and local smoke: [deploy/invite/README.md](deploy/invite/README.md).
+The same invite service covers both hosts. Set `RECEIPT_INVITE_BASE_URL` in this repo's `.env` (alongside the shared `INVITE_SECRET` / SMTP settings). After cutover, mint from [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge) (`python deploy/invite/mint.py --site receipt`); the env file path does not change. Contract: [deploy/invite/README.md](deploy/invite/README.md).
 
-Gate HTML lives in [roxanatapia-web](https://github.com/RoxanaTapia/roxanatapia-web) (`sites/receipt-gate`). On the VPS, run `cd /srv/roxanatapia-web && git pull` so that directory exists **before** you recreate Caddy; otherwise the public gate returns 404. After pulling this repo's Caddy changes, recreate the edge with the same compose overlay as before (`docker-compose.yml` + `docker-compose.caddy.yml`) so `/invite*` and `/app*` forward_auth take effect. The apex portfolio tile links to the subdomain root and should land on that public gate. This repo owns TLS and reverse-proxy routes only; it does **not** define receipt Compose services or workflows. Do not run a second Caddy from the receipt repo on this host.
+Gate HTML lives in [roxanatapia-web](https://github.com/RoxanaTapia/roxanatapia-web) (`sites/receipt-gate`). On the VPS, run `cd /srv/roxanatapia-web && git pull` so that directory exists **before** you recreate Caddy; otherwise the public gate returns 404. Recreate Caddy from **roxanatapia-edge** after cutover (see [CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-edge/blob/main/CUTOVER.md)), or from this overlay for rollback. The apex portfolio tile links to the subdomain root and should land on that public gate. This repo does **not** define receipt Compose services. Do not run a second Caddy from the receipt repo on this host.
 
 Cross-repo ship order:
 
@@ -312,7 +319,7 @@ Restart the app container after changing provider or key. Leave `LLM_PROVIDER` u
 |---------|-------------|-----|
 | `app` never starts | Ollama not healthy yet | `docker compose -f deploy/docker-compose.yml logs ollama` (wait for `healthy`) |
 | Connection refused on Ollama | Wrong host or app started too early | Use Compose; `OLLAMA_HOST` must be `http://ollama:11434`, not `localhost` |
-| `YOUR_VPS_IP:8501` accessible from internet | Caddy overlay not active | Use `-f deploy/docker-compose.caddy.yml`; confirm `caddy` is Up |
+| `YOUR_VPS_IP:8501` accessible from internet | Caddy / shared-edge overlay not active | Dedicated VM: use `-f deploy/docker-compose.caddy.yml`. Portfolio VPS: use `docker-compose.shared-edge.yml` and run Caddy from roxanatapia-edge |
 | **401** with correct password | Wrong hash in conf file | Re-run `./deploy/generate-caddy-auth.sh`, restart Caddy |
 | **401** on `/app` without password | Expected | Public gate is `/`; only `/app` requires basic auth |
 | Caddy restart loop: `email` parse error | Empty `ACME_EMAIL` inside container, or `{$VAR:you@…}` default | Pass `--env-file .env`; do not use an `@` in Caddy env defaults |

--- a/deploy/docker-compose.caddy.yml
+++ b/deploy/docker-compose.caddy.yml
@@ -1,4 +1,11 @@
-# HTTPS reverse proxy overlay — run from the **repo root**:
+# HTTPS reverse proxy overlay. Single-product self-host, or VPS rollback.
+#
+# Portfolio VPS after cutover: Caddy/invite live in roxanatapia-edge.
+# This overlay stays for a dedicated PDF Q&A VM and for rollback.
+# Cutover (keep both demos live, reuse .env + cert volumes):
+#   https://github.com/RoxanaTapia/roxanatapia-edge/blob/main/CUTOVER.md
+#
+# Single-product self-host, from the **repo root**:
 #
 #   docker compose --env-file .env -p ai-doc-to-chat-pipeline \
 #     -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up -d

--- a/deploy/docker-compose.shared-edge.yml
+++ b/deploy/docker-compose.shared-edge.yml
@@ -1,0 +1,28 @@
+# Shared-host overlay. Caddy/invite run in roxanatapia-edge (ports 80/443).
+#
+# Create the network once on the VPS:
+#   docker network create edge
+#
+# From repo root, with the existing .env (do not rename keys):
+#   docker compose --env-file .env -p ai-doc-to-chat-pipeline \
+#     -f deploy/docker-compose.yml -f deploy/docker-compose.shared-edge.yml up -d
+#
+# Do NOT also use deploy/docker-compose.caddy.yml on that host after cutover
+# (two Caddys). Keep the caddy overlay in git for rollback / a dedicated VM.
+#
+# Alias `app` is what the shared Caddyfile reverse_proxy targets (app:8501).
+# Cutover order: https://github.com/RoxanaTapia/roxanatapia-edge/blob/main/CUTOVER.md
+
+services:
+  app:
+    ports: !override []
+    networks:
+      default: {}
+      edge:
+        aliases:
+          - app
+
+networks:
+  edge:
+    external: true
+    name: edge

--- a/deploy/invite/README.md
+++ b/deploy/invite/README.md
@@ -4,6 +4,8 @@ HMAC-signed, time-limited invite tokens for `/app` on both the AI Doc pilot and 
 One service handles both sites; site is resolved per-request from the `Host` header.
 Caddy basic auth remains the operator **Login** fallback.
 
+On the portfolio VPS after cutover, mint from [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge). This tree stays for a dedicated VM and for rollback. Env keys stay in this repo's `.env`.
+
 ## Supported sites
 
 | Key | Cookie | Default host | Product |
@@ -57,8 +59,12 @@ SMTP_TLS=true
 ## Start
 
 ```bash
+# Dedicated VM (this overlay):
 docker compose --env-file .env -p ai-doc-to-chat-pipeline \
   -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up -d --build
+
+# Portfolio VPS after cutover: invite runs in roxanatapia-edge.
+# https://github.com/RoxanaTapia/roxanatapia-edge/blob/main/CUTOVER.md
 ```
 
 ## Request flow (visitors)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ This page is the map of the repository. The [root README](../README.md) is the p
 ├── src/               Application code
 ├── configs/           Chunking, retrieval, and prompt tunables
 ├── tests/             pytest suite
-├── deploy/            Docker, Compose, Caddy
+├── deploy/            Docker, Compose (Caddy overlay for a dedicated VM)
 ├── .cursor/           Agent roles, rules, slash commands
 └── docs/              You are here
       product/         Architecture, walkthrough, sample NDA
@@ -38,7 +38,7 @@ This page is the map of the repository. The [root README](../README.md) is the p
 | [`src/api/`](../src/api/) | Thin FastAPI `/health` and `/chat` |
 | [`configs/config.yaml`](../configs/config.yaml) | Chunk size, hybrid weights, reranker |
 | [`configs/prompts.yaml`](../configs/prompts.yaml) | Grounded-answer prompt |
-| [`deploy/`](../deploy/) | Container stack and edge proxy |
+| [`deploy/`](../deploy/) | Container stack. Shared portfolio Caddy: [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge) |
 | [`docs/product/architecture.md`](product/architecture.md) | Single-VM deploy picture |
 | [`docs/operators/REPO-STRUCTURE.md`](operators/REPO-STRUCTURE.md) | Extra layout rules |
 

--- a/docs/operators/REPO-STRUCTURE.md
+++ b/docs/operators/REPO-STRUCTURE.md
@@ -16,14 +16,16 @@ Everything that runs the container stack lives under [`deploy/`](../../deploy/).
 deploy/
 ├── Dockerfile
 ├── docker-compose.yml
-├── docker-compose.caddy.yml
+├── docker-compose.caddy.yml         Single-product HTTPS, or VPS rollback
+├── docker-compose.shared-edge.yml   Portfolio VPS: alias `app` on network edge
 ├── Caddyfile
-└── invite/            Shared invite service (pilot + other sites)
+└── invite/                          Rollback copy; canonical is roxanatapia-edge
 ```
 
 - No root copies of Dockerfile, Compose, or Caddy files.
 - No stub files that say “Moved to `deploy/`…”.
-- Compose from the repo root: `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up --build -d`
+- Dedicated VM: `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.caddy.yml up --build -d`
+- Portfolio VPS: app uses `docker-compose.shared-edge.yml`; Caddy lives in [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge).
 
 Install narrative: [DEPLOYMENT.md](../../DEPLOYMENT.md).
 

--- a/docs/product/architecture.md
+++ b/docs/product/architecture.md
@@ -20,7 +20,7 @@ flowchart LR
 
 | Piece | Role |
 |-------|------|
-| **Caddy** | HTTPS and the invite gate. Only ports 80 and 443 face the internet. |
+| **Caddy** | HTTPS and the invite gate. Only ports 80 and 443 face the internet. On the portfolio VPS this process runs in [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge). |
 | **App** | Streamlit UI plus retrieval. The PDF, chunks, and FAISS index stay in RAM. |
 | **Ollama** | Local model on the same VM, when that provider is selected. |
 | **Anthropic** | Optional. Quicker answers; retrieved passages leave the VM for generation. |


### PR DESCRIPTION
## Main contribution

The PDF Q&A app can run on the portfolio VPS without owning Caddy, apex, or receipt routes. It joins the existing `edge` network as `app`, so both demos keep working while HTTPS moves to [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge).

The live `.env` file and key names stay as they are. The Caddy overlay remains in this repo for a dedicated VM and for rollback.

## Summary

- Add `deploy/docker-compose.shared-edge.yml` (alias `app` on network `edge`, no public 8501)
- Keep `docker-compose.caddy.yml` as rollback / single-product self-host
- Document that the VPS still uses this repo’s `.env` via `--env-file`

VPS cutover is a human step: [CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-edge/blob/main/CUTOVER.md). Do not retag `deploy/stable` until both hosts smoke green.

## Test plan

- [x] Invite unit tests still pass
- [x] `docker compose … -f docker-compose.yml -f docker-compose.shared-edge.yml config` succeeds
- [ ] VPS: follow edge CUTOVER (attach app → swap Caddy on existing cert volumes → drop overlay)
- [ ] Smoke `ai-doc-pilot.roxanatapia.dev` gate + `/app`
- [ ] Smoke `receipt-intelligence.roxanatapia.dev` gate + `/app` and n8n host
- [ ] Confirm no second `.env` and no new Caddy volumes


Made with [Cursor](https://cursor.com)