### PR TITLE
Strip receipt portfolio routing from PDF Q&A

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,7 +113,6 @@ ACME_EMAIL=
 # Time-limited pilot invites (deploy/invite/). Required when using the Caddy overlay.
 # Generate: openssl rand -hex 32
 # Mint codes: python deploy/invite/mint.py --ttl 72h --label client-acme
-# Multi-site: add --site receipt for receipt-intelligence invites
 INVITE_SECRET=
 
 # Public base URL for redeem links in auto-sent emails
@@ -122,11 +121,6 @@ INVITE_REQUEST_TTL=72h
 INVITE_NOTIFY_TO=hello@roxanatapia.dev
 # Operator notify timing: redeem (default) | request (legacy) | none
 INVITE_NOTIFY_ON=redeem
-
-# Receipt Intelligence site (multi-site invite; #115)
-RECEIPT_INVITE_BASE_URL=https://receipt-intelligence.roxanatapia.dev
-# Optional override; empty means use INVITE_NOTIFY_TO
-RECEIPT_INVITE_NOTIFY_TO=
 
 # Cloudflare Turnstile (invite spam hardening #124). Secret only — site key is
 # on gate HTML in roxanatapia-web. Defaults to enabled when secret is set;

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -165,62 +165,12 @@ Open `https://YOUR_DOMAIN/` for the gate, then **Sign in** → `/app`. Upload a 
 
 **Apex landing** (`roxanatapia.dev`) is served by the shared Caddy process via static files under `/srv/roxanatapia-web/sites/apex`. After cutover that process runs in [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge). Static files: [roxanatapia-web deploy/CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md). Deploy those files on the VPS before reloading Caddy.
 
-**Receipt Intelligence** is terminated by the same shared Caddy (pilot + apex + receipt) on two hostnames. After cutover, that Caddy is [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge); this overlay remains for rollback. Hostnames:
+**Receipt Intelligence (portfolio shared host)** is served by the shared edge stack in [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge) after the portfolio cutover. This repo no longer owns receipt or n8n routing here. Follow:
 
-- **`receipt-intelligence.roxanatapia.dev`** — public static gate at `/`, invites on `/invite*` and `/app*`, Basic Auth as the operator **Login** fallback for `/app`.
-- **`n8n.receipt-intelligence.roxanatapia.dev`** — n8n operator UI at **/** (no edge Basic Auth — it loops with n8n’s pre-login `/rest` 401s in Chrome). Protected by n8n **owner** login; keep sibling `N8N_BASIC_AUTH_ACTIVE=false` and `N8N_PATH=` empty. Do not advertise this host publicly.
+- [roxanatapia-edge CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-edge/blob/main/CUTOVER.md) for the ordered VPS steps + rollback plan
+- [roxanatapia-edge README](https://github.com/RoxanaTapia/roxanatapia-edge) for the operator-facing run context
 
-Create the shared Docker network once (`docker network create edge`). Caddy (in this overlay, or in roxanatapia-edge after cutover) joins it. This app joins with alias `app` via `docker-compose.shared-edge.yml`. Upstream API, n8n, and demo UX run in [receipt-intelligence-demo](https://github.com/RoxanaTapia/receipt-intelligence-demo) via its overlay, with stable aliases `receipt-api:8000`, `receipt-n8n:5678`, and `receipt-ux:8080`.
-
-| Host / path | Access | Upstream |
-|------|--------|----------|
-| `receipt-intelligence…` `/` | Public (no auth) | Static HTML from `/srv/roxanatapia-web/sites/receipt-gate` |
-| `receipt-intelligence…` `/invite*` | Public (request / redeem / exit) | Shared invite service (`invite:8090`) |
-| `receipt-intelligence…` `/app*` | `receipt_invite` cookie + `forward_auth`, **or** edge Basic Auth | `receipt-ux:8080` (prefix stripped; health is `/app/health`) |
-| `receipt-intelligence…` `/n8n*` | 308 → n8n subdomain `/` | (legacy bookmarks) |
-| `n8n.receipt-intelligence…` `/` | n8n owner login (no edge Basic Auth) | `receipt-n8n:5678` (sibling `N8N_PATH=` + `N8N_BASIC_AUTH_ACTIVE=false`) |
-
-The same invite service covers both hosts. Set `RECEIPT_INVITE_BASE_URL` in this repo's `.env` (alongside the shared `INVITE_SECRET` / SMTP settings). After cutover, mint from [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge) (`python deploy/invite/mint.py --site receipt`); the env file path does not change. Contract: [deploy/invite/README.md](deploy/invite/README.md).
-
-Gate HTML lives in [roxanatapia-web](https://github.com/RoxanaTapia/roxanatapia-web) (`sites/receipt-gate`). On the VPS, run `cd /srv/roxanatapia-web && git pull` so that directory exists **before** you recreate Caddy; otherwise the public gate returns 404. Recreate Caddy from **roxanatapia-edge** after cutover (see [CUTOVER.md](https://github.com/RoxanaTapia/roxanatapia-edge/blob/main/CUTOVER.md)), or from this overlay for rollback. The apex portfolio tile links to the subdomain root and should land on that public gate. This repo does **not** define receipt Compose services. Do not run a second Caddy from the receipt repo on this host.
-
-Cross-repo ship order:
-
-1. DNS for `receipt-intelligence.roxanatapia.dev` **and** `n8n.receipt-intelligence.roxanatapia.dev` → this VPS
-2. receipt-intelligence-demo: shared-host compose (api + n8n joined to `edge`) with `N8N_HOST=n8n.receipt-intelligence.roxanatapia.dev`, empty `N8N_PATH`, matching `WEBHOOK_URL`
-3. Multi-site invite service live (receipt cookie + verify; see [deploy/invite/README.md](deploy/invite/README.md))
-4. VPS: `cd /srv/roxanatapia-web && git pull` (so `sites/receipt-gate` exists)
-5. This Caddy change (recreate the edge with the caddy overlay, receipt-gate mounted)
-6. VPS smoke (commands below)
-7. Portfolio tile in [roxanatapia-web](https://github.com/RoxanaTapia/roxanatapia-web) (subdomain root → public gate)
-
-```bash
-# Receipt public gate (no credentials): expect 200 HTML from sites/receipt-gate
-curl -sk -o /dev/null -w "%{http_code}\n" \
-  https://receipt-intelligence.roxanatapia.dev/
-
-# App health: 401 without cookie or credentials, 200 with edge Basic Auth
-curl -sk -o /dev/null -w "%{http_code}\n" \
-  https://receipt-intelligence.roxanatapia.dev/app/health
-curl -sk -o /dev/null -w "%{http_code}\n" \
-  -u demo:YOUR_PASSWORD https://receipt-intelligence.roxanatapia.dev/app/health
-
-# Optional invite path (cookie redeem is awkward to fully curl; mint then open redeem URL in a browser)
-# python deploy/invite/mint.py --site receipt --ttl 72h --label smoke
-# → redeem the printed URL on the receipt host; expect Set-Cookie: receipt_invite=… then /app without Basic Auth
-
-# n8n subdomain: no edge Basic Auth (expect 200 HTML / n8n login shell)
-curl -sk -o /dev/null -w "%{http_code}\n" \
-  https://n8n.receipt-intelligence.roxanatapia.dev/
-
-# Legacy /n8n* redirects to the n8n subdomain (expect 308)
-curl -sk -o /dev/null -w "%{http_code}\n" \
-  https://receipt-intelligence.roxanatapia.dev/n8n/
-
-# Regression: pilot gate + apex still behave as today
-curl -sk -o /dev/null -w "%{http_code}\n" https://ai-doc-pilot.roxanatapia.dev/
-curl -sk -o /dev/null -w "%{http_code}\n" https://roxanatapia.dev/
-```
+Do not run a second Caddy from the receipt repo on this host.
 
 **IP-only mode** (`Caddyfile.ip`) still puts basic auth on the whole listener (no static gate). Use domain mode for the hybrid front door.
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -8,10 +8,8 @@
 # Cutover checklist: https://github.com/RoxanaTapia/roxanatapia-web/blob/main/deploy/CUTOVER.md
 # Apply only after those directories exist on the VPS (otherwise apex/gate 404).
 #
-# receipt-intelligence.roxanatapia.dev (when present below) proxies an external
-# compose project on Docker network edge (aliases receipt-api, receipt-n8n).
-# Upstream stack: https://github.com/RoxanaTapia/receipt-intelligence-demo
-# This repo does not own receipt compose internals. Operator notes: DEPLOYMENT.md.
+# Sibling services are cut over to the shared edge after cutover.
+# This dedicated VM overlay is pilot-only.
 #
 # Do not use {$ACME_EMAIL:you@example.com} — a default containing "@" breaks Caddy's
 # placeholder parser. ACME contact is optional; existing certs in caddy_data keep working.
@@ -61,62 +59,4 @@ roxanatapia.dev, www.roxanatapia.dev {
 
 	root * /srv/roxanatapia-web/sites/apex
 	file_server
-}
-
-# Receipt Intelligence (sibling stack on Docker network `edge`).
-# Upstream aliases (stable across recreate):
-#   receipt-api:8000 · receipt-n8n:5678 · receipt-ux:8080
-# Sibling must join `edge` via its shared-edge overlay — see receipt-intelligence-demo DEPLOYMENT.md.
-# Hybrid gate: public / → receipt-gate; /app/* invite cookie or Basic Auth → receipt-ux:8080.
-# n8n on its own host at / — avoids n8n's known path-prefix login redirect bug.
-# Sibling: N8N_PATH= empty, N8N_HOST=n8n.receipt-intelligence.roxanatapia.dev,
-# N8N_BASIC_AUTH_ACTIVE=false. No edge Basic Auth here: Chrome loops when Caddy
-# basicauth + n8n's pre-login /rest 401s share a host (same issue as yesterday on /n8n*).
-# Protect with n8n owner login; do not advertise this host publicly.
-# Use handle_path /app/* (not /app*) so only the /app prefix is stripped — otherwise /app/static/*
-# is stripped to / and CSS never loads.
-n8n.receipt-intelligence.roxanatapia.dev {
-	reverse_proxy receipt-n8n:5678 {
-		header_up Host {host}
-		header_up X-Forwarded-Host {host}
-		header_up X-Forwarded-Proto {scheme}
-		# SSE / long-lived editor push
-		flush_interval -1
-	}
-}
-
-receipt-intelligence.roxanatapia.dev {
-	handle /invite* {
-		reverse_proxy invite:8090
-	}
-
-	# Legacy /n8n* bookmarks → n8n subdomain root.
-	redir /n8n https://n8n.receipt-intelligence.roxanatapia.dev/ 308
-	redir /n8n/* https://n8n.receipt-intelligence.roxanatapia.dev/ 308
-
-	redir /app /app/ 308
-
-	handle_path /app/* {
-		@hasInviteCookie {
-			header Cookie *receipt_invite=*
-		}
-
-		handle @hasInviteCookie {
-			forward_auth invite:8090 {
-				uri /verify
-				copy_headers X-Invite-Ok
-			}
-			reverse_proxy receipt-ux:8080
-		}
-
-		handle {
-			import /etc/caddy/caddy-basicauth.conf
-			reverse_proxy receipt-ux:8080
-		}
-	}
-
-	handle {
-		root * /srv/roxanatapia-web/sites/receipt-gate
-		file_server
-	}
 }

--- a/deploy/docker-compose.caddy.yml
+++ b/deploy/docker-compose.caddy.yml
@@ -34,10 +34,8 @@ services:
       INVITE_BIND: 0.0.0.0
       INVITE_PORT: "8090"
       INVITE_BASE_URL: ${INVITE_BASE_URL:-https://ai-doc-pilot.roxanatapia.dev}
-      RECEIPT_INVITE_BASE_URL: ${RECEIPT_INVITE_BASE_URL:-https://receipt-intelligence.roxanatapia.dev}
       INVITE_REQUEST_TTL: ${INVITE_REQUEST_TTL:-72h}
       INVITE_NOTIFY_TO: ${INVITE_NOTIFY_TO:-hello@roxanatapia.dev}
-      RECEIPT_INVITE_NOTIFY_TO: ${RECEIPT_INVITE_NOTIFY_TO:-}
       # redeem (default) | request (legacy) | none — see deploy/invite/spam_guards.py
       INVITE_NOTIFY_ON: ${INVITE_NOTIFY_ON:-redeem}
       # Cloudflare Turnstile secret (site key lives on gate HTML in roxanatapia-web)
@@ -68,14 +66,12 @@ services:
       # Static front doors from roxanatapia-web (clone/rsync to host paths first).
       - /srv/roxanatapia-web/sites/apex:/srv/roxanatapia-web/sites/apex:ro
       - /srv/roxanatapia-web/sites/pilot-gate:/srv/roxanatapia-web/sites/pilot-gate:ro
-      - /srv/roxanatapia-web/sites/receipt-gate:/srv/roxanatapia-web/sites/receipt-gate:ro
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
       - app
       - invite
     # default: app + invite on the project network
-    # edge (external): receipt-api / receipt-n8n aliases from sibling compose
     networks:
       - default
       - edge
@@ -85,7 +81,6 @@ volumes:
   caddy_config:
 
 # Create once on the VPS: docker network create edge
-# Receipt stack joins the same network with aliases receipt-api / receipt-n8n.
 networks:
   edge:
     external: true

--- a/deploy/invite/README.md
+++ b/deploy/invite/README.md
@@ -1,7 +1,7 @@
-# Invite service — multi-site
+# Invite service — pilot-only
 
-HMAC-signed, time-limited invite tokens for `/app` on both the AI Doc pilot and Receipt Intelligence hosts.
-One service handles both sites; site is resolved per-request from the `Host` header.
+HMAC-signed, time-limited invite tokens for `/app` on the AI Doc pilot host.
+Site is resolved per-request from the `Host` header (defaulting to pilot).
 Caddy basic auth remains the operator **Login** fallback.
 
 On the portfolio VPS after cutover, mint from [roxanatapia-edge](https://github.com/RoxanaTapia/roxanatapia-edge). This tree stays for a dedicated VM and for rollback. Env keys stay in this repo's `.env`.
@@ -11,12 +11,11 @@ On the portfolio VPS after cutover, mint from [roxanatapia-edge](https://github.
 | Key | Cookie | Default host | Product |
 |-----|--------|--------------|---------|
 | `pilot` | `pilot_invite` | `ai-doc-pilot.roxanatapia.dev` | AI Doc pilot |
-| `receipt` | `receipt_invite` | `receipt-intelligence.roxanatapia.dev` | Receipt Intelligence |
 
 ## Site resolution order
 
-1. **Host header** — matched against the configured `base_url` hostname for each site.
-2. **`site` POST field** — `pilot` or `receipt` sent by the gate form (fallback when Host is ambiguous, e.g. direct IP access).
+1. **Host header** — matched against the configured `base_url` hostname.
+2. **`site` POST field** — `pilot` sent by the gate form (fallback when Host is ambiguous, e.g. direct IP access).
 3. **Default: `pilot`** — backward-compatible; existing codes keep working.
 
 Old tokens (minted before multi-site) have no `site` claim and are treated as `pilot`.
@@ -33,10 +32,6 @@ INVITE_REQUEST_TTL=72h
 # AI Doc pilot (existing)
 INVITE_BASE_URL=https://ai-doc-pilot.roxanatapia.dev
 INVITE_NOTIFY_TO=hello@roxanatapia.dev   # shared notify unless overridden
-
-# Receipt Intelligence (new)
-RECEIPT_INVITE_BASE_URL=https://receipt-intelligence.roxanatapia.dev
-# RECEIPT_INVITE_NOTIFY_TO=team@example.com  # optional; falls back to INVITE_NOTIFY_TO
 
 # Operator notify timing: redeem (default) | request (legacy) | none
 INVITE_NOTIFY_ON=redeem
@@ -92,12 +87,6 @@ The browser response never includes the token.
 ```bash
 # AI Doc pilot (default)
 python deploy/invite/mint.py --ttl 72h --label client-acme
-
-# Receipt Intelligence
-python deploy/invite/mint.py --site receipt --ttl 24h --label client-beta
-
-# Override URL explicitly
-python deploy/invite/mint.py --site receipt --base-url https://receipt-intelligence.roxanatapia.dev --ttl 48h
 ```
 
 ## Smoke-test (local / no SMTP)
@@ -107,37 +96,11 @@ Start the server with a dummy secret and Turnstile off (no Cloudflare widget loc
 ```bash
 cd deploy/invite
 INVITE_SECRET=localtestonly INVITE_BASE_URL=http://localhost:8090 \
-  RECEIPT_INVITE_BASE_URL=http://localhost:8090 \
   TURNSTILE_ENABLED=false INVITE_NOTIFY_ON=none \
   python server.py &
 ```
 
 With SMTP unset, `POST /invite/request` returns **503** (`smtp_unconfigured`) after spam checks — that is expected. Redeem / verify still work with minted tokens.
-
-Mint a receipt token:
-
-```bash
-INVITE_SECRET=localtestonly python mint.py --site receipt --ttl 72h
-# → code=v1.<body>.<sig>   url=http://localhost:8090/invite/redeem?token=…
-```
-
-Redeem via Host-spoofed curl (simulates receipt host):
-
-```bash
-TOKEN=<paste code here>
-curl -si -H "Host: receipt-intelligence.roxanatapia.dev" \
-  "http://localhost:8090/invite/redeem?token=$TOKEN"
-# Expect: 303 Location=/app  Set-Cookie: receipt_invite=…
-```
-
-Verify the receipt cookie:
-
-```bash
-curl -si -H "Host: receipt-intelligence.roxanatapia.dev" \
-  -H "Cookie: receipt_invite=$TOKEN" \
-  http://localhost:8090/verify
-# Expect: 200 X-Invite-Ok: 1
-```
 
 Pilot path unchanged (no Host header → defaults to pilot):
 
@@ -150,20 +113,14 @@ curl -si "http://localhost:8090/invite/redeem?token=$TOKEN"
 
 ### Exit demo
 
-Visitors and operators leave the invited session via **`GET` or `POST` `/invite/exit`**. The service clears the site invite cookie (`pilot_invite` or `receipt_invite`) and responds **303** to `/` (public gate / home). Caddy already treats `/invite*` as public, so no proxy change is needed.
+Visitors and operators leave the invited session via **`GET` or `POST` `/invite/exit`**. The service clears the `pilot_invite` cookie and responds **303** to `/` (public gate / home). Caddy already treats `/invite*` as public, so no proxy change is needed.
 
 UI copy should say **Exit demo** or **Back to home**, not "Log out." Exit clears only the invite cookie; it does **not** clear browser Basic Auth credentials used by the operator **Login** fallback.
 
 If `/app` is hit with a **stale or invalid** invite cookie, Caddy still matches the cookie header and calls `forward_auth` → `/verify`. Verify now clears that cookie and **303**s to `/` (same as Exit) instead of returning a bare `invalid invite` page that blocked Login.
 
 ```bash
-# After a redeem smoke (cookie set), exit clears it and redirects home
-curl -si -H "Host: receipt-intelligence.roxanatapia.dev" \
-  -H "Cookie: receipt_invite=$TOKEN" \
-  http://localhost:8090/invite/exit
-# Expect: 303 Location=/  Set-Cookie: receipt_invite=… (Max-Age=0 / expired)
-
-# Pilot (no Host → defaults to pilot)
+# After a redeem smoke (cookie set), exit clears it and redirects home (pilot-only)
 curl -si -H "Cookie: pilot_invite=$TOKEN" \
   http://localhost:8090/invite/exit
 # Expect: 303 Location=/  Set-Cookie: pilot_invite=… (expired)

--- a/deploy/invite/mint.py
+++ b/deploy/invite/mint.py
@@ -3,7 +3,6 @@
 
 Usage (repo root, INVITE_SECRET in env or .env):
   python deploy/invite/mint.py --ttl 72h --label client-acme
-  python deploy/invite/mint.py --site receipt --ttl 24h --label client-beta
 """
 
 from __future__ import annotations
@@ -35,22 +34,13 @@ def _load_dotenv() -> None:
             os.environ[key] = value
 
 
-def _default_base_url(site: str) -> str:
-    """Return the env-configured base URL for a site, with fallback."""
-    if site == "receipt":
-        return os.environ.get(
-            "RECEIPT_INVITE_BASE_URL", "https://receipt-intelligence.roxanatapia.dev"
-        )
-    return os.environ.get("INVITE_BASE_URL", "https://ai-doc-pilot.roxanatapia.dev")
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description="Mint a time-limited invite")
     parser.add_argument(
         "--site",
         default="pilot",
         choices=VALID_SITES,
-        help="Target site: pilot (default) or receipt",
+        help="Target site: pilot (only option)",
     )
     parser.add_argument("--ttl", default="72h", help="TTL like 24h, 72h, 7d (default 72h)")
     parser.add_argument("--label", default="", help="Optional label stored in the token")
@@ -62,7 +52,9 @@ def main() -> int:
     args = parser.parse_args()
     _load_dotenv()
 
-    base = (args.base_url or _default_base_url(args.site)).rstrip("/")
+    base = (args.base_url or os.environ.get("INVITE_BASE_URL", "https://ai-doc-pilot.roxanatapia.dev")).rstrip(
+        "/"
+    )
 
     try:
         ttl = parse_ttl(args.ttl)

--- a/deploy/invite/server.py
+++ b/deploy/invite/server.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Invite redeem, request-by-email, and forward_auth verify service.
 
-Serves both ai-doc-pilot and receipt-intelligence from a single process.
-Site is resolved per-request from the Host header (or explicit ``site`` POST
-field, falling back to pilot for backward compatibility).
+This repository is pilot-only after the edge cutover. Site is resolved per
+request from the Host header (defaulting to the pilot site).
 """
 
 from __future__ import annotations

--- a/deploy/invite/sites.py
+++ b/deploy/invite/sites.py
@@ -1,4 +1,7 @@
-"""Site registry: maps pilot / receipt to per-site config loaded from env."""
+"""Site registry for the dedicated invite gate.
+
+This repository is pilot-only after the edge cutover.
+"""
 
 from __future__ import annotations
 
@@ -7,9 +10,8 @@ from dataclasses import dataclass
 from urllib.parse import urlparse
 
 PILOT = "pilot"
-RECEIPT = "receipt"
 
-VALID_SITES = (PILOT, RECEIPT)
+VALID_SITES = (PILOT,)
 
 
 @dataclass(frozen=True)
@@ -28,11 +30,7 @@ def load_registry() -> dict[str, SiteConfig]:
     pilot_base = os.environ.get("INVITE_BASE_URL", "https://ai-doc-pilot.roxanatapia.dev").rstrip(
         "/"
     )
-    receipt_base = os.environ.get(
-        "RECEIPT_INVITE_BASE_URL", "https://receipt-intelligence.roxanatapia.dev"
-    ).rstrip("/")
     shared_notify = os.environ.get("INVITE_NOTIFY_TO", "hello@roxanatapia.dev").strip()
-    receipt_notify = os.environ.get("RECEIPT_INVITE_NOTIFY_TO", "").strip() or shared_notify
 
     return {
         PILOT: SiteConfig(
@@ -43,15 +41,6 @@ def load_registry() -> dict[str, SiteConfig]:
             host_label="AI Doc pilot",
             access_phrase="Access to the AI Doc pilot is by invitation.",
             notify_to=shared_notify,
-        ),
-        RECEIPT: SiteConfig(
-            key=RECEIPT,
-            cookie="receipt_invite",
-            base_url=receipt_base,
-            product_name="Receipt Intelligence",
-            host_label="Receipt Intelligence",
-            access_phrase="Access to Receipt Intelligence is by invitation.",
-            notify_to=receipt_notify,
         ),
     }
 
@@ -76,8 +65,8 @@ def resolve_site(
     """
     Resolve the active site config using priority:
     1. Host header matched against configured base_url hostnames.
-    2. Explicit `site` field (pilot|receipt) from POST body.
-    3. Default: pilot (backward compatible).
+    2. Explicit `site` field (pilot) from POST body.
+    3. Default: pilot.
     """
     from_host = _host_to_site(host_header or "", registry)
     if from_host:

--- a/tests/test_invite_exit.py
+++ b/tests/test_invite_exit.py
@@ -20,10 +20,6 @@ def invite_server(monkeypatch: pytest.MonkeyPatch):
     """Start invite Handler on an ephemeral port with a loaded site registry."""
     monkeypatch.setenv("INVITE_SECRET", "test-invite-secret-for-exit")
     monkeypatch.setenv("INVITE_BASE_URL", "https://ai-doc-pilot.roxanatapia.dev")
-    monkeypatch.setenv(
-        "RECEIPT_INVITE_BASE_URL",
-        "https://receipt-intelligence.roxanatapia.dev",
-    )
 
     import server as invite_server_mod
     from sites import load_registry
@@ -106,24 +102,24 @@ def test_exit_get_pilot_unknown_host_defaults(invite_server: dict) -> None:
     _assert_exit_clears(status, headers, cookie_name="pilot_invite")
 
 
-def test_exit_get_receipt_host(invite_server: dict) -> None:
+def test_exit_get_unknown_host_defaults_to_pilot(invite_server: dict) -> None:
     status, headers = _request(
         invite_server,
         method="GET",
         path="/invite/exit",
-        host="receipt-intelligence.roxanatapia.dev",
+        host="unknown.example.test",
     )
-    _assert_exit_clears(status, headers, cookie_name="receipt_invite")
+    _assert_exit_clears(status, headers, cookie_name="pilot_invite")
 
 
-def test_exit_post_also_clears(invite_server: dict) -> None:
+def test_exit_post_also_clears_defaults_to_pilot(invite_server: dict) -> None:
     status, headers = _request(
         invite_server,
         method="POST",
         path="/invite/exit",
-        host="receipt-intelligence.roxanatapia.dev",
+        host="unknown.example.test",
     )
-    _assert_exit_clears(status, headers, cookie_name="receipt_invite")
+    _assert_exit_clears(status, headers, cookie_name="pilot_invite")
 
 
 def test_clear_cookie_header_helper(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Main contribution
This update removes receipt-intelligence and n8n portfolio routing from the PDF Q&A repo after the shared edge cutover. The ai-doc project is now clean and focuses on the dedicated pilot experience, while shared HTTPS remains in roxanatapia-edge.

> Takeaway: A cleaner GitHub story, with the shared portfolio proxy owned by the edge repo.

## Summary
- Make deploy/Caddyfile and deploy/docker-compose.caddy.yml pilot-only (receipt host blocks removed)
- Remove receipt multi-site invite support (site=receipt + RECEIPT_* env support removed)
- Trim DEPLOYMENT.md receipt runbook to a short pointer to roxanatapia-edge
- Update invite exit tests to match pilot-only behavior

## Test plan
- [ ] Run ./ .venv/bin/pytest -q tests/test_invite_exit.py tests/test_invite_spam.py

Closes #143

Made with [Cursor](https://cursor.com)