### PR TITLE
Record v0.9.0 as the live deploy pin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Full detail: [docs/operators/ROADMAP.md](docs/operators/ROADMAP.md).
 ## 🎯 Current focus
 
 - **Ship next:** demo video (#57) last — thin M8 (#58–#60) shipped; need public walkthrough URL.
-- **Do not** bump `deploy/stable` unless the operator asks (VPS/Cloud stay on v0.8.0).
+- **Do not** bump `deploy/stable` unless the operator asks (live pin is **v0.9.0** as of Phase 3 close).
 - **Then pause** this repo for the Support MVP sibling unless a paid engagement needs more depth here.
 - **Later / on demand:** M8.5, M9–M11.
 
@@ -136,7 +136,7 @@ Invoke by role name. Files live in `.cursor/agents/`.
 | #92 M7.96-4 README + docs index | docs-writer | - | 1 | after #90 |
 | #93 M7.96-5 templates + pre-commit | config-guardian | docs-writer | 1 | after #92 |
 
-**Rule:** no root stub files (“Moved to deploy/…”). Update real paths. Do not ff `deploy/stable` in this milestone.
+**Rule:** no root stub files (“Moved to deploy/…”). Update real paths. `deploy/stable` was advanced to **v0.9.0** after the edge cutover (operator-approved; see #144).
 
 ### M8: Thin FastAPI contract (after packaging; before video)
 

--- a/docs/operators/PROJECT-DIRECTION.md
+++ b/docs/operators/PROJECT-DIRECTION.md
@@ -129,7 +129,7 @@ After each issue, you should answer **without opening Cursor**:
 |---|-------|-----------|-----------|
 | 53–56, 70–73, 80–83, 89–93 | M7.8–M7.96 | (shipped) | Demo tier, UI, Sources trust, repo clarity |
 
-**M7.96 note:** left `deploy/stable` on v0.8.0; advance only when you intentionally choose to.
+**Pin note:** `deploy/stable` and tag **v0.9.0** mark the post–edge-split tree (operator-approved in #144). Advance the pin only when you intentionally choose to.
 
 ---
 

--- a/docs/operators/ROADMAP.md
+++ b/docs/operators/ROADMAP.md
@@ -193,7 +193,7 @@ GitHub milestone: [M7.95 Sources trust](https://github.com/RoxanaTapia/ai-doc-to
 
 **Background**
 
-Clients who open the GitHub repo should see a calm, professional layout. Deploy assets consolidate under `deploy/` with **no root shims**. Agentic tooling (`.cursor/`, `AGENTS.md`) stays visible and intentional. Merge to **`main` only** — do **not** bump `deploy/stable` as part of this milestone (VPS/Cloud stay on v0.8.0 until you choose).
+Clients who open the GitHub repo should see a calm, professional layout. Deploy assets consolidate under `deploy/` with **no root shims**. Agentic tooling (`.cursor/`, `AGENTS.md`) stays visible and intentional. Merged to **`main` only** during the milestone; **`deploy/stable` / v0.9.0** advanced later after the portfolio edge cutover (operator-approved; see #144).
 
 > **Takeaway:** One obvious tree: product in `src/` + `docs/product/`, ops in `deploy/` + `DEPLOYMENT.md`, agents in `.cursor/` + `AGENTS.md`.
 
@@ -220,7 +220,7 @@ Clients who open the GitHub repo should see a calm, professional layout. Deploy 
 | 3 | **#92** README + docs index | docs-writer | After paths final |
 | 4 | **#93** GitHub templates + pre-commit | config-guardian → docs-writer | Keep pre-commit |
 
-**Out of scope:** RAG/UI features, bumping `deploy/stable`, inventing new product scope.
+**Out of scope (for M7.96 itself):** RAG/UI features, bumping `deploy/stable` during that milestone, inventing new product scope.
 
 GitHub milestone: [M7.96 Repo clarity](https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/milestone/10)
 


### PR DESCRIPTION
## Main contribution

Operator docs now match the post–edge-split release: tag v0.9.0 and deploy/stable point at the same tree as main. Contributors no longer read “stay on v0.8.0” after that pin was intentionally advanced.

## Summary
- Update AGENTS.md, PROJECT-DIRECTION, and ROADMAP to record v0.9.0 / deploy/stable
- No app or Compose changes

## Test plan
- [ ] Skim the three docs for the pin note
- [ ] Confirm https://github.com/RoxanaTapia/ai-doc-to-chat-pipeline/releases/tag/v0.9.0 exists

Closes #144

Made with [Cursor](https://cursor.com)